### PR TITLE
fix(weather editor): handling of weathers without overrides

### DIFF
--- a/src/State.cpp
+++ b/src/State.cpp
@@ -18,6 +18,7 @@
 #include "TruePBR.h"
 #include "Utils/FileSystem.h"
 #include "WeatherManager.h"
+#include "WeatherVariableRegistry.h"
 
 void State::Draw()
 {
@@ -343,6 +344,9 @@ void State::Load(ConfigMode a_configMode, bool a_allowReload)
 							logger::warn("Invalid override settings for {}, keeping original settings.", feature->GetName());
 						}
 					}
+
+					// Capture current values as user settings baseline for weather overrides
+					WeatherVariables::GlobalWeatherRegistry::GetSingleton()->CaptureFeatureUserSettings(featureName);
 				} else {
 					logger::info("Feature '{}' is disabled at boot.", featureName);
 				}

--- a/src/WeatherManager.cpp
+++ b/src/WeatherManager.cpp
@@ -98,8 +98,20 @@ void WeatherManager::UpdateFeatures()
 					LoadSettingsFromWeather(currentWeathers.currentWeather, featureName, nextWeatherSettings);
 				}
 
-				// Let the global registry handle variable interpolation
-				globalRegistry->UpdateFeatureFromWeathers(featureName, currWeatherSettings, nextWeatherSettings, currentWeathers.lerpFactor);
+				// If transition is complete (lerpFactor >= 1.0) and current weather has no override,
+				// ensure values are set to user settings baseline to prevent contamination from previous overrides
+				if (currentWeathers.lerpFactor >= 1.0f && nextWeatherSettings.empty()) {
+					auto* featureRegistry = globalRegistry->GetFeatureRegistry(featureName);
+					if (featureRegistry) {
+						const auto& variables = featureRegistry->GetVariables();
+						for (const auto& var : variables) {
+							var->SetToUserSettings();
+						}
+					}
+				} else {
+					// Let the global registry handle variable interpolation
+					globalRegistry->UpdateFeatureFromWeathers(featureName, currWeatherSettings, nextWeatherSettings, currentWeathers.lerpFactor);
+				}
 			}
 		}
 

--- a/src/WeatherVariableRegistry.h
+++ b/src/WeatherVariableRegistry.h
@@ -285,6 +285,11 @@ namespace WeatherVariables
 			variables.push_back(std::static_pointer_cast<IWeatherVariable>(var));
 		}
 
+		void ClearVariables()
+		{
+			variables.clear();
+		}
+
 		void LerpAllVariables(const json& from, const json& to, float factor)
 		{
 			for (auto& var : variables) {
@@ -343,6 +348,9 @@ namespace WeatherVariables
 			auto it = featureRegistries.find(featureName);
 			if (it == featureRegistries.end()) {
 				featureRegistries[featureName] = std::make_unique<FeatureWeatherRegistry>();
+			} else {
+				// Clear existing variables before re-registration (handles settings reload)
+				it->second->ClearVariables();
 			}
 			return featureRegistries[featureName].get();
 		}

--- a/src/WeatherVariableRegistry.h
+++ b/src/WeatherVariableRegistry.h
@@ -41,6 +41,7 @@ namespace WeatherVariables
 		virtual std::string GetName() const = 0;
 		virtual std::string GetDisplayName() const = 0;
 		virtual std::string GetTooltip() const = 0;
+		virtual void CaptureUserSettingsValue() = 0;
 	};
 
 	// Templated weather variable for type safety
@@ -52,7 +53,7 @@ namespace WeatherVariables
 			T* valuePtr, T defaultValue,
 			std::function<T(const T&, const T&, float)> lerpFunc = nullptr) :
 			name(name),
-			displayName(displayName), tooltip(tooltip), valuePtr(valuePtr), defaultValue(defaultValue), lerpFunc(lerpFunc)
+			displayName(displayName), tooltip(tooltip), valuePtr(valuePtr), defaultValue(defaultValue), userSettingsValue(defaultValue), lerpFunc(lerpFunc)
 		{
 			if (!lerpFunc) {
 				// Default lerp for float types
@@ -78,16 +79,18 @@ namespace WeatherVariables
 				return;
 			}
 
-			T fromVal = defaultValue;
-			T toVal = defaultValue;
+			T fromVal;
+			T toVal;
 
 			if (hasFromOverride) {
 				try {
 					fromVal = from.get<T>();
 				} catch (const nlohmann::json::type_error& e) {
 					logger::debug("Type error in Lerp 'from' for {}: {}", name, e.what());
-					fromVal = defaultValue;
+					fromVal = *valuePtr;  // Fallback to current value on error
 				}
+			} else {
+				fromVal = *valuePtr;
 			}
 
 			if (hasToOverride) {
@@ -95,8 +98,10 @@ namespace WeatherVariables
 					toVal = to.get<T>();
 				} catch (const nlohmann::json::type_error& e) {
 					logger::debug("Type error in Lerp 'to' for {}: {}", name, e.what());
-					toVal = defaultValue;
+					toVal = userSettingsValue;  // Fallback to user settings on error
 				}
+			} else {
+				toVal = userSettingsValue;
 			}
 
 			*valuePtr = lerpFunc(fromVal, toVal, factor);
@@ -128,6 +133,13 @@ namespace WeatherVariables
 			}
 		}
 
+		void CaptureUserSettingsValue() override
+		{
+			if (valuePtr) {
+				userSettingsValue = *valuePtr;
+			}
+		}
+
 		std::string GetName() const override { return name; }
 		std::string GetDisplayName() const override { return displayName; }
 		std::string GetTooltip() const override { return tooltip; }
@@ -138,6 +150,7 @@ namespace WeatherVariables
 		std::string tooltip;
 		T* valuePtr;
 		T defaultValue;
+		T userSettingsValue;
 		std::function<T(const T&, const T&, float)> lerpFunc;
 	};
 
@@ -302,6 +315,13 @@ namespace WeatherVariables
 			}
 		}
 
+		void CaptureAllUserSettingsValues()
+		{
+			for (auto& var : variables) {
+				var->CaptureUserSettingsValue();
+			}
+		}
+
 		const std::vector<std::shared_ptr<IWeatherVariable>>& GetVariables() const { return variables; }
 
 	private:
@@ -377,6 +397,14 @@ namespace WeatherVariables
 			auto* registry = GetFeatureRegistry(featureName);
 			if (registry) {
 				registry->LoadAllFromJson(j);
+			}
+		}
+
+		void CaptureFeatureUserSettings(const std::string& featureName)
+		{
+			auto* registry = GetFeatureRegistry(featureName);
+			if (registry) {
+				registry->CaptureAllUserSettingsValues();
 			}
 		}
 

--- a/src/WeatherVariableRegistry.h
+++ b/src/WeatherVariableRegistry.h
@@ -54,7 +54,8 @@ namespace WeatherVariables
 			T* valuePtr, T defaultValue,
 			std::function<T(const T&, const T&, float)> lerpFunc = nullptr) :
 			name(name),
-			displayName(displayName), tooltip(tooltip), valuePtr(valuePtr), defaultValue(defaultValue), userSettingsValue(defaultValue), lerpFunc(lerpFunc)
+			displayName(displayName), tooltip(tooltip), valuePtr(valuePtr), defaultValue(defaultValue),
+			userSettingsValue(valuePtr ? *valuePtr : defaultValue), lerpFunc(lerpFunc)
 		{
 			if (!lerpFunc) {
 				// Default lerp for float types

--- a/src/WeatherVariableRegistry.h
+++ b/src/WeatherVariableRegistry.h
@@ -42,6 +42,7 @@ namespace WeatherVariables
 		virtual std::string GetDisplayName() const = 0;
 		virtual std::string GetTooltip() const = 0;
 		virtual void CaptureUserSettingsValue() = 0;
+		virtual void SetToUserSettings() = 0;
 	};
 
 	// Templated weather variable for type safety
@@ -137,6 +138,13 @@ namespace WeatherVariables
 		{
 			if (valuePtr) {
 				userSettingsValue = *valuePtr;
+			}
+		}
+
+		void SetToUserSettings() override
+		{
+			if (valuePtr) {
+				*valuePtr = userSettingsValue;
 			}
 		}
 


### PR DESCRIPTION
Currently the weather manager will use the default settings that are predefined in the code for feature overrides as start- and end-points of weather transitions. This means that when a transition occurs from a weather without an enabled override to one with an enabled override, the manager will momentarily set the feature settings to default and then lerp from that. Conversely, when transitioning to a weather without an enabled override, the manager will transition to the default settings, not to the settings set in UserSettings.json or the per feature overrides. This means that a preset will have to define overrides for each and every weather, or else it will fall back to defaults. 

This PR changes this behaviour so that a snapshot is taken of the Usersettings and overrides that are loaded at startup or when the user clicks on load settings. This snapshot will be used to transition to. When transitioning from a weather that has no override, we will perform a smooth transition from whatever the current setting is.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-feature snapshot and restore of user weather settings; captures baseline after loading and restores on full transition.
  * Ability to reset feature variables back to recorded user values when a transition completes.

* **Bug Fixes**
  * Clear and reinitialize feature weather variables on reload to avoid stale state.
  * Improved interpolation fallbacks so missing or type-mismatched overrides reliably fall back to current or user-baseline values.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->