### PR TITLE
fix(weather overrides): fix feature settings resetting on weather change

### DIFF
--- a/src/WeatherVariableRegistry.h
+++ b/src/WeatherVariableRegistry.h
@@ -69,10 +69,20 @@ namespace WeatherVariables
 			if (!valuePtr || !lerpFunc)
 				return;
 
+			// Check if either weather actually has an override for this setting
+			bool hasFromOverride = !from.is_null();
+			bool hasToOverride = !to.is_null();
+
+			// If neither weather overrides this setting, don't modify the current value
+			// This preserves user settings when weather changes without overrides
+			if (!hasFromOverride && !hasToOverride) {
+				return;
+			}
+
 			T fromVal = defaultValue;
 			T toVal = defaultValue;
 
-			if (!from.is_null()) {
+			if (hasFromOverride) {
 				try {
 					fromVal = from.get<T>();
 				} catch (const nlohmann::json::type_error& e) {
@@ -81,13 +91,20 @@ namespace WeatherVariables
 				}
 			}
 
-			if (!to.is_null()) {
+			if (hasToOverride) {
 				try {
 					toVal = to.get<T>();
 				} catch (const nlohmann::json::type_error& e) {
 					logger::debug("Type error in Lerp 'to' for {}: {}", name, e.what());
 					toVal = defaultValue;
 				}
+			}
+
+			// If only one weather has an override, use current value as the other endpoint
+			if (hasFromOverride && !hasToOverride) {
+				toVal = *valuePtr;
+			} else if (!hasFromOverride && hasToOverride) {
+				fromVal = *valuePtr;
 			}
 
 			*valuePtr = lerpFunc(fromVal, toVal, factor);

--- a/src/WeatherVariableRegistry.h
+++ b/src/WeatherVariableRegistry.h
@@ -99,13 +99,6 @@ namespace WeatherVariables
 				}
 			}
 
-			// If only one weather has an override, lerp to/from the default (UserSettings.json) value
-			if (hasFromOverride && !hasToOverride) {
-				toVal = defaultValue;
-			} else if (!hasFromOverride && hasToOverride) {
-				fromVal = defaultValue;
-			}
-
 			*valuePtr = lerpFunc(fromVal, toVal, factor);
 		}
 

--- a/src/WeatherVariableRegistry.h
+++ b/src/WeatherVariableRegistry.h
@@ -74,7 +74,6 @@ namespace WeatherVariables
 			bool hasToOverride = !to.is_null();
 
 			// If neither weather overrides this setting, don't modify the current value
-			// This preserves user settings when weather changes without overrides
 			if (!hasFromOverride && !hasToOverride) {
 				return;
 			}
@@ -100,11 +99,11 @@ namespace WeatherVariables
 				}
 			}
 
-			// If only one weather has an override, use current value as the other endpoint
+			// If only one weather has an override, lerp to/from the default (UserSettings.json) value
 			if (hasFromOverride && !hasToOverride) {
-				toVal = *valuePtr;
+				toVal = defaultValue;
 			} else if (!hasFromOverride && hasToOverride) {
-				fromVal = *valuePtr;
+				fromVal = defaultValue;
 			}
 
 			*valuePtr = lerpFunc(fromVal, toVal, factor);


### PR DESCRIPTION
This pull request improves the logic for handling weather variable overrides in the `WeatherVariables` namespace. The main change ensures that the current value is only modified if at least one of the weather configurations (`from` or `to`) actually provides an override for the setting. This prevents unnecessary updates when neither configuration specifies an override.

Weather variable override logic improvements:

* Added checks to determine if either `from` or `to` weather configurations have an override for the setting, and early return if neither does. (`src/WeatherVariableRegistry.h`)
* Updated conditions to use the new override checks when assigning values from `from` and `to` configurations. (`src/WeatherVariableRegistry.h`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved weather variable interpolation to correctly detect missing override data. When neither side provides override values, the system now leaves the current value unchanged. Validation for override values is only applied when override data is present, reducing erroneous type checks and preventing unintended updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->