### PR TITLE
feat(menu): add option to disable Clear Shader Cache button

### DIFF
--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -134,6 +134,7 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	UseMonochromeLogo,
 	ShowFooter,
 	CenterHeader,
+	DisableClearCacheButton,
 	TooltipHoverDelay,
 	BackgroundBlurEnabled,
 	ScrollbarOpacity,
@@ -153,7 +154,6 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	ShaderBlockNextKey,
 	EnableShaderBlocking,
 	FirstTimeSetupCompleted,
-	DisableClearCacheButton,
 	Theme,
 	SelectedThemePreset)
 

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -153,6 +153,7 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	ShaderBlockNextKey,
 	EnableShaderBlocking,
 	FirstTimeSetupCompleted,
+	DisableClearCacheButton,
 	Theme,
 	SelectedThemePreset)
 

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -377,6 +377,7 @@ public:
 		uint32_t ShaderBlockNextKey = VK_NEXT;   // Debug: cycle forward through shaders (PageDown)
 		bool EnableShaderBlocking = false;       // Enable shader blocking hotkeys for debugging
 		bool FirstTimeSetupCompleted = false;    // Track if first-time setup has been completed
+		bool DisableClearCacheButton = false;    // Disable the Clear Shader Cache button in the menu header
 		ThemeSettings Theme;
 		std::string SelectedThemePreset = "";  // Currently selected theme preset (empty = custom/user theme)
 	};

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -242,15 +242,15 @@ public:
 			return roles;
 		}();
 
-		bool UseSimplePalette = false;       // DEPRECATED: No longer affects behavior. UI now shows both Simple and Advanced controls.
-		bool ShowActionIcons = true;         // whether to show action buttons as icons
-		bool UseMonochromeIcons = false;     // whether to use monochrome (white) action icons with text color tinting
-		bool UseMonochromeLogo = false;      // whether to use monochrome CS logo
-		bool ShowFooter = true;              // whether to show the footer with game version/GPU info
-		bool CenterHeader = false;           // whether to center the header title and logo
-		bool DisableClearCacheButton = false; // disable the Clear Shader Cache button in the menu header
-		float TooltipHoverDelay = 0.5f;      // tooltip hover delay in seconds
-		bool BackgroundBlurEnabled = false;  // enable background blur effect
+		bool UseSimplePalette = false;         // DEPRECATED: No longer affects behavior. UI now shows both Simple and Advanced controls.
+		bool ShowActionIcons = true;           // whether to show action buttons as icons
+		bool UseMonochromeIcons = false;       // whether to use monochrome (white) action icons with text color tinting
+		bool UseMonochromeLogo = false;        // whether to use monochrome CS logo
+		bool ShowFooter = true;                // whether to show the footer with game version/GPU info
+		bool CenterHeader = false;             // whether to center the header title and logo
+		bool DisableClearCacheButton = false;  // disable the Clear Shader Cache button in the menu header
+		float TooltipHoverDelay = 0.5f;        // tooltip hover delay in seconds
+		bool BackgroundBlurEnabled = false;    // enable background blur effect
 		// Scrollbar opacity settings
 		struct ScrollbarOpacitySettings
 		{

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -248,6 +248,7 @@ public:
 		bool UseMonochromeLogo = false;      // whether to use monochrome CS logo
 		bool ShowFooter = true;              // whether to show the footer with game version/GPU info
 		bool CenterHeader = false;           // whether to center the header title and logo
+		bool DisableClearCacheButton = false; // disable the Clear Shader Cache button in the menu header
 		float TooltipHoverDelay = 0.5f;      // tooltip hover delay in seconds
 		bool BackgroundBlurEnabled = false;  // enable background blur effect
 		// Scrollbar opacity settings
@@ -377,7 +378,6 @@ public:
 		uint32_t ShaderBlockNextKey = VK_NEXT;   // Debug: cycle forward through shaders (PageDown)
 		bool EnableShaderBlocking = false;       // Enable shader blocking hotkeys for debugging
 		bool FirstTimeSetupCompleted = false;    // Track if first-time setup has been completed
-		bool DisableClearCacheButton = false;    // Disable the Clear Shader Cache button in the menu header
 		ThemeSettings Theme;
 		std::string SelectedThemePreset = "";  // Currently selected theme preset (empty = custom/user theme)
 	};

--- a/src/Menu/MenuHeaderRenderer.cpp
+++ b/src/Menu/MenuHeaderRenderer.cpp
@@ -206,10 +206,19 @@ void MenuHeaderRenderer::RenderHeader(bool isDocked, bool showLogo, bool canShow
 
 			// Clear Shader Cache Button
 			ImGui::TableNextColumn();
-			if (ImGui::Button("Clear Shader Cache", { -1, 0 })) {
-				shaderCache->Clear();
-				if (shaderCache->IsDiskCache()) {
-					shaderCache->DeleteDiskCache();
+			{
+				bool isDisabled = globals::menu->GetSettings().DisableClearCacheButton;
+				if (isDisabled) {
+					ImGui::BeginDisabled();
+				}
+				if (ImGui::Button("Clear Shader Cache", { -1, 0 })) {
+					shaderCache->Clear();
+					if (shaderCache->IsDiskCache()) {
+						shaderCache->DeleteDiskCache();
+					}
+				}
+				if (isDisabled) {
+					ImGui::EndDisabled();
 				}
 			}
 			if (auto _tt = Util::HoverTooltipWrapper()) {
@@ -281,30 +290,35 @@ std::vector<MenuHeaderRenderer::ActionIcon> MenuHeaderRenderer::BuildActionIcons
 			[]() {
 				globals::state->Save();
 				globals::state->SaveTheme();
-			} });
+			},
+			false });
 	}
 	if (uiIcons.loadSettings.texture) {
 		actionIcons.push_back({ uiIcons.loadSettings.texture,
 			"Restore Saved Settings",
 			[]() {
 				globals::state->Load();
-			} });
+			},
+			false });
 	}
 	if (uiIcons.clearCache.texture) {
 		auto shaderCache = globals::shaderCache;
+		bool isDisabled = globals::menu->GetSettings().DisableClearCacheButton;
 		actionIcons.push_back({ uiIcons.clearCache.texture,
-			"Clear Shader Cache\n\n"
-			"Clears the shader cache and disk cache (if enabled).\n"
-			"The Shader Cache is the collection of compiled shaders which replace\n"
-			"the vanilla shaders at runtime. The Disk Cache is a collection of\n"
-			"compiled shaders on disk. Clearing will mean that shaders are\n"
-			"recompiled only when the game re-encounters them.",
+			isDisabled ? "Clear Shader Cache (Disabled)" :
+			             "Clear Shader Cache\n\n"
+			             "Clears the shader cache and disk cache (if enabled).\n"
+			             "The Shader Cache is the collection of compiled shaders which replace\n"
+			             "the vanilla shaders at runtime. The Disk Cache is a collection of\n"
+			             "compiled shaders on disk. Clearing will mean that shaders are\n"
+			             "recompiled only when the game re-encounters them.",
 			[shaderCache]() {
 				shaderCache->Clear();
 				if (shaderCache->IsDiskCache()) {
 					shaderCache->DeleteDiskCache();
 				}
-			} });
+			},
+			isDisabled });
 	}
 
 	return actionIcons;
@@ -365,25 +379,31 @@ void MenuHeaderRenderer::RenderDockedIcons(const std::vector<ActionIcon>& action
 			// Draw icon with hover effect, using reduced area to minimize padding
 			ImU32 tintColor;
 			if (globals::menu->GetSettings().Theme.UseMonochromeIcons) {
-				// Use theme text color for monochrome icons
 				ImVec4 textColor = globals::menu->GetSettings().Theme.Palette.Text;
-				if (!isHovered) {
-					textColor.w *= 0.85f;  // Slightly reduce alpha when not hovered
+				if (it->disabled) {
+					textColor.w *= 0.35f;
+				} else if (!isHovered) {
+					textColor.w *= 0.85f;
 				}
 				tintColor = ImGui::GetColorU32(textColor);
 			} else {
-				// Use white/gray tint for colored icons
-				tintColor = isHovered ? IM_COL32(255, 255, 255, 255) : IM_COL32(220, 220, 220, 220);
+				if (it->disabled) {
+					tintColor = IM_COL32(128, 128, 128, 90);
+				} else {
+					tintColor = isHovered ? IM_COL32(255, 255, 255, 255) : IM_COL32(220, 220, 220, 220);
+				}
 			}
 			fgDrawList->AddImage(it->texture, iconMin, iconMax, ImVec2(0, 0), ImVec2(1, 1), tintColor);
 		}
 
 		// Handle interaction
 		if (isHovered) {
-			// Draw subtle background for hovered icon using interaction area
-			fgDrawList->AddRectFilled(interactionMin, interactionMax, IM_COL32(255, 255, 255, 40));
+			// Draw subtle background for hovered icon using interaction area (only if not disabled)
+			if (!it->disabled) {
+				fgDrawList->AddRectFilled(interactionMin, interactionMax, IM_COL32(255, 255, 255, 40));
+			}
 
-			if (ImGui::IsMouseClicked(ImGuiMouseButton_Left)) {
+			if (ImGui::IsMouseClicked(ImGuiMouseButton_Left) && !it->disabled) {
 				it->callback();
 			}
 
@@ -429,12 +449,21 @@ void MenuHeaderRenderer::RenderUndockedIcons(const std::vector<ActionIcon>& acti
 
 		std::string buttonId = std::format("##ActionBtn{}", i);
 
+		// Disable interaction for disabled icons
+		if (icon.disabled) {
+			ImGui::BeginDisabled();
+		}
+
 		// Use ImageButton with reduced image size to minimize padding
 		if (ImGui::ImageButton(buttonId.c_str(), icon.texture, imageSize, ImVec2(0, 0), ImVec2(1, 1), ImVec4(0, 0, 0, 0), tintColor)) {
 			icon.callback();
 		}
 		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("%s", icon.tooltip);
+		}
+
+		if (icon.disabled) {
+			ImGui::EndDisabled();
 		}
 
 		// Add SameLine except for the last button

--- a/src/Menu/MenuHeaderRenderer.cpp
+++ b/src/Menu/MenuHeaderRenderer.cpp
@@ -304,12 +304,12 @@ std::vector<MenuHeaderRenderer::ActionIcon> MenuHeaderRenderer::BuildActionIcons
 		bool isDisabled = globals::menu->GetSettings().Theme.DisableClearCacheButton;
 		actionIcons.push_back({ uiIcons.clearCache.texture,
 			isDisabled ? "Clear Shader Cache (Disabled)" :
-			             "Clear Shader Cache\n\n"
-			             "Clears the shader cache and disk cache (if enabled).\n"
-			             "The Shader Cache is the collection of compiled shaders which replace\n"
-			             "the vanilla shaders at runtime. The Disk Cache is a collection of\n"
-			             "compiled shaders on disk. Clearing will mean that shaders are\n"
-			             "recompiled only when the game re-encounters them.",
+						 "Clear Shader Cache\n\n"
+						 "Clears the shader cache and disk cache (if enabled).\n"
+						 "The Shader Cache is the collection of compiled shaders which replace\n"
+						 "the vanilla shaders at runtime. The Disk Cache is a collection of\n"
+						 "compiled shaders on disk. Clearing will mean that shaders are\n"
+						 "recompiled only when the game re-encounters them.",
 			[shaderCache]() {
 				shaderCache->Clear();
 				if (shaderCache->IsDiskCache()) {

--- a/src/Menu/MenuHeaderRenderer.cpp
+++ b/src/Menu/MenuHeaderRenderer.cpp
@@ -290,16 +290,14 @@ std::vector<MenuHeaderRenderer::ActionIcon> MenuHeaderRenderer::BuildActionIcons
 			[]() {
 				globals::state->Save();
 				globals::state->SaveTheme();
-			},
-			false });
+			} });
 	}
 	if (uiIcons.loadSettings.texture) {
 		actionIcons.push_back({ uiIcons.loadSettings.texture,
 			"Restore Saved Settings",
 			[]() {
 				globals::state->Load();
-			},
-			false });
+			} });
 	}
 	if (uiIcons.clearCache.texture) {
 		auto shaderCache = globals::shaderCache;

--- a/src/Menu/MenuHeaderRenderer.cpp
+++ b/src/Menu/MenuHeaderRenderer.cpp
@@ -207,7 +207,7 @@ void MenuHeaderRenderer::RenderHeader(bool isDocked, bool showLogo, bool canShow
 			// Clear Shader Cache Button
 			ImGui::TableNextColumn();
 			{
-				bool isDisabled = globals::menu->GetSettings().DisableClearCacheButton;
+				bool isDisabled = globals::menu->GetSettings().Theme.DisableClearCacheButton;
 				if (isDisabled) {
 					ImGui::BeginDisabled();
 				}
@@ -303,7 +303,7 @@ std::vector<MenuHeaderRenderer::ActionIcon> MenuHeaderRenderer::BuildActionIcons
 	}
 	if (uiIcons.clearCache.texture) {
 		auto shaderCache = globals::shaderCache;
-		bool isDisabled = globals::menu->GetSettings().DisableClearCacheButton;
+		bool isDisabled = globals::menu->GetSettings().Theme.DisableClearCacheButton;
 		actionIcons.push_back({ uiIcons.clearCache.texture,
 			isDisabled ? "Clear Shader Cache (Disabled)" :
 			             "Clear Shader Cache\n\n"

--- a/src/Menu/MenuHeaderRenderer.h
+++ b/src/Menu/MenuHeaderRenderer.h
@@ -10,6 +10,7 @@ public:
 		ID3D11ShaderResourceView* texture;
 		const char* tooltip;
 		std::function<void()> callback;
+		bool disabled = false;
 	};
 
 	static void RenderHeader(bool isDocked, bool showLogo, bool canShowIcons, float uiScale, const Menu::UIIcons& uiIcons);

--- a/src/Menu/SettingsTabRenderer.cpp
+++ b/src/Menu/SettingsTabRenderer.cpp
@@ -315,6 +315,21 @@ void SettingsTabRenderer::RenderInterfaceTab()
 			RenderColorsTab();
 			ImGui::EndTabBar();
 		}
+		
+		// Additional Interface Settings (outside of sub-tabs)
+		ImGui::Spacing();
+		SeparatorTextWithFont("Button Visibility", Menu::FontRole::Subheading);
+		
+		bool disableClearCache = globals::menu->GetSettings().DisableClearCacheButton;
+		if (ImGui::Checkbox("Disable Clear Shader Cache Button", &disableClearCache)) {
+			globals::menu->GetSettings().DisableClearCacheButton = disableClearCache;
+		}
+		if (auto _tt = Util::HoverTooltipWrapper()) {
+			ImGui::Text(
+				"Disables the Clear Shader Cache button in the menu header.\n"
+				"The button will appear greyed out and non-functional.");
+		}
+		
 		ImGui::EndTabItem();
 	}
 }

--- a/src/Menu/SettingsTabRenderer.cpp
+++ b/src/Menu/SettingsTabRenderer.cpp
@@ -315,11 +315,11 @@ void SettingsTabRenderer::RenderInterfaceTab()
 			RenderColorsTab();
 			ImGui::EndTabBar();
 		}
-		
+
 		// Additional Interface Settings (outside of sub-tabs)
 		ImGui::Spacing();
 		SeparatorTextWithFont("Header Buttons", Menu::FontRole::Subheading);
-		
+
 		bool disableClearCache = globals::menu->GetSettings().Theme.DisableClearCacheButton;
 		if (ImGui::Checkbox("Disable Clear Shader Cache Button", &disableClearCache)) {
 			globals::menu->GetSettings().Theme.DisableClearCacheButton = disableClearCache;
@@ -329,7 +329,7 @@ void SettingsTabRenderer::RenderInterfaceTab()
 				"Disables the Clear Shader Cache button in the menu header.\n"
 				"The button will appear greyed out and non-functional.");
 		}
-		
+
 		ImGui::EndTabItem();
 	}
 }

--- a/src/Menu/SettingsTabRenderer.cpp
+++ b/src/Menu/SettingsTabRenderer.cpp
@@ -320,9 +320,9 @@ void SettingsTabRenderer::RenderInterfaceTab()
 		ImGui::Spacing();
 		SeparatorTextWithFont("Button Visibility", Menu::FontRole::Subheading);
 		
-		bool disableClearCache = globals::menu->GetSettings().DisableClearCacheButton;
+		bool disableClearCache = globals::menu->GetSettings().Theme.DisableClearCacheButton;
 		if (ImGui::Checkbox("Disable Clear Shader Cache Button", &disableClearCache)) {
-			globals::menu->GetSettings().DisableClearCacheButton = disableClearCache;
+			globals::menu->GetSettings().Theme.DisableClearCacheButton = disableClearCache;
 		}
 		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text(

--- a/src/Menu/SettingsTabRenderer.cpp
+++ b/src/Menu/SettingsTabRenderer.cpp
@@ -318,7 +318,7 @@ void SettingsTabRenderer::RenderInterfaceTab()
 		
 		// Additional Interface Settings (outside of sub-tabs)
 		ImGui::Spacing();
-		SeparatorTextWithFont("Button Visibility", Menu::FontRole::Subheading);
+		SeparatorTextWithFont("Header Buttons", Menu::FontRole::Subheading);
 		
 		bool disableClearCache = globals::menu->GetSettings().Theme.DisableClearCacheButton;
 		if (ImGui::Checkbox("Disable Clear Shader Cache Button", &disableClearCache)) {


### PR DESCRIPTION
Some preset authors have voiced a frustration about how they often accidentally click the clear shader cache button instead of clicking save settings. This leads to having lengthy shader recompilations. 

This PR aims to address this frustration by adding a new toggle in the themes tab, which will grey out this button and disable it, this setting is turned off by default as to not affect default behaviour and my intention is to save this to the themes, rather than the user settings. however this is currently cumbersome as the theme saving system has jank.

Draft for now, will talk to Davo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Interface setting to disable the Clear Shader Cache button in the menu header.
  * When disabled, the button appears greyed out and becomes non-functional.
  * The new option is available in the Interface settings tab under Additional Interface Settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->