### PR TITLE
fix(weather editor): override desync with weather transitions

### DIFF
--- a/src/WeatherManager.cpp
+++ b/src/WeatherManager.cpp
@@ -12,8 +12,15 @@ WeatherManager::CurrentWeathers WeatherManager::GetCurrentWeathers()
 	}
 
 	result.currentWeather = sky->currentWeather;
-	result.lastWeather = sky->lastWeather;
 	result.lerpFactor = sky->currentWeatherPct;
+
+	// Update cache: store current lastWeather if it exists, otherwise keep the cached one
+	if (sky->lastWeather) {
+		cachedLastWeather = sky->lastWeather;
+	}
+
+	// Use cached last weather if sky->lastWeather is null
+	result.lastWeather = sky->lastWeather ? sky->lastWeather : cachedLastWeather;
 
 	return result;
 }
@@ -260,5 +267,6 @@ void WeatherManager::ClearCache()
 {
 	perWeatherSettingsCache.clear();
 	lastKnownWeather = CurrentWeathers();
+	cachedLastWeather = nullptr;
 	logger::info("Cleared WeatherManager cache");
 }

--- a/src/WeatherManager.h
+++ b/src/WeatherManager.h
@@ -57,4 +57,7 @@ private:
 
 	// Track last known weather state to detect changes
 	CurrentWeathers lastKnownWeather;
+
+	// Cached last weather - sky->lastWeather can be cleared before currentWeatherPct reaches 1.0
+	RE::TESWeather* cachedLastWeather = nullptr;
 };


### PR DESCRIPTION
Potential fix for some desync I have observed between the lerpfactor used by the weather editor and the weather percentage shown by the weather picker. Copies the weather caching for the last weather from weather picker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved weather system data handling to ensure weather information persists correctly during transitions, preventing data loss in edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->