### PR TITLE
chore: rename debug category to utility, move feats

### DIFF
--- a/src/Features/OverlayFeature.h
+++ b/src/Features/OverlayFeature.h
@@ -28,9 +28,9 @@ struct OverlayFeature : Feature
 	virtual bool IsOverlayVisible() const = 0;
 
 	/**
-     * @brief Get the category for UI grouping. Overlays default to "Debug".
+     * @brief Get the category for UI grouping. Overlays default to "Utility".
      *
      * Subclasses may override this to provide a different category.
      */
-	virtual std::string_view GetCategory() const override { return "Debug"; }
+	virtual std::string_view GetCategory() const override { return "Utility"; }
 };

--- a/src/Features/RenderDoc.h
+++ b/src/Features/RenderDoc.h
@@ -49,7 +49,7 @@ public:
 	// Feature overrides
 	std::string GetName() override { return "RenderDoc"; }
 	std::string GetShortName() override { return "RenderDoc"; }
-	std::string_view GetCategory() const override { return "Debug"; }
+	std::string_view GetCategory() const override { return "Utility"; }
 	bool IsCore() const override { return true; }
 	bool IsInMenu() const override { return true; }
 	std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override

--- a/src/Features/VR.h
+++ b/src/Features/VR.h
@@ -290,7 +290,7 @@ public:
 
 	virtual void DrawSettings() override;
 
-	virtual std::string_view GetCategory() const override { return "Debug"; }
+	virtual std::string_view GetCategory() const override { return "Utility"; }
 
 	//=============================================================================
 	// OVERLAY FEATURE OVERRIDES

--- a/src/Features/WeatherEditor.h
+++ b/src/Features/WeatherEditor.h
@@ -16,7 +16,7 @@ public:
 	virtual inline std::string GetName() override { return "Weather Editor"; }
 	virtual inline std::string GetShortName() override { return "WeatherEditor"; }
 	virtual inline std::string_view GetShaderDefineName() override { return "WEATHER"; }
-	virtual inline std::string_view GetCategory() const override { return "Sky"; }
+	virtual inline std::string_view GetCategory() const override { return "Utility"; }
 	virtual inline std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override
 	{
 		return {

--- a/src/Features/WeatherPicker.h
+++ b/src/Features/WeatherPicker.h
@@ -11,7 +11,7 @@ struct WeatherPicker : OverlayFeature
 
 	virtual bool SupportsVR() override { return true; }
 	virtual bool IsCore() const override { return true; }
-	virtual std::string_view GetCategory() const override { return "Sky"; }
+	virtual std::string_view GetCategory() const override { return "Utility"; }
 	virtual bool IsInMenu() const override { return true; }  // Show in main menu to provide weather debugging UI
 
 	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override;

--- a/src/Menu/FeatureListRenderer.cpp
+++ b/src/Menu/FeatureListRenderer.cpp
@@ -118,7 +118,7 @@ std::vector<FeatureListRenderer::MenuFuncInfo> FeatureListRenderer::BuildMenuLis
 	}
 
 	// Define category order
-	std::vector<std::string> categoryOrder = { "Display", "Debug", "Characters", "Grass", "Lighting", "Materials", "Post-Processing", "Sky", "Landscape & Textures", "Water", "Other" };
+	std::vector<std::string> categoryOrder = { "Display", "Utility", "Characters", "Grass", "Lighting", "Materials", "Post-Processing", "Sky", "Landscape & Textures", "Water", "Other" };
 	// Add categorized features to menu with collapsible headers
 	for (const std::string& category : categoryOrder) {
 		if (categorizedFeatures.find(category) != categorizedFeatures.end() && !categorizedFeatures[category].empty()) {


### PR DESCRIPTION
This PR renames the Debug feature tab to Utility.
It also moves the weather editor and picker to that tab.

Debug has contained the VR feature already, which isn't explicitly a debug feature already.
Combined with the weather editor and picker not being solely related to sky features, but being more akin to utility features that other features rely on. I think this is a better arrangement of features.
This also makes the weather editor more easily accessible for weather/preset authors as they don't have to scroll down all the time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Refactor**
- Reorganized feature categorization in the overlay menu system. Several features have been moved from the "Debug" and "Sky" categories to the "Utility" category. This restructuring updates how overlay features are grouped and presented in the user interface, providing improved feature organization and discoverability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->