### PR TITLE
fix(weather-editor): no-override weather file deletion (#1777)

### DIFF
--- a/src/WeatherManager.cpp
+++ b/src/WeatherManager.cpp
@@ -180,10 +180,13 @@ void WeatherManager::SaveSettingsToWeather(RE::TESWeather* weather, const std::s
 		std::error_code ec;
 		if (std::filesystem::remove(filePath, ec)) {
 			logger::info("Removed weather settings file (no data remain): {}", filePath);
-		} else if (ec) {
-			logger::warn("Failed to remove empty weather settings file ({}): {}", filePath, ec.message());
+			return;
 		}
-		return;
+		if (ec == std::errc::no_such_file_or_directory) {
+			return;
+		}
+		logger::warn("Failed to remove empty weather settings file ({}): {}", filePath, ec.message());
+		// fall through to write updated JSON as a best-effort fallback
 	}
 
 	std::ofstream settingsFile(filePath);

--- a/src/WeatherManager.cpp
+++ b/src/WeatherManager.cpp
@@ -175,11 +175,11 @@ void WeatherManager::SaveSettingsToWeather(RE::TESWeather* weather, const std::s
 	}
 
 	// Write back to disk
-	if (featureSettings.empty()) {
-		// No features left for this weather — remove file if it exists
+	// Only delete file if featureSettings is empty AND weatherData contains only featureSettings (no other data)
+	if (featureSettings.empty() && weatherData.size() == 1 && weatherData.contains("featureSettings")) {
 		std::error_code ec;
 		if (std::filesystem::remove(filePath, ec)) {
-			logger::info("Removed weather settings file (no features remain): {}", filePath);
+			logger::info("Removed weather settings file (no data remain): {}", filePath);
 		} else if (ec) {
 			logger::warn("Failed to remove empty weather settings file ({}): {}", filePath, ec.message());
 		}


### PR DESCRIPTION
Fixed a bug where the saving system would delete the whole weather file if there were no more feature overrides left, even if there are other weather settings. Now checks if there's any data left at all and only then deletes the file. I accidentally introduced this bug myself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unintended deletion of weather files that only contained configuration settings.
  * Improved handling and logging when removing or updating weather data so files are preserved or safely rewritten if deletion fails.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->