### PR TITLE
feat(grass lighting): add complex grass detection threshold slider

### DIFF
--- a/package/Shaders/Common/SharedData.hlsli
+++ b/package/Shaders/Common/SharedData.hlsli
@@ -34,7 +34,8 @@ namespace SharedData
 
 		float BasicGrassBrightness;
 		bool EnableWrappedLighting;
-		float2 pad0;
+		float ComplexGrassThreshold;
+		float1 pad0;
 	};
 
 	struct CPMSettings

--- a/package/Shaders/RunGrass.hlsl
+++ b/package/Shaders/RunGrass.hlsl
@@ -485,7 +485,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 
 	float3 complexTest = TexBaseSampler.Load(int3(0, int(y) - 1, 0)).xyz * 2.0 - 1.0;
 	float complexLength = length(complexTest);
-	bool complex = abs(complexLength - 1.0) < 0.03;
+	bool complex = abs(complexLength - 1.0) < SharedData::grassLightingSettings.ComplexGrassThreshold;
 #		endif  // !TRUE_PBR
 
 	float4 baseColor;

--- a/src/Features/GrassLighting.cpp
+++ b/src/Features/GrassLighting.cpp
@@ -7,7 +7,8 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	SubsurfaceScatteringAmount,
 	OverrideComplexGrassSettings,
 	BasicGrassBrightness,
-	EnableWrappedLighting)
+	EnableWrappedLighting,
+	ComplexGrassThreshold)
 
 void GrassLighting::DrawSettings()
 {
@@ -21,6 +22,16 @@ void GrassLighting::DrawSettings()
 		ImGui::SliderFloat("Specular Strength", &settings.SpecularStrength, 0.0f, 1.0f);
 		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text("Specular highlight strength.");
+		}
+
+		ImGui::Spacing();
+		ImGui::Spacing();
+		ImGui::TextWrapped("Complex Grass Detection");
+		ImGui::SliderFloat("Detection Threshold", &settings.ComplexGrassThreshold, 0.001f, 0.1f, "%.3f");
+		if (auto _tt = Util::HoverTooltipWrapper()) {
+			ImGui::Text(
+				"Threshold for detecting complex grass textures. "
+				"Lower values are more strict. Adjust if grass is incorrectly detected as complex/non-complex.");
 		}
 
 		ImGui::Spacing();

--- a/src/Features/GrassLighting.cpp
+++ b/src/Features/GrassLighting.cpp
@@ -25,13 +25,11 @@ void GrassLighting::DrawSettings()
 		}
 
 		ImGui::Spacing();
-		ImGui::Spacing();
 		ImGui::TextWrapped("Complex Grass Detection");
 		ImGui::SliderFloat("Detection Threshold", &settings.ComplexGrassThreshold, 0.001f, 0.1f, "%.3f");
 		if (auto _tt = Util::HoverTooltipWrapper()) {
 			ImGui::Text(
-				"Threshold for detecting complex grass textures. "
-				"Lower values are more strict. Adjust if grass is incorrectly detected as complex/non-complex.");
+				"Threshold for detecting complex grass textures. Lower values are more strict.");
 		}
 
 		ImGui::Spacing();

--- a/src/Features/GrassLighting.h
+++ b/src/Features/GrassLighting.h
@@ -36,7 +36,8 @@ public:
 		uint OverrideComplexGrassSettings = false;
 		float BasicGrassBrightness = 1.0f;
 		uint EnableWrappedLighting = false;
-		uint pad[2];
+		float ComplexGrassThreshold = 0.03f;
+		uint pad1;
 	};
 	STATIC_ASSERT_ALIGNAS_16(Settings);
 


### PR DESCRIPTION
adds a complex grass detection slider.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Made complex grass detection threshold configurable through UI slider, replacing the previously hardcoded default value.
  * Added labeled control with tooltip explaining the threshold's role in detecting complex grass textures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->