### PR TITLE
feat(weather editor): block editor access in loading screens

### DIFF
--- a/src/Features/WeatherEditor.cpp
+++ b/src/Features/WeatherEditor.cpp
@@ -63,9 +63,13 @@ void LerpDirectional(RE::BGSDirectionalAmbientLightingColors::Directional& oldCo
 
 void WeatherEditor::DrawSettings()
 {
-	if (ImGui::Button("Open Editor", { -1, 0 })) {
+	auto player = RE::PlayerCharacter::GetSingleton();
+	bool hasCell = player && player->parentCell;
+	ImGui::BeginDisabled(!hasCell);
+	if (ImGui::Button(hasCell ? "Open Editor" : "Open Editor (no active cell)", { -1, 0 })) {
 		EditorWindow::GetSingleton()->open = true;
 	}
+	ImGui::EndDisabled();
 
 	ImGui::Spacing();
 	ImGui::Separator();
@@ -228,6 +232,10 @@ void WeatherEditor::DrawWeatherStatusPanel()
 void WeatherEditor::RenderWeatherDetailsWindow(bool* open)
 {
 	if (!*open)
+		return;
+
+	auto player = RE::PlayerCharacter::GetSingleton();
+	if (!player || !player->parentCell)
 		return;
 
 	// Set initial position if not already set
@@ -1028,6 +1036,10 @@ std::string WeatherEditor::GetDisplayName(const RE::TESWeather* weather)
 
 void WeatherEditor::DrawOverlay()
 {
+	auto player = RE::PlayerCharacter::GetSingleton();
+	if (!player || !player->parentCell)
+		return;
+
 	bool overlayVisible = Menu::GetSingleton()->overlayVisible;
 	static bool lastShowInOverlay = false;
 	const bool showInOverlay = WeatherDetailsWindow.ShowInOverlay;

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -1047,7 +1047,7 @@ void Menu::ProcessInputEventQueue()
 						{ settings.ShaderBlockPrevKey, [this, shaderCache]() { if (settings.EnableShaderBlocking) shaderCache->IterateShaderBlock(); } },
 						{ settings.ShaderBlockNextKey, [this, shaderCache]() { if (settings.EnableShaderBlocking) shaderCache->IterateShaderBlock(false); } },
 						{ settings.OverlayToggleKey, []() { Menu::GetSingleton()->overlayVisible = !Menu::GetSingleton()->overlayVisible; } },
-						{ settings.WeatherEditorToggleKey, []() { EditorWindow::GetSingleton()->open = !EditorWindow::GetSingleton()->open; } },
+						{ settings.WeatherEditorToggleKey, []() { auto p = RE::PlayerCharacter::GetSingleton(); if (p && p->parentCell) EditorWindow::GetSingleton()->open = !EditorWindow::GetSingleton()->open; } },
 					};
 					for (const auto& ka : keyActions) {
 						// Check if key matches last key in combo and all modifiers are held (exact match)

--- a/src/Menu/OverlayRenderer.cpp
+++ b/src/Menu/OverlayRenderer.cpp
@@ -52,9 +52,15 @@ void OverlayRenderer::RenderOverlay(
 	RenderFirstTimeSetupOverlay();
 
 	// Draw weather editor independently of main menu state
-	if (EditorWindow::GetSingleton()->open) {
+	// Auto-close editor if player leaves valid game space (e.g., loading screen)
+	auto* editorWindow = EditorWindow::GetSingleton();
+	auto player = RE::PlayerCharacter::GetSingleton();
+	if (editorWindow->open && !(player && player->parentCell)) {
+		editorWindow->open = false;
+	}
+	if (editorWindow->open) {
 		ImGui::GetIO().MouseDrawCursor = true;
-		EditorWindow::GetSingleton()->Draw();
+		editorWindow->Draw();
 	} else if (menu.IsEnabled || HomePageRenderer::ShouldShowFirstTimeSetup()) {
 		ImGui::GetIO().MouseDrawCursor = true;
 		if (menu.IsEnabled) {


### PR DESCRIPTION
Prevents the user from opening the editor when in the main menu or when loading the game.
Could prevent other unforseen behaviour too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Weather Editor button is now disabled when the player lacks a valid game context
  * Editor window automatically closes if the player loses a valid game cell context
  * Weather Editor hotkey respects active player state before toggling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->