### PR TITLE
fix(weather editor): apply weather settings post-load

### DIFF
--- a/src/WeatherEditor/Widget.cpp
+++ b/src/WeatherEditor/Widget.cpp
@@ -113,6 +113,7 @@ void Widget::Load()
 		}
 
 		LoadSettings();
+		ApplyChanges();
 
 		EditorWindow::GetSingleton()->ShowNotification(
 			std::format("Loaded saved settings for {}", GetEditorID()),


### PR DESCRIPTION
On startup and after loading weather adjustments the editor would only load these edits into memory and not actually apply them to the weathers in game, this PR ensures that all weather edits that are loaded also get applied when they are loaded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Saved settings now automatically apply when loaded, ensuring your preferences take effect immediately without requiring additional steps.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->