### PR TITLE
fix(weather editor): desynced override transitions

### DIFF
--- a/src/WeatherManager.cpp
+++ b/src/WeatherManager.cpp
@@ -78,6 +78,12 @@ void WeatherManager::UpdateFeatures()
 	bool weatherChanged = (currentWeathers.currentWeather != lastKnownWeather.currentWeather) ||
 	                      (currentWeathers.lastWeather != lastKnownWeather.lastWeather);
 
+	// Detect if a new transition is starting
+	bool transitionStarting = weatherChanged && currentWeathers.lerpFactor < 1.0f;
+
+	// Detect if transition just completed
+	bool transitionEnding = lastKnownWeather.lerpFactor < 1.0f && currentWeathers.lerpFactor >= 1.0f;
+
 	// Always update if lerp factor changes or weather changed
 	if (weatherChanged || std::abs(currentWeathers.lerpFactor - lastKnownWeather.lerpFactor) > 0.001f) {
 		auto* globalRegistry = WeatherVariables::GlobalWeatherRegistry::GetSingleton();
@@ -105,19 +111,28 @@ void WeatherManager::UpdateFeatures()
 					LoadSettingsFromWeather(currentWeathers.currentWeather, featureName, nextWeatherSettings);
 				}
 
-				// If transition is complete (lerpFactor >= 1.0) and current weather has no override,
-				// ensure values are set to user settings baseline to prevent contamination from previous overrides
+				// Handle transition lifecycle
+				if (transitionStarting) {
+					// Begin new transition - cache the "from" values
+					globalRegistry->BeginFeatureTransition(featureName, currWeatherSettings);
+				}
+
+				// Update feature variables
 				if (currentWeathers.lerpFactor >= 1.0f && nextWeatherSettings.empty()) {
+					// Transition complete, no override on destination - reset to user settings
+					globalRegistry->EndFeatureTransition(featureName);
 					auto* featureRegistry = globalRegistry->GetFeatureRegistry(featureName);
 					if (featureRegistry) {
-						const auto& variables = featureRegistry->GetVariables();
-						for (const auto& var : variables) {
+						for (const auto& var : featureRegistry->GetVariables()) {
 							var->SetToUserSettings();
 						}
 					}
 				} else {
-					// Let the global registry handle variable interpolation
+					// In transition or has override - interpolate
 					globalRegistry->UpdateFeatureFromWeathers(featureName, currWeatherSettings, nextWeatherSettings, currentWeathers.lerpFactor);
+					if (transitionEnding) {
+						globalRegistry->EndFeatureTransition(featureName);
+					}
 				}
 			}
 		}

--- a/src/WeatherVariableRegistry.h
+++ b/src/WeatherVariableRegistry.h
@@ -43,10 +43,6 @@ namespace WeatherVariables
 		virtual std::string GetTooltip() const = 0;
 		virtual void CaptureUserSettingsValue() = 0;
 		virtual void SetToUserSettings() = 0;
-
-		// Transition lifecycle - called by FeatureWeatherRegistry
-		// BeginTransition captures the current value as the transition start point
-		// EndTransition clears the cached transition state
 		virtual void BeginTransition(const json& fromOverride) = 0;
 		virtual void EndTransition() = 0;
 		virtual bool IsInTransition() const = 0;
@@ -120,7 +116,6 @@ namespace WeatherVariables
 			*valuePtr = lerpFunc(fromVal, toVal, factor);
 		}
 
-		// Transition lifecycle implementation
 		void BeginTransition(const json& fromOverride) override
 		{
 			if (!valuePtr)
@@ -128,7 +123,6 @@ namespace WeatherVariables
 
 			// Capture the starting value for this transition
 			if (!fromOverride.is_null()) {
-				// Source weather has an override - use that value
 				try {
 					transitionStartValue = fromOverride.get<T>();
 				} catch (const nlohmann::json::type_error& e) {
@@ -136,7 +130,6 @@ namespace WeatherVariables
 					transitionStartValue = *valuePtr;
 				}
 			} else {
-				// Source weather has no override - use current value (which should be user settings)
 				transitionStartValue = *valuePtr;
 			}
 			inTransition = true;
@@ -382,7 +375,6 @@ namespace WeatherVariables
 			}
 		}
 
-		// Transition management - call at start of weather transition to cache "from" values
 		void BeginTransition(const json& fromWeatherSettings)
 		{
 			for (auto& var : variables) {
@@ -392,7 +384,6 @@ namespace WeatherVariables
 			inTransition = true;
 		}
 
-		// Call when transition completes to clear cached state
 		void EndTransition()
 		{
 			for (auto& var : variables) {
@@ -501,7 +492,6 @@ namespace WeatherVariables
 			}
 		}
 
-		// Transition management - called by WeatherManager when weather transitions start/end
 		void BeginFeatureTransition(const std::string& featureName, const json& fromWeatherSettings)
 		{
 			auto* registry = GetFeatureRegistry(featureName);

--- a/src/WeatherVariableRegistry.h
+++ b/src/WeatherVariableRegistry.h
@@ -45,7 +45,6 @@ namespace WeatherVariables
 		virtual void SetToUserSettings() = 0;
 		virtual void BeginTransition(const json& fromOverride) = 0;
 		virtual void EndTransition() = 0;
-		virtual bool IsInTransition() const = 0;
 	};
 
 	// Templated weather variable for type safety
@@ -138,11 +137,6 @@ namespace WeatherVariables
 		void EndTransition() override
 		{
 			inTransition = false;
-		}
-
-		bool IsInTransition() const override
-		{
-			return inTransition;
 		}
 
 		void SaveToJson(json& j) const override
@@ -381,7 +375,6 @@ namespace WeatherVariables
 				auto [fromVar, _] = ExtractVarJson(var->GetName(), fromWeatherSettings, json{});
 				var->BeginTransition(fromVar);
 			}
-			inTransition = true;
 		}
 
 		void EndTransition()
@@ -389,10 +382,7 @@ namespace WeatherVariables
 			for (auto& var : variables) {
 				var->EndTransition();
 			}
-			inTransition = false;
 		}
-
-		bool IsInTransition() const { return inTransition; }
 
 		const std::vector<std::shared_ptr<IWeatherVariable>>& GetVariables() const { return variables; }
 
@@ -406,7 +396,6 @@ namespace WeatherVariables
 		}
 
 		std::vector<std::shared_ptr<IWeatherVariable>> variables;
-		bool inTransition = false;
 	};
 
 	// Global registry mapping feature names to their weather variables
@@ -506,15 +495,6 @@ namespace WeatherVariables
 			if (registry) {
 				registry->EndTransition();
 			}
-		}
-
-		bool IsFeatureInTransition(const std::string& featureName) const
-		{
-			auto it = featureRegistries.find(featureName);
-			if (it != featureRegistries.end()) {
-				return it->second->IsInTransition();
-			}
-			return false;
 		}
 
 	private:

--- a/src/WeatherVariableRegistry.h
+++ b/src/WeatherVariableRegistry.h
@@ -43,6 +43,13 @@ namespace WeatherVariables
 		virtual std::string GetTooltip() const = 0;
 		virtual void CaptureUserSettingsValue() = 0;
 		virtual void SetToUserSettings() = 0;
+
+		// Transition lifecycle - called by FeatureWeatherRegistry
+		// BeginTransition captures the current value as the transition start point
+		// EndTransition clears the cached transition state
+		virtual void BeginTransition(const json& fromOverride) = 0;
+		virtual void EndTransition() = 0;
+		virtual bool IsInTransition() const = 0;
 	};
 
 	// Templated weather variable for type safety
@@ -55,7 +62,8 @@ namespace WeatherVariables
 			std::function<T(const T&, const T&, float)> lerpFunc = nullptr) :
 			name(name),
 			displayName(displayName), tooltip(tooltip), valuePtr(valuePtr), defaultValue(defaultValue),
-			userSettingsValue(valuePtr ? *valuePtr : defaultValue), lerpFunc(lerpFunc)
+			userSettingsValue(valuePtr ? *valuePtr : defaultValue), lerpFunc(lerpFunc),
+			inTransition(false), transitionStartValue(defaultValue)
 		{
 			if (!lerpFunc) {
 				// Default lerp for float types
@@ -84,15 +92,18 @@ namespace WeatherVariables
 			T fromVal;
 			T toVal;
 
-			if (hasFromOverride) {
+			// Use cached transition start value if in transition, otherwise parse from JSON
+			if (inTransition) {
+				fromVal = transitionStartValue;
+			} else if (hasFromOverride) {
 				try {
 					fromVal = from.get<T>();
 				} catch (const nlohmann::json::type_error& e) {
 					logger::debug("Type error in Lerp 'from' for {}: {}", name, e.what());
-					fromVal = *valuePtr;  // Fallback to current value on error
+					fromVal = userSettingsValue;
 				}
 			} else {
-				fromVal = *valuePtr;
+				fromVal = userSettingsValue;
 			}
 
 			if (hasToOverride) {
@@ -107,6 +118,38 @@ namespace WeatherVariables
 			}
 
 			*valuePtr = lerpFunc(fromVal, toVal, factor);
+		}
+
+		// Transition lifecycle implementation
+		void BeginTransition(const json& fromOverride) override
+		{
+			if (!valuePtr)
+				return;
+
+			// Capture the starting value for this transition
+			if (!fromOverride.is_null()) {
+				// Source weather has an override - use that value
+				try {
+					transitionStartValue = fromOverride.get<T>();
+				} catch (const nlohmann::json::type_error& e) {
+					logger::debug("Type error in BeginTransition for {}: {}", name, e.what());
+					transitionStartValue = *valuePtr;
+				}
+			} else {
+				// Source weather has no override - use current value (which should be user settings)
+				transitionStartValue = *valuePtr;
+			}
+			inTransition = true;
+		}
+
+		void EndTransition() override
+		{
+			inTransition = false;
+		}
+
+		bool IsInTransition() const override
+		{
+			return inTransition;
 		}
 
 		void SaveToJson(json& j) const override
@@ -161,6 +204,10 @@ namespace WeatherVariables
 		T defaultValue;
 		T userSettingsValue;
 		std::function<T(const T&, const T&, float)> lerpFunc;
+
+		// Transition state
+		bool inTransition;
+		T transitionStartValue;
 	};
 
 	// Specialized weather variables for common types
@@ -302,8 +349,7 @@ namespace WeatherVariables
 		void LerpAllVariables(const json& from, const json& to, float factor)
 		{
 			for (auto& var : variables) {
-				json fromVar = from.is_null() || !from.contains(var->GetName()) ? json{} : from[var->GetName()];
-				json toVar = to.is_null() || !to.contains(var->GetName()) ? json{} : to[var->GetName()];
+				auto [fromVar, toVar] = ExtractVarJson(var->GetName(), from, to);
 				var->Lerp(fromVar, toVar, factor);
 			}
 		}
@@ -336,10 +382,40 @@ namespace WeatherVariables
 			}
 		}
 
+		// Transition management - call at start of weather transition to cache "from" values
+		void BeginTransition(const json& fromWeatherSettings)
+		{
+			for (auto& var : variables) {
+				auto [fromVar, _] = ExtractVarJson(var->GetName(), fromWeatherSettings, json{});
+				var->BeginTransition(fromVar);
+			}
+			inTransition = true;
+		}
+
+		// Call when transition completes to clear cached state
+		void EndTransition()
+		{
+			for (auto& var : variables) {
+				var->EndTransition();
+			}
+			inTransition = false;
+		}
+
+		bool IsInTransition() const { return inTransition; }
+
 		const std::vector<std::shared_ptr<IWeatherVariable>>& GetVariables() const { return variables; }
 
 	private:
+		// Extract per-variable JSON from weather settings, returning null json if absent
+		static std::pair<json, json> ExtractVarJson(const std::string& varName, const json& from, const json& to)
+		{
+			json fromVar = (from.is_null() || !from.contains(varName)) ? json{} : from[varName];
+			json toVar = (to.is_null() || !to.contains(varName)) ? json{} : to[varName];
+			return { fromVar, toVar };
+		}
+
 		std::vector<std::shared_ptr<IWeatherVariable>> variables;
+		bool inTransition = false;
 	};
 
 	// Global registry mapping feature names to their weather variables
@@ -423,6 +499,32 @@ namespace WeatherVariables
 			if (registry) {
 				registry->CaptureAllUserSettingsValues();
 			}
+		}
+
+		// Transition management - called by WeatherManager when weather transitions start/end
+		void BeginFeatureTransition(const std::string& featureName, const json& fromWeatherSettings)
+		{
+			auto* registry = GetFeatureRegistry(featureName);
+			if (registry) {
+				registry->BeginTransition(fromWeatherSettings);
+			}
+		}
+
+		void EndFeatureTransition(const std::string& featureName)
+		{
+			auto* registry = GetFeatureRegistry(featureName);
+			if (registry) {
+				registry->EndTransition();
+			}
+		}
+
+		bool IsFeatureInTransition(const std::string& featureName) const
+		{
+			auto it = featureRegistries.find(featureName);
+			if (it != featureRegistries.end()) {
+				return it->second->IsInTransition();
+			}
+			return false;
 		}
 
 	private:

--- a/src/WeatherVariableRegistry.h
+++ b/src/WeatherVariableRegistry.h
@@ -390,8 +390,8 @@ namespace WeatherVariables
 		// Extract per-variable JSON from weather settings, returning null json if absent
 		static std::pair<json, json> ExtractVarJson(const std::string& varName, const json& from, const json& to)
 		{
-			json fromVar = (from.is_null() || !from.contains(varName)) ? json{} : from[varName];
-			json toVar = (to.is_null() || !to.contains(varName)) ? json{} : to[varName];
+			json fromVar = (!from.is_object() || !from.contains(varName)) ? json{} : from[varName];
+			json toVar = (!to.is_object() || !to.contains(varName)) ? json{} : to[varName];
 			return { fromVar, toVar };
 		}
 


### PR DESCRIPTION
I previously committed a caching system to prevent lerping to desync between the weather and the feature overrides, however that didn't fix the issue. This PR does actually fix the issue, a proper caching system is implemented that caches the value that the manager lerps from at the start of the transition, and then tracks if the transition is complete or not. This way we do not lerp from a moving origin to a static target, effectively causing an "ease in" effect. Instead the transition is always correctly in sync with the actual weather transition.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Smoother, more reliable weather transitions with explicit start/end handling for interpolations
  * Better caching of previous weather values so transitions preserve expected visuals
  * Per-variable transition tracking to ensure consistent blending of overrides and user settings
  * Improved coordination across weather features for more consistent behavior in complex scenarios
<!-- end of auto-generated comment: release notes by coderabbit.ai -->