### PR TITLE
fix(upscaling): reduce default value for RCAS

### DIFF
--- a/src/Features/Upscaling.h
+++ b/src/Features/Upscaling.h
@@ -56,7 +56,7 @@ public:
 		uint frameGenerationForceEnable = 0;
 		uint streamlineLogLevel = 0;  // 0=Off, 1=Default, 2=Verbose
 		float sharpnessFSR = 1.0f;
-		float sharpnessDLSS = 1.0f;
+		float sharpnessDLSS = 0.5f;
 	};
 
 	Settings settings;


### PR DESCRIPTION
Reduced the default sharpness of RCAS, values around 0.5 are more balanced and still allow the user to increase or decrease it when necessary. 1.0 was very oversharpened.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted default upscaling sharpness setting to provide optimized visual quality baseline.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->