### PR TITLE
feat(UI): require confirmation to clear shader cache

### DIFF
--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -153,6 +153,7 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	ShaderBlockNextKey,
 	EnableShaderBlocking,
 	FirstTimeSetupCompleted,
+	SkipClearCacheConfirmation,
 	Theme,
 	SelectedThemePreset)
 
@@ -680,6 +681,9 @@ void Menu::DrawSettings()
 			ImGui::Spacing();
 			DrawFooter();
 		}
+
+		// Draw global popups (needs to be called once per frame)
+		Util::DrawClearShaderCacheConfirmation();
 	}
 	ImGui::End();
 }

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -377,6 +377,7 @@ public:
 		uint32_t ShaderBlockNextKey = VK_NEXT;   // Debug: cycle forward through shaders (PageDown)
 		bool EnableShaderBlocking = false;       // Enable shader blocking hotkeys for debugging
 		bool FirstTimeSetupCompleted = false;    // Track if first-time setup has been completed
+		bool SkipClearCacheConfirmation = false; // Skip confirmation dialog when clearing shader cache
 		ThemeSettings Theme;
 		std::string SelectedThemePreset = "";  // Currently selected theme preset (empty = custom/user theme)
 	};

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -371,13 +371,13 @@ public:
 	{
 		uint32_t ToggleKey = VK_END;
 		uint32_t SkipCompilationKey = VK_ESCAPE;
-		uint32_t EffectToggleKey = VK_MULTIPLY;  // toggle all effects
-		uint32_t OverlayToggleKey = VK_F10;      // Global overlay toggle key for all overlays
-		uint32_t ShaderBlockPrevKey = VK_PRIOR;  // Debug: cycle backward through shaders (PageUp)
-		uint32_t ShaderBlockNextKey = VK_NEXT;   // Debug: cycle forward through shaders (PageDown)
-		bool EnableShaderBlocking = false;       // Enable shader blocking hotkeys for debugging
-		bool FirstTimeSetupCompleted = false;    // Track if first-time setup has been completed
-		bool SkipClearCacheConfirmation = false; // Skip confirmation dialog when clearing shader cache
+		uint32_t EffectToggleKey = VK_MULTIPLY;   // toggle all effects
+		uint32_t OverlayToggleKey = VK_F10;       // Global overlay toggle key for all overlays
+		uint32_t ShaderBlockPrevKey = VK_PRIOR;   // Debug: cycle backward through shaders (PageUp)
+		uint32_t ShaderBlockNextKey = VK_NEXT;    // Debug: cycle forward through shaders (PageDown)
+		bool EnableShaderBlocking = false;        // Enable shader blocking hotkeys for debugging
+		bool FirstTimeSetupCompleted = false;     // Track if first-time setup has been completed
+		bool SkipClearCacheConfirmation = false;  // Skip confirmation dialog when clearing shader cache
 		ThemeSettings Theme;
 		std::string SelectedThemePreset = "";  // Currently selected theme preset (empty = custom/user theme)
 	};

--- a/src/Menu/MenuHeaderRenderer.cpp
+++ b/src/Menu/MenuHeaderRenderer.cpp
@@ -207,10 +207,7 @@ void MenuHeaderRenderer::RenderHeader(bool isDocked, bool showLogo, bool canShow
 			// Clear Shader Cache Button
 			ImGui::TableNextColumn();
 			if (ImGui::Button("Clear Shader Cache", { -1, 0 })) {
-				shaderCache->Clear();
-				if (shaderCache->IsDiskCache()) {
-					shaderCache->DeleteDiskCache();
-				}
+				Util::RequestClearShaderCacheConfirmation();
 			}
 			if (auto _tt = Util::HoverTooltipWrapper()) {
 				ImGui::Text(
@@ -291,7 +288,6 @@ std::vector<MenuHeaderRenderer::ActionIcon> MenuHeaderRenderer::BuildActionIcons
 			} });
 	}
 	if (uiIcons.clearCache.texture) {
-		auto shaderCache = globals::shaderCache;
 		actionIcons.push_back({ uiIcons.clearCache.texture,
 			"Clear Shader Cache\n\n"
 			"Clears the shader cache and disk cache (if enabled).\n"
@@ -299,11 +295,8 @@ std::vector<MenuHeaderRenderer::ActionIcon> MenuHeaderRenderer::BuildActionIcons
 			"the vanilla shaders at runtime. The Disk Cache is a collection of\n"
 			"compiled shaders on disk. Clearing will mean that shaders are\n"
 			"recompiled only when the game re-encounters them.",
-			[shaderCache]() {
-				shaderCache->Clear();
-				if (shaderCache->IsDiskCache()) {
-					shaderCache->DeleteDiskCache();
-				}
+			[]() {
+				Util::RequestClearShaderCacheConfirmation();
 			} });
 	}
 

--- a/src/Menu/SettingsTabRenderer.cpp
+++ b/src/Menu/SettingsTabRenderer.cpp
@@ -218,7 +218,7 @@ void SettingsTabRenderer::RenderShadersTab()
 		// Skip confirmation when clearing shader cache
 		auto& menuSettings = globals::menu->GetSettings();
 		bool skipConfirmation = menuSettings.SkipClearCacheConfirmation;
-		if (ImGui::Checkbox("Don't ask me again", &skipConfirmation)) {
+		if (ImGui::Checkbox("Skip Clear Cache Dialogue", &skipConfirmation)) {
 			menuSettings.SkipClearCacheConfirmation = skipConfirmation;
 		}
 		if (auto _tt = Util::HoverTooltipWrapper()) {

--- a/src/Menu/SettingsTabRenderer.cpp
+++ b/src/Menu/SettingsTabRenderer.cpp
@@ -215,6 +215,16 @@ void SettingsTabRenderer::RenderShadersTab()
 			ImGui::Text("Skips a shader being replaced if it hasn't been compiled yet. Also makes compilation blazingly fast!");
 		}
 
+		// Skip confirmation when clearing shader cache
+		auto& menuSettings = globals::menu->GetSettings();
+		bool skipConfirmation = menuSettings.SkipClearCacheConfirmation;
+		if (ImGui::Checkbox("Don't ask me again", &skipConfirmation)) {
+			menuSettings.SkipClearCacheConfirmation = skipConfirmation;
+		}
+		if (auto _tt = Util::HoverTooltipWrapper()) {
+			ImGui::Text("When checked, the shader cache will be cleared immediately without asking for confirmation.");
+		}
+
 		if (shaderCache->GetTotalTasks() > 0) {
 			ImGui::Text("Last shader cache build duration: %s",
 				shaderCache->GetShaderStatsString(true, true).c_str());

--- a/src/Menu/ThemeManager.h
+++ b/src/Menu/ThemeManager.h
@@ -179,6 +179,7 @@ public:
 		static constexpr float CURSOR_POSITION_PADDING = 14.0f;
 		static constexpr float SEPARATOR_THICKNESS = 3.0f;
 		static constexpr float UNDOCKED_ICON_ITEM_SPACING = 6.0f;
+		static constexpr float POPUP_BUTTON_WIDTH = 120.0f;
 	};
 
 	static ThemeManager* GetSingleton()

--- a/src/Menu/ThemeManager.h
+++ b/src/Menu/ThemeManager.h
@@ -179,7 +179,7 @@ public:
 		static constexpr float CURSOR_POSITION_PADDING = 14.0f;
 		static constexpr float SEPARATOR_THICKNESS = 3.0f;
 		static constexpr float UNDOCKED_ICON_ITEM_SPACING = 6.0f;
-		static constexpr float POPUP_BUTTON_WIDTH = 120.0f;
+		static constexpr float POPUP_BUTTON_WIDTH = 180.0f;
 	};
 
 	static ThemeManager* GetSingleton()

--- a/src/Utils/UI.cpp
+++ b/src/Utils/UI.cpp
@@ -117,9 +117,11 @@ namespace Util
 		if (ImGui::BeginPopupModal("Clear Shader Cache?", &showClearCacheConfirmation, ImGuiWindowFlags_AlwaysAutoResize)) {
 			ImGui::Text("Are you sure you want to clear the shader cache?");
 			ImGui::Spacing();
+			ImGui::Spacing();
 			ImGui::TextWrapped(
 				"This will clear all compiled shaders from memory and disk cache (if enabled). "
 				"Shaders will be recompiled when the game next encounters them.");
+			ImGui::Spacing();
 			ImGui::Spacing();
 			ImGui::Separator();
 			ImGui::Spacing();
@@ -128,7 +130,7 @@ namespace Util
 
 			ImGui::Spacing();
 
-			// Center the buttons using same pattern as first-time setup
+			// Center buttons
 			constexpr float buttonWidth = ThemeManager::Constants::POPUP_BUTTON_WIDTH;
 			const float spacing = ImGui::GetStyle().ItemSpacing.x;
 			const float totalWidth = buttonWidth * 2 + spacing;

--- a/src/Utils/UI.cpp
+++ b/src/Utils/UI.cpp
@@ -4,6 +4,8 @@
 #include "FileSystem.h"
 #include "Menu.h"
 #include "Menu/IconLoader.h"
+#include "Menu/ThemeManager.h"
+#include "ShaderCache.h"
 #include "WeatherManager.h"
 #include "WeatherVariableRegistry.h"
 
@@ -66,6 +68,97 @@ namespace Util
 	{
 		if (disable)
 			ImGui::EndDisabled();
+	}
+
+	// Static state for clear shader cache confirmation popup
+	static bool showClearCacheConfirmation = false;
+	static bool dontAskAgainCheckbox = false;
+
+	// Helper function to perform the actual cache clearing
+	static void PerformClearShaderCache()
+	{
+		auto* shaderCache = globals::shaderCache;
+		if (shaderCache) {
+			shaderCache->Clear();
+			if (shaderCache->IsDiskCache()) {
+				shaderCache->DeleteDiskCache();
+			}
+		}
+	}
+
+	void RequestClearShaderCacheConfirmation()
+	{
+		auto* menu = globals::menu;
+		if (!menu)
+			return;
+
+		// If user has opted to skip confirmation, clear immediately
+		if (menu->GetSettings().SkipClearCacheConfirmation) {
+			PerformClearShaderCache();
+			return;
+		}
+
+		// Show confirmation popup
+		showClearCacheConfirmation = true;
+		dontAskAgainCheckbox = false;
+	}
+
+	void DrawClearShaderCacheConfirmation()
+	{
+		if (!showClearCacheConfirmation)
+			return;
+
+		ImGui::OpenPopup("Clear Shader Cache?");
+
+		// Center the popup
+		ImVec2 center = ImGui::GetMainViewport()->GetCenter();
+		ImGui::SetNextWindowPos(center, ImGuiCond_Always, ImVec2(0.5f, 0.5f));
+
+		if (ImGui::BeginPopupModal("Clear Shader Cache?", &showClearCacheConfirmation, ImGuiWindowFlags_AlwaysAutoResize)) {
+			ImGui::Text("Are you sure you want to clear the shader cache?");
+			ImGui::Spacing();
+			ImGui::TextWrapped(
+				"This will clear all compiled shaders from memory and disk cache (if enabled). "
+				"Shaders will be recompiled when the game next encounters them.");
+			ImGui::Spacing();
+			ImGui::Separator();
+			ImGui::Spacing();
+
+			ImGui::Checkbox("Don't ask me again", &dontAskAgainCheckbox);
+
+			ImGui::Spacing();
+
+			// Center the buttons using same pattern as first-time setup
+			constexpr float buttonWidth = ThemeManager::Constants::POPUP_BUTTON_WIDTH;
+			const float spacing = ImGui::GetStyle().ItemSpacing.x;
+			const float totalWidth = buttonWidth * 2 + spacing;
+			const float windowWidth = ImGui::GetWindowWidth();
+			const float offset = (windowWidth - totalWidth) * 0.5f;
+			if (offset > 0)
+				ImGui::SetCursorPosX(offset);
+
+			if (ImGui::Button("Clear Cache", ImVec2(buttonWidth, 0))) {
+				// Save preference if checkbox is checked
+				if (dontAskAgainCheckbox) {
+					if (auto* menu = globals::menu) {
+						menu->GetSettings().SkipClearCacheConfirmation = true;
+					}
+				}
+
+				PerformClearShaderCache();
+				showClearCacheConfirmation = false;
+				ImGui::CloseCurrentPopup();
+			}
+
+			ImGui::SameLine();
+
+			if (ImGui::Button("Cancel", ImVec2(buttonWidth, 0))) {
+				showClearCacheConfirmation = false;
+				ImGui::CloseCurrentPopup();
+			}
+
+			ImGui::EndPopup();
+		}
 	}
 
 	bool PercentageSlider(const char* label, float* data, float lb, float ub, const char* format)

--- a/src/Utils/UI.h
+++ b/src/Utils/UI.h
@@ -83,6 +83,15 @@ namespace Util
 	};
 
 	/**
+	 * Confirmation popup for clearing shader cache.
+	 * Call RequestClearShaderCacheConfirmation() when the clear button is clicked.
+	 * Call DrawClearShaderCacheConfirmation() every frame to render the popup.
+	 * The popup respects the "don't ask me again" setting.
+	 */
+	void RequestClearShaderCacheConfirmation();
+	void DrawClearShaderCacheConfirmation();
+
+	/**
 	 * RAII wrapper for styled ImGui buttons that automatically applies and restores styling.
 	 * Use this to ensure consistent button styling without forgetting to pop styles.
 	 */


### PR DESCRIPTION
Add confirmation popup with "don't ask me again" checkbox when clearing cache via header buttons. 
Secondary checkbox in menu so that it can be enabled/disabled without using the clear cache button.
Advanced settings button clears without confirmation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Shader cache now requires confirmation before clearing to prevent accidental data loss.
  * Added "Skip Clear Cache Dialogue" setting in Shaders preferences, allowing users to disable the confirmation prompt for future cache clears.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->