### PR TITLE
feat(weather editor): toggle hotkey

### DIFF
--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -1084,13 +1084,9 @@ void Menu::ProcessInputEventQueue()
 					}
 				}
 
-				// ESC closes editor first (without propagating), then menu
+				// Close menu with ESC if no editor window is open
 				auto* editorWindow = EditorWindow::GetSingleton();
-				if (key == VK_ESCAPE && editorWindow && editorWindow->open) {
-					editorWindow->open = false;
-					continue;  // Don't send to ImGui/menu
-				}
-				if (key == VK_ESCAPE && IsEnabled) {
+				if (key == VK_ESCAPE && IsEnabled && editorWindow && !editorWindow->open) {
 					IsEnabled = false;
 				}
 			}

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -1046,8 +1046,8 @@ void Menu::ProcessInputEventQueue()
 						{ settings.EffectToggleKey, [shaderCache]() { shaderCache->SetEnabled(!shaderCache->IsEnabled()); } },
 						{ settings.ShaderBlockPrevKey, [this, shaderCache]() { if (settings.EnableShaderBlocking) shaderCache->IterateShaderBlock(); } },
 						{ settings.ShaderBlockNextKey, [this, shaderCache]() { if (settings.EnableShaderBlocking) shaderCache->IterateShaderBlock(false); } },
-						{ settings.OverlayToggleKey, []() {Menu::GetSingleton()->overlayVisible = !Menu::GetSingleton()->overlayVisible; } },
-						{ settings.WeatherEditorToggleKey, []() {EditorWindow::GetSingleton()->open = !EditorWindow::GetSingleton()->open;} },
+						{ settings.OverlayToggleKey, []() { Menu::GetSingleton()->overlayVisible = !Menu::GetSingleton()->overlayVisible; } },
+						{ settings.WeatherEditorToggleKey, []() { EditorWindow::GetSingleton()->open = !EditorWindow::GetSingleton()->open; } },
 					};
 					for (const auto& ka : keyActions) {
 						// Check if key matches last key in combo and all modifiers are held (exact match)

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -152,6 +152,7 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	OverlayToggleKey,
 	ShaderBlockPrevKey,
 	ShaderBlockNextKey,
+	WeatherEditorToggleKey,
 	EnableShaderBlocking,
 	FirstTimeSetupCompleted,
 	SkipClearCacheConfirmation,
@@ -262,6 +263,7 @@ void Menu::Load(json& o_json)
 	migrateKey(o_json, "OverlayToggleKey", settings.OverlayToggleKey);
 	migrateKey(o_json, "ShaderBlockPrevKey", settings.ShaderBlockPrevKey);
 	migrateKey(o_json, "ShaderBlockNextKey", settings.ShaderBlockNextKey);
+	migrateKey(o_json, "WeatherEditorToggleKey", settings.WeatherEditorToggleKey);
 
 	// Helper for new smart serialization with error handling
 	auto loadComboList = [](const json& j, const char* keyName, std::vector<InputCombo>& target) {
@@ -281,6 +283,7 @@ void Menu::Load(json& o_json)
 	loadComboList(o_json, "OverlayToggleKey", settings.OverlayToggleKey);
 	loadComboList(o_json, "ShaderBlockPrevKey", settings.ShaderBlockPrevKey);
 	loadComboList(o_json, "ShaderBlockNextKey", settings.ShaderBlockNextKey);
+	loadComboList(o_json, "WeatherEditorToggleKey", settings.WeatherEditorToggleKey);
 
 	// Legacy support: If old config has Theme data and no SelectedThemePreset, load it
 	if (o_json.contains("Theme") && o_json["Theme"].is_object() && settings.SelectedThemePreset.empty()) {
@@ -343,6 +346,7 @@ void Menu::Save(json& o_json)
 	InputCombo::ComboList::to_json(o_json["OverlayToggleKey"], settings.OverlayToggleKey);
 	InputCombo::ComboList::to_json(o_json["ShaderBlockPrevKey"], settings.ShaderBlockPrevKey);
 	InputCombo::ComboList::to_json(o_json["ShaderBlockNextKey"], settings.ShaderBlockNextKey);
+	InputCombo::ComboList::to_json(o_json["WeatherEditorToggleKey"], settings.WeatherEditorToggleKey);
 }
 
 void Menu::LoadTheme(json& o_json)
@@ -773,7 +777,8 @@ void Menu::DrawGeneralSettings()
 		.settingSkipCompilationKey = settingSkipCompilationKey,
 		.settingOverlayToggleKey = settingOverlayToggleKey,
 		.settingShaderBlockPrevKey = settingShaderBlockPrevKey,
-		.settingShaderBlockNextKey = settingShaderBlockNextKey
+		.settingShaderBlockNextKey = settingShaderBlockNextKey,
+		.settingWeatherEditorToggleKey = settingWeatherEditorToggleKey
 	};
 
 	// Render settings using extracted component
@@ -988,6 +993,7 @@ void Menu::ProcessInputEventQueue()
 					{ &settings.OverlayToggleKey, &settingOverlayToggleKey, [this](std::vector<InputCombo> keys) { settings.OverlayToggleKey = keys; settingOverlayToggleKey = false; } },
 					{ &settings.ShaderBlockPrevKey, &settingShaderBlockPrevKey, [this](std::vector<InputCombo> keys) { settings.ShaderBlockPrevKey = keys; settingShaderBlockPrevKey = false; } },
 					{ &settings.ShaderBlockNextKey, &settingShaderBlockNextKey, [this](std::vector<InputCombo> keys) { settings.ShaderBlockNextKey = keys; settingShaderBlockNextKey = false; } },
+					{ &settings.WeatherEditorToggleKey, &settingWeatherEditorToggleKey, [this](std::vector<InputCombo> keys) { settings.WeatherEditorToggleKey = keys; settingWeatherEditorToggleKey = false; } },
 				};
 				bool handled = false;
 				for (auto& h : hotkeyActions) {
@@ -1045,9 +1051,8 @@ void Menu::ProcessInputEventQueue()
 						{ settings.EffectToggleKey, [shaderCache]() { shaderCache->SetEnabled(!shaderCache->IsEnabled()); } },
 						{ settings.ShaderBlockPrevKey, [this, shaderCache]() { if (settings.EnableShaderBlocking) shaderCache->IterateShaderBlock(); } },
 						{ settings.ShaderBlockNextKey, [this, shaderCache]() { if (settings.EnableShaderBlocking) shaderCache->IterateShaderBlock(false); } },
-						{ settings.OverlayToggleKey, []() {
-							 Menu::GetSingleton()->overlayVisible = !Menu::GetSingleton()->overlayVisible;
-						 } },
+						{ settings.OverlayToggleKey, []() {Menu::GetSingleton()->overlayVisible = !Menu::GetSingleton()->overlayVisible; } },
+						{ settings.WeatherEditorToggleKey, []() {EditorWindow::GetSingleton()->open = !EditorWindow::GetSingleton()->open;} },
 					};
 					for (const auto& ka : keyActions) {
 						// Check if key matches last key in combo and all modifiers are held (exact match)
@@ -1084,10 +1089,16 @@ void Menu::ProcessInputEventQueue()
 					}
 				}
 
-				// Close menu with ESC if no editor window is open
+				// Handle ESC key for editor and menu
 				auto* editorWindow = EditorWindow::GetSingleton();
-				if (key == VK_ESCAPE && IsEnabled && editorWindow && !editorWindow->open) {
-					IsEnabled = false;
+				if (key == VK_ESCAPE) {
+					if (editorWindow && editorWindow->open) {
+						// Close editor window, don't propagate to menu
+						editorWindow->open = false;
+					} else if (IsEnabled) {
+						// Close menu only if editor is not open
+						IsEnabled = false;
+					}
 				}
 			}
 

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -687,11 +687,6 @@ void Menu::DrawSettings()
 	ImGui::SetNextWindowSize(Util::GetNativeViewportSizeScaled(0.8f), ImGuiCond_FirstUseEver);
 	auto title = std::format("Community Shaders {}", Util::GetFormattedVersion(Plugin::VERSION));
 
-	if (EditorWindow::GetSingleton()->open) {
-		EditorWindow::GetSingleton()->Draw();
-		return;
-	}
-
 	// Determine window flags based on docking state
 	ImGuiWindowFlags windowFlags = ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoScrollbar;
 	// Check if this will be docked (we need to peek at the docking state)
@@ -1089,16 +1084,14 @@ void Menu::ProcessInputEventQueue()
 					}
 				}
 
-				// Handle ESC key for editor and menu
+				// ESC closes editor first (without propagating), then menu
 				auto* editorWindow = EditorWindow::GetSingleton();
-				if (key == VK_ESCAPE) {
-					if (editorWindow && editorWindow->open) {
-						// Close editor window, don't propagate to menu
-						editorWindow->open = false;
-					} else if (IsEnabled) {
-						// Close menu only if editor is not open
-						IsEnabled = false;
-					}
+				if (key == VK_ESCAPE && editorWindow && editorWindow->open) {
+					editorWindow->open = false;
+					continue;  // Don't send to ImGui/menu
+				}
+				if (key == VK_ESCAPE && IsEnabled) {
+					IsEnabled = false;
 				}
 			}
 

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -139,6 +139,7 @@ public:
 	bool settingOverlayToggleKey = false;
 	bool settingShaderBlockPrevKey = false;  // Debug: capture shader block prev key
 	bool settingShaderBlockNextKey = false;  // Debug: capture shader block next key
+	bool settingWeatherEditorToggleKey = false;  // Weather Editor toggle key
 
 	// Font caching (made public for ThemeManager and OverlayRenderer access)
 	// Marked mutable because they're cache fields that may be updated from const methods
@@ -378,15 +379,16 @@ public:
 	{
 		std::vector<InputCombo> ToggleKey = { InputCombo::Keyboard(VK_END) };
 		std::vector<InputCombo> SkipCompilationKey = { InputCombo::Keyboard(VK_ESCAPE) };
-		std::vector<InputCombo> EffectToggleKey = { InputCombo::Keyboard(VK_MULTIPLY) };  // toggle all effects
-		std::vector<InputCombo> OverlayToggleKey = { InputCombo::Keyboard(VK_F10) };      // Global overlay toggle key for all overlays
-		std::vector<InputCombo> ShaderBlockPrevKey = { InputCombo::Keyboard(VK_PRIOR) };  // Debug: cycle backward through shaders (PageUp)
-		std::vector<InputCombo> ShaderBlockNextKey = { InputCombo::Keyboard(VK_NEXT) };   // Debug: cycle forward through shaders (PageDown)
-		bool EnableShaderBlocking = false;                                                // Enable shader blocking hotkeys for debugging
-		bool FirstTimeSetupCompleted = false;                                             // Track if first-time setup has been completed
-		bool SkipClearCacheConfirmation = false;                                          // Skip confirmation dialog when clearing shader cache
-		bool AutoHideFeatureList = false;                                                 // Auto-hide left feature list panel, show on hover
-		bool SkipConstraintWarning = false;                                               // Skip popup when a setting change creates new constraints
+		std::vector<InputCombo> EffectToggleKey = { InputCombo::Keyboard(VK_MULTIPLY) };  	// toggle all effects
+		std::vector<InputCombo> OverlayToggleKey = { InputCombo::Keyboard(VK_F10) };      	// Global overlay toggle key for all overlays
+		std::vector<InputCombo> ShaderBlockPrevKey = { InputCombo::Keyboard(VK_PRIOR) };  	// Debug: cycle backward through shaders (PageUp)
+		std::vector<InputCombo> ShaderBlockNextKey = { InputCombo::Keyboard(VK_NEXT) };   	// Debug: cycle forward through shaders (PageDown)
+		std::vector<InputCombo> WeatherEditorToggleKey = { InputCombo::Keyboard(VK_F11) };  // Weather Editor toggle key
+		bool EnableShaderBlocking = false;                                                	// Enable shader blocking hotkeys for debugging
+		bool FirstTimeSetupCompleted = false;                                             	// Track if first-time setup has been completed
+		bool SkipClearCacheConfirmation = false;                                          	// Skip confirmation dialog when clearing shader cache
+		bool AutoHideFeatureList = false;                                                 	// Auto-hide left feature list panel, show on hover
+		bool SkipConstraintWarning = false;                                               	// Skip popup when a setting change creates new constraints
 		ThemeSettings Theme;
 		std::string SelectedThemePreset = "";  // Currently selected theme preset (empty = custom/user theme)
 	};

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -383,7 +383,7 @@ public:
 		std::vector<InputCombo> OverlayToggleKey = { InputCombo::Keyboard(VK_F10) };      	// Global overlay toggle key for all overlays
 		std::vector<InputCombo> ShaderBlockPrevKey = { InputCombo::Keyboard(VK_PRIOR) };  	// Debug: cycle backward through shaders (PageUp)
 		std::vector<InputCombo> ShaderBlockNextKey = { InputCombo::Keyboard(VK_NEXT) };   	// Debug: cycle forward through shaders (PageDown)
-		std::vector<InputCombo> WeatherEditorToggleKey = { InputCombo::Keyboard(VK_F11) };  // Weather Editor toggle key
+		std::vector<InputCombo> WeatherEditorToggleKey = { InputCombo::Keyboard(VK_F12) };  // Weather Editor toggle key
 		bool EnableShaderBlocking = false;                                                	// Enable shader blocking hotkeys for debugging
 		bool FirstTimeSetupCompleted = false;                                             	// Track if first-time setup has been completed
 		bool SkipClearCacheConfirmation = false;                                          	// Skip confirmation dialog when clearing shader cache

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -379,16 +379,16 @@ public:
 	{
 		std::vector<InputCombo> ToggleKey = { InputCombo::Keyboard(VK_END) };
 		std::vector<InputCombo> SkipCompilationKey = { InputCombo::Keyboard(VK_ESCAPE) };
-		std::vector<InputCombo> EffectToggleKey = { InputCombo::Keyboard(VK_MULTIPLY) };   // toggle all effects
-		std::vector<InputCombo> OverlayToggleKey = { InputCombo::Keyboard(VK_F10) };       // Global overlay toggle key for all overlays
-		std::vector<InputCombo> ShaderBlockPrevKey = { InputCombo::Keyboard(VK_PRIOR) };   // Debug: cycle backward through shaders (PageUp)
-		std::vector<InputCombo> ShaderBlockNextKey = { InputCombo::Keyboard(VK_NEXT) };    // Debug: cycle forward through shaders (PageDown)
+		std::vector<InputCombo> EffectToggleKey = { InputCombo::Keyboard(VK_MULTIPLY) };    // toggle all effects
+		std::vector<InputCombo> OverlayToggleKey = { InputCombo::Keyboard(VK_F10) };        // Global overlay toggle key for all overlays
+		std::vector<InputCombo> ShaderBlockPrevKey = { InputCombo::Keyboard(VK_PRIOR) };    // Debug: cycle backward through shaders (PageUp)
+		std::vector<InputCombo> ShaderBlockNextKey = { InputCombo::Keyboard(VK_NEXT) };     // Debug: cycle forward through shaders (PageDown)
 		std::vector<InputCombo> WeatherEditorToggleKey = { InputCombo::Keyboard(VK_F11) };  // Weather Editor toggle key
-		bool EnableShaderBlocking = false;                                                 // Enable shader blocking hotkeys for debugging
-		bool FirstTimeSetupCompleted = false;                                              // Track if first-time setup has been completed
-		bool SkipClearCacheConfirmation = false;                                           // Skip confirmation dialog when clearing shader cache
-		bool AutoHideFeatureList = false;                                                  // Auto-hide left feature list panel, show on hover
-		bool SkipConstraintWarning = false;                                                // Skip popup when a setting change creates new constraints
+		bool EnableShaderBlocking = false;                                                  // Enable shader blocking hotkeys for debugging
+		bool FirstTimeSetupCompleted = false;                                               // Track if first-time setup has been completed
+		bool SkipClearCacheConfirmation = false;                                            // Skip confirmation dialog when clearing shader cache
+		bool AutoHideFeatureList = false;                                                   // Auto-hide left feature list panel, show on hover
+		bool SkipConstraintWarning = false;                                                 // Skip popup when a setting change creates new constraints
 		ThemeSettings Theme;
 		std::string SelectedThemePreset = "";  // Currently selected theme preset (empty = custom/user theme)
 	};

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -137,8 +137,8 @@ public:
 	bool settingSkipCompilationKey = false;
 	bool settingsEffectsToggle = false;
 	bool settingOverlayToggleKey = false;
-	bool settingShaderBlockPrevKey = false;  // Debug: capture shader block prev key
-	bool settingShaderBlockNextKey = false;  // Debug: capture shader block next key
+	bool settingShaderBlockPrevKey = false;      // Debug: capture shader block prev key
+	bool settingShaderBlockNextKey = false;      // Debug: capture shader block next key
 	bool settingWeatherEditorToggleKey = false;  // Weather Editor toggle key
 
 	// Font caching (made public for ThemeManager and OverlayRenderer access)
@@ -379,16 +379,16 @@ public:
 	{
 		std::vector<InputCombo> ToggleKey = { InputCombo::Keyboard(VK_END) };
 		std::vector<InputCombo> SkipCompilationKey = { InputCombo::Keyboard(VK_ESCAPE) };
-		std::vector<InputCombo> EffectToggleKey = { InputCombo::Keyboard(VK_MULTIPLY) };  	// toggle all effects
-		std::vector<InputCombo> OverlayToggleKey = { InputCombo::Keyboard(VK_F10) };      	// Global overlay toggle key for all overlays
-		std::vector<InputCombo> ShaderBlockPrevKey = { InputCombo::Keyboard(VK_PRIOR) };  	// Debug: cycle backward through shaders (PageUp)
-		std::vector<InputCombo> ShaderBlockNextKey = { InputCombo::Keyboard(VK_NEXT) };   	// Debug: cycle forward through shaders (PageDown)
+		std::vector<InputCombo> EffectToggleKey = { InputCombo::Keyboard(VK_MULTIPLY) };    // toggle all effects
+		std::vector<InputCombo> OverlayToggleKey = { InputCombo::Keyboard(VK_F10) };        // Global overlay toggle key for all overlays
+		std::vector<InputCombo> ShaderBlockPrevKey = { InputCombo::Keyboard(VK_PRIOR) };    // Debug: cycle backward through shaders (PageUp)
+		std::vector<InputCombo> ShaderBlockNextKey = { InputCombo::Keyboard(VK_NEXT) };     // Debug: cycle forward through shaders (PageDown)
 		std::vector<InputCombo> WeatherEditorToggleKey = { InputCombo::Keyboard(VK_F12) };  // Weather Editor toggle key
-		bool EnableShaderBlocking = false;                                                	// Enable shader blocking hotkeys for debugging
-		bool FirstTimeSetupCompleted = false;                                             	// Track if first-time setup has been completed
-		bool SkipClearCacheConfirmation = false;                                          	// Skip confirmation dialog when clearing shader cache
-		bool AutoHideFeatureList = false;                                                 	// Auto-hide left feature list panel, show on hover
-		bool SkipConstraintWarning = false;                                               	// Skip popup when a setting change creates new constraints
+		bool EnableShaderBlocking = false;                                                  // Enable shader blocking hotkeys for debugging
+		bool FirstTimeSetupCompleted = false;                                               // Track if first-time setup has been completed
+		bool SkipClearCacheConfirmation = false;                                            // Skip confirmation dialog when clearing shader cache
+		bool AutoHideFeatureList = false;                                                   // Auto-hide left feature list panel, show on hover
+		bool SkipConstraintWarning = false;                                                 // Skip popup when a setting change creates new constraints
 		ThemeSettings Theme;
 		std::string SelectedThemePreset = "";  // Currently selected theme preset (empty = custom/user theme)
 	};

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -379,16 +379,16 @@ public:
 	{
 		std::vector<InputCombo> ToggleKey = { InputCombo::Keyboard(VK_END) };
 		std::vector<InputCombo> SkipCompilationKey = { InputCombo::Keyboard(VK_ESCAPE) };
-		std::vector<InputCombo> EffectToggleKey = { InputCombo::Keyboard(VK_MULTIPLY) };    // toggle all effects
-		std::vector<InputCombo> OverlayToggleKey = { InputCombo::Keyboard(VK_F10) };        // Global overlay toggle key for all overlays
-		std::vector<InputCombo> ShaderBlockPrevKey = { InputCombo::Keyboard(VK_PRIOR) };    // Debug: cycle backward through shaders (PageUp)
-		std::vector<InputCombo> ShaderBlockNextKey = { InputCombo::Keyboard(VK_NEXT) };     // Debug: cycle forward through shaders (PageDown)
-		std::vector<InputCombo> WeatherEditorToggleKey = { InputCombo::Keyboard(VK_F12) };  // Weather Editor toggle key
-		bool EnableShaderBlocking = false;                                                  // Enable shader blocking hotkeys for debugging
-		bool FirstTimeSetupCompleted = false;                                               // Track if first-time setup has been completed
-		bool SkipClearCacheConfirmation = false;                                            // Skip confirmation dialog when clearing shader cache
-		bool AutoHideFeatureList = false;                                                   // Auto-hide left feature list panel, show on hover
-		bool SkipConstraintWarning = false;                                                 // Skip popup when a setting change creates new constraints
+		std::vector<InputCombo> EffectToggleKey = { InputCombo::Keyboard(VK_MULTIPLY) };   // toggle all effects
+		std::vector<InputCombo> OverlayToggleKey = { InputCombo::Keyboard(VK_F10) };       // Global overlay toggle key for all overlays
+		std::vector<InputCombo> ShaderBlockPrevKey = { InputCombo::Keyboard(VK_PRIOR) };   // Debug: cycle backward through shaders (PageUp)
+		std::vector<InputCombo> ShaderBlockNextKey = { InputCombo::Keyboard(VK_NEXT) };    // Debug: cycle forward through shaders (PageDown)
+		std::vector<InputCombo> WeatherEditorToggleKey = { InputCombo::Keyboard(VK_F11) };  // Weather Editor toggle key
+		bool EnableShaderBlocking = false;                                                 // Enable shader blocking hotkeys for debugging
+		bool FirstTimeSetupCompleted = false;                                              // Track if first-time setup has been completed
+		bool SkipClearCacheConfirmation = false;                                           // Skip confirmation dialog when clearing shader cache
+		bool AutoHideFeatureList = false;                                                  // Auto-hide left feature list panel, show on hover
+		bool SkipConstraintWarning = false;                                                // Skip popup when a setting change creates new constraints
 		ThemeSettings Theme;
 		std::string SelectedThemePreset = "";  // Currently selected theme preset (empty = custom/user theme)
 	};

--- a/src/Menu/OverlayRenderer.cpp
+++ b/src/Menu/OverlayRenderer.cpp
@@ -16,6 +16,7 @@
 #include "ShaderCache.h"
 #include "State.h"
 #include "Util.h"
+#include "WeatherEditor/EditorWindow.h"
 
 #include "Features/PerformanceOverlay.h"
 #include "Features/PerformanceOverlay/ABTesting/ABTesting.h"
@@ -50,7 +51,11 @@ void OverlayRenderer::RenderOverlay(
 	RenderShaderBlockingStatus();
 	RenderFirstTimeSetupOverlay();
 
-	if (menu.IsEnabled || HomePageRenderer::ShouldShowFirstTimeSetup()) {
+	// Draw weather editor independently of main menu state
+	if (EditorWindow::GetSingleton()->open) {
+		ImGui::GetIO().MouseDrawCursor = true;
+		EditorWindow::GetSingleton()->Draw();
+	} else if (menu.IsEnabled || HomePageRenderer::ShouldShowFirstTimeSetup()) {
 		ImGui::GetIO().MouseDrawCursor = true;
 		if (menu.IsEnabled) {
 			drawSettings();
@@ -81,6 +86,7 @@ bool OverlayRenderer::ShouldSkipRendering()
 
 	return !(shaderCache->IsCompiling() ||
 			 Menu::GetSingleton()->IsEnabled ||
+			 EditorWindow::GetSingleton()->open ||
 			 abTestingManager->IsEnabled() ||
 			 (failed && !hide) ||
 			 globals::features::performanceOverlay.settings.ShowInOverlay ||

--- a/src/Menu/SettingsTabRenderer.cpp
+++ b/src/Menu/SettingsTabRenderer.cpp
@@ -263,6 +263,12 @@ void SettingsTabRenderer::RenderKeybindingsTab(
 			state.settingOverlayToggleKey,
 			"Change##OverlayToggle");
 
+		Util::InputComboWidget(
+			"Weather Editor Toggle Key:",
+			settings.WeatherEditorToggleKey,
+			state.settingWeatherEditorToggleKey,
+			"Change##WeatherEditorToggle");
+
 		ImGui::EndTabItem();
 	}
 }

--- a/src/Menu/SettingsTabRenderer.h
+++ b/src/Menu/SettingsTabRenderer.h
@@ -19,6 +19,7 @@ public:
 		bool& settingOverlayToggleKey;
 		bool& settingShaderBlockPrevKey;  // Debug: shader block previous key
 		bool& settingShaderBlockNextKey;  // Debug: shader block next key
+		bool& settingWeatherEditorToggleKey;  // Weather Editor toggle key
 	};
 
 	static void RenderGeneralSettings(

--- a/src/Menu/SettingsTabRenderer.h
+++ b/src/Menu/SettingsTabRenderer.h
@@ -17,8 +17,8 @@ public:
 		bool& settingsEffectsToggle;
 		bool& settingSkipCompilationKey;
 		bool& settingOverlayToggleKey;
-		bool& settingShaderBlockPrevKey;  // Debug: shader block previous key
-		bool& settingShaderBlockNextKey;  // Debug: shader block next key
+		bool& settingShaderBlockPrevKey;      // Debug: shader block previous key
+		bool& settingShaderBlockNextKey;      // Debug: shader block next key
 		bool& settingWeatherEditorToggleKey;  // Weather Editor toggle key
 	};
 


### PR DESCRIPTION
Adds a hotkey to open and close the weather editor.
By default bound to F11.
Also changed the editor to be drawn as overlay rather than part of the main menu so it can be opened separately from the main CS menu.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable hotkey (default: F11) to toggle the Weather Editor window
  * Weather Editor now operates independently from the main menu and can be shown/hidden via the hotkey
  * New keybinding setting in Settings to customize the Weather Editor toggle key
<!-- end of auto-generated comment: release notes by coderabbit.ai -->