### PR TITLE
fix(ISL): fix color luminance not affecting light

### DIFF
--- a/src/Features/InverseSquareLighting.cpp
+++ b/src/Features/InverseSquareLighting.cpp
@@ -64,7 +64,6 @@ void InverseSquareLighting::ProcessLight(LightLimitFix::LightData& light, RE::BS
 		light.invRadius = 1.f / light.radius;
 		light.fadeZone = 1.f / (light.radius * std::clamp(FadeZoneBase * light.invRadius, 0.f, 1.f));
 		light.sizeBias = ScaledUnitsSq * runtimeData->size * runtimeData->size * 0.5f;
-		light.color /= std::max(0.001f, std::max(light.color.x, std::max(light.color.y, light.color.z)));
 		light.color *= intensity;
 		light.fade = intensity;
 	} else {


### PR DESCRIPTION
This PR removes a line that was normalizing bulb colour data before scaling it with the intensity,
This normalization step causes loss of colour intensity information, which breaks effects like external emittance that rely on changing this intensity over time/depending on weather.
However this step is unnecessary as we can assume that an RGB colour channel value will stay within the 0.0f to 1.0f range for bulbs. 

Fixes [#1670](https://github.com/doodlum/skyrim-community-shaders/issues/1670)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inverse square lighting to preserve original light color values instead of normalizing them by their maximum RGB component, resulting in more accurate light color rendering.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->