### PR TITLE
fix(weather editor): sync UI for full transition

### DIFF
--- a/src/Utils/UI.cpp
+++ b/src/Utils/UI.cpp
@@ -1514,6 +1514,11 @@ namespace Util
 				return false;
 			}
 
+			// Still controlled if variable is mid-transition (e.g., transitioning to a weather without an override)
+			if (globalRegistry->IsFeatureVariableInTransition(featureName, settingName)) {
+				return true;
+			}
+
 			// Check if current weather exists
 			auto currentWeathers = weatherManager->GetCurrentWeathers();
 			if (!currentWeathers.currentWeather) {

--- a/src/WeatherManager.cpp
+++ b/src/WeatherManager.cpp
@@ -84,8 +84,8 @@ void WeatherManager::UpdateFeatures()
 	// Detect if transition just completed
 	bool transitionEnding = lastKnownWeather.lerpFactor < 1.0f && currentWeathers.lerpFactor >= 1.0f;
 
-	// Always update if lerp factor changes or weather changed
-	if (weatherChanged || std::abs(currentWeathers.lerpFactor - lastKnownWeather.lerpFactor) > 0.001f) {
+	// Always update if lerp factor changes, weather changed, or transition just completed
+	if (weatherChanged || transitionEnding || std::abs(currentWeathers.lerpFactor - lastKnownWeather.lerpFactor) > 0.001f) {
 		auto* globalRegistry = WeatherVariables::GlobalWeatherRegistry::GetSingleton();
 
 		// Get all features and update those that have registered weather variables

--- a/src/WeatherVariableRegistry.h
+++ b/src/WeatherVariableRegistry.h
@@ -45,6 +45,7 @@ namespace WeatherVariables
 		virtual void SetToUserSettings() = 0;
 		virtual void BeginTransition(const json& fromOverride) = 0;
 		virtual void EndTransition() = 0;
+		virtual bool IsInTransition() const = 0;
 	};
 
 	// Templated weather variable for type safety
@@ -138,6 +139,8 @@ namespace WeatherVariables
 		{
 			inTransition = false;
 		}
+
+		bool IsInTransition() const override { return inTransition; }
 
 		void SaveToJson(json& j) const override
 		{
@@ -384,6 +387,15 @@ namespace WeatherVariables
 			}
 		}
 
+		bool IsVariableInTransition(const std::string& settingName) const
+		{
+			for (const auto& var : variables) {
+				if (var->GetName() == settingName)
+					return var->IsInTransition();
+			}
+			return false;
+		}
+
 		const std::vector<std::shared_ptr<IWeatherVariable>>& GetVariables() const { return variables; }
 
 	private:
@@ -495,6 +507,12 @@ namespace WeatherVariables
 			if (registry) {
 				registry->EndTransition();
 			}
+		}
+
+		bool IsFeatureVariableInTransition(const std::string& featureName, const std::string& settingName)
+		{
+			auto* registry = GetFeatureRegistry(featureName);
+			return registry && registry->IsVariableInTransition(settingName);
 		}
 
 	private:


### PR DESCRIPTION
uses inTransition bool introduced in #1820 to properly take control of the feature UI when a transition occurs.
Previously the editor would release control of the UI the moment a transition starts to a weather without an override.
However user control was not yet possible as the system is still lerping the variables.
Now the UI control will only be released once the transition has finished fully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced detection of weather variable transitions to ensure weather-controlled UI controls (sliders, checkboxes) properly lock during active transitions, preventing accidental modifications and displaying appropriate prompts for Weather Editor access.
  * Improved feature refresh timing to immediately update settings when weather transitions complete, enabling more responsive system behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->