### PR TITLE
fix(weather editor): reorder categories for better intuition.

### DIFF
--- a/src/WeatherEditor/EditorWindow.cpp
+++ b/src/WeatherEditor/EditorWindow.cpp
@@ -135,7 +135,7 @@ void EditorWindow::ShowObjectsWindow()
 	ImGui::Begin("Weather and Lighting Browser");
 
 	// Static variable to track the selected category
-	static std::string selectedCategory = "Lighting Template";
+	static std::string selectedCategory = "Weather";
 
 	// Static variable for filtering objects
 	static char filterBuffer[256] = "";
@@ -157,7 +157,7 @@ void EditorWindow::ShowObjectsWindow()
 		ImGui::Spacing();
 
 		// List of categories
-		const char* categories[] = { "Lighting Template", "Weather", "WorldSpace", "Cell Lighting", "ImageSpace", "Volumetric Lighting", "Shader Particle Geometry", "Lens Flare", "Visual Effect" };
+		const char* categories[] = { "Weather", "Lighting Template", "WorldSpace", "Cell Lighting", "ImageSpace", "Volumetric Lighting", "Shader Particle Geometry", "Lens Flare", "Visual Effect" };
 		for (int i = 0; i < IM_ARRAYSIZE(categories); ++i) {
 			// Highlight the selected category
 			if (ImGui::Selectable(categories[i], selectedCategory == categories[i])) {

--- a/src/WeatherEditor/EditorWindow.cpp
+++ b/src/WeatherEditor/EditorWindow.cpp
@@ -157,7 +157,7 @@ void EditorWindow::ShowObjectsWindow()
 		ImGui::Spacing();
 
 		// List of categories
-		const char* categories[] = { "Weather", "Lighting Template", "WorldSpace", "Cell Lighting", "ImageSpace", "Volumetric Lighting", "Shader Particle Geometry", "Lens Flare", "Visual Effect" };
+		const char* categories[] = { "Weather", "ImageSpace", "WorldSpace", "Lighting Template", "Cell Lighting", "Volumetric Lighting", "Shader Particle Geometry", "Lens Flare", "Visual Effect" };
 		for (int i = 0; i < IM_ARRAYSIZE(categories); ++i) {
 			// Highlight the selected category
 			if (ImGui::Selectable(categories[i], selectedCategory == categories[i])) {


### PR DESCRIPTION
This pull request updates the default category selection and reorganizes the category list in the objects window of the weather editor. The changes improve the user experience by prioritizing "Weather" as the default and making the category list more intuitive.

**UI/UX improvements:**

* Changed the default selected category from `"Lighting Template"` to `"Weather"` in the `ShowObjectsWindow` method (`EditorWindow.cpp`).
* Reordered the categories array so that `"Weather"` appears first, and the order is more logical for users browsing weather-related objects (`EditorWindow.cpp`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Changed the default selected category and reordered the category options displayed in the editor window.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->