### PR TITLE
fix(weather editor): prevent inputs when editor is open

### DIFF
--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -1158,7 +1158,8 @@ void Menu::ProcessInputEvents(RE::InputEvent* const* a_events)
 
 bool Menu::ShouldSwallowInput()
 {
-	return IsEnabled || HomePageRenderer::ShouldShowFirstTimeSetup() || EditorWindow::GetSingleton()->open;
+	auto editorWindow = EditorWindow::GetSingleton();
+	return IsEnabled || HomePageRenderer::ShouldShowFirstTimeSetup() || (editorWindow && editorWindow->open);
 }
 
 void Menu::SelectFeatureMenu(const std::string& featureName)

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -1158,7 +1158,7 @@ void Menu::ProcessInputEvents(RE::InputEvent* const* a_events)
 
 bool Menu::ShouldSwallowInput()
 {
-	return IsEnabled || HomePageRenderer::ShouldShowFirstTimeSetup();
+	return IsEnabled || HomePageRenderer::ShouldShowFirstTimeSetup() || EditorWindow::GetSingleton()->open;
 }
 
 void Menu::SelectFeatureMenu(const std::string& featureName)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Input handling now also swallows user input while the editor window is open, ensuring keystrokes and clicks are ignored by the main interface during editor use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->