### PR TITLE
feat(widget): shorten fallback prefix for Volumetric Lighting

### DIFF
--- a/src/WeatherEditor/Weather/WeatherWidget.cpp
+++ b/src/WeatherEditor/Weather/WeatherWidget.cpp
@@ -280,7 +280,7 @@ void WeatherWidget::DrawWidget()
 				for (int i = 0; i < ColorTimes::kTotal; i++) {
 					ImGui::PushID(100 + i);
 					std::string label = ColorTimeLabel(i);
-					   std::string inheritKey = "VL_" + std::to_string(i);
+					std::string inheritKey = "VL_" + std::to_string(i);
 
 					// Inherit checkbox
 					if (hasParent) {

--- a/src/WeatherEditor/Weather/WeatherWidget.cpp
+++ b/src/WeatherEditor/Weather/WeatherWidget.cpp
@@ -280,7 +280,7 @@ void WeatherWidget::DrawWidget()
 				for (int i = 0; i < ColorTimes::kTotal; i++) {
 					ImGui::PushID(100 + i);
 					std::string label = ColorTimeLabel(i);
-					std::string inheritKey = "VolumetricLighting_" + std::to_string(i);
+					   std::string inheritKey = "VL_" + std::to_string(i);
 
 					// Inherit checkbox
 					if (hasParent) {

--- a/src/WeatherEditor/Widget.h
+++ b/src/WeatherEditor/Widget.h
@@ -31,15 +31,15 @@ public:
 	virtual std::string GetEditorID() const
 	{
 		// If cachedEditorID looks like a fallback ID, try to get the real one
-		   // For Volumetric Lighting, support both old and new fallback prefixes
-		   if ((cachedEditorID.find("VolumetricLighting_") == 0 || cachedEditorID.find("VL_") == 0) && form) {
-			   const char* editorID = form->GetFormEditorID();
-			   if (editorID && editorID[0] != '\0') {
-				   const_cast<Widget*>(this)->cachedEditorID = editorID;
-				   return editorID;
-			   }
-		   }
-		   return cachedEditorID;
+		// For Volumetric Lighting, support both old and new fallback prefixes
+		if ((cachedEditorID.find("VolumetricLighting_") == 0 || cachedEditorID.find("VL_") == 0) && form) {
+			const char* editorID = form->GetFormEditorID();
+			if (editorID && editorID[0] != '\0') {
+				const_cast<Widget*>(this)->cachedEditorID = editorID;
+				return editorID;
+			}
+		}
+		return cachedEditorID;
 	}
 
 	virtual std::string GetFormID() const
@@ -90,10 +90,10 @@ public:
 		case RE::FormType::ImageSpace:
 			cachedEditorID = std::format("ImageSpace_{:08X}", form->GetFormID());
 			break;
-		   case RE::FormType::VolumetricLighting:
-			   // Use short fallback prefix for Volumetric Lighting
-			   cachedEditorID = std::format("VL_{:08X}", form->GetFormID());
-			   break;
+		case RE::FormType::VolumetricLighting:
+			// Use short fallback prefix for Volumetric Lighting
+			cachedEditorID = std::format("VL_{:08X}", form->GetFormID());
+			break;
 		case RE::FormType::ShaderParticleGeometryData:
 			cachedEditorID = std::format("ShaderParticleGeometry_{:08X}", form->GetFormID());
 			break;

--- a/src/WeatherEditor/Widget.h
+++ b/src/WeatherEditor/Widget.h
@@ -31,14 +31,15 @@ public:
 	virtual std::string GetEditorID() const
 	{
 		// If cachedEditorID looks like a fallback ID, try to get the real one
-		if (cachedEditorID.find("VolumetricLighting_") == 0 && form) {
-			const char* editorID = form->GetFormEditorID();
-			if (editorID && editorID[0] != '\0') {
-				const_cast<Widget*>(this)->cachedEditorID = editorID;
-				return editorID;
-			}
-		}
-		return cachedEditorID;
+		   // For Volumetric Lighting, support both old and new fallback prefixes
+		   if ((cachedEditorID.find("VolumetricLighting_") == 0 || cachedEditorID.find("VL_") == 0) && form) {
+			   const char* editorID = form->GetFormEditorID();
+			   if (editorID && editorID[0] != '\0') {
+				   const_cast<Widget*>(this)->cachedEditorID = editorID;
+				   return editorID;
+			   }
+		   }
+		   return cachedEditorID;
 	}
 
 	virtual std::string GetFormID() const
@@ -89,9 +90,10 @@ public:
 		case RE::FormType::ImageSpace:
 			cachedEditorID = std::format("ImageSpace_{:08X}", form->GetFormID());
 			break;
-		case RE::FormType::VolumetricLighting:
-			cachedEditorID = std::format("VolumetricLighting_{:08X}", form->GetFormID());
-			break;
+		   case RE::FormType::VolumetricLighting:
+			   // Use short fallback prefix for Volumetric Lighting
+			   cachedEditorID = std::format("VL_{:08X}", form->GetFormID());
+			   break;
 		case RE::FormType::ShaderParticleGeometryData:
 			cachedEditorID = std::format("ShaderParticleGeometry_{:08X}", form->GetFormID());
 			break;


### PR DESCRIPTION
Since actually fixing the EditorID of the volumetric shadows requires the inclusion of a whole new dependency(Clib).
This PR shortens the fallback name so that the FormIDs are more easily read.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized volumetric lighting identifier management within the weather editor. Enhanced backward compatibility handling while improving efficiency of identifier caching and fallback logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->