### PR TITLE
fix(weather editor): clear feature overrides on revert button

### DIFF
--- a/src/WeatherEditor/Weather/WeatherWidget.cpp
+++ b/src/WeatherEditor/Weather/WeatherWidget.cpp
@@ -1462,9 +1462,30 @@ void WeatherWidget::SaveFeatureSettings()
 {
 	auto* weatherManager = WeatherManager::GetSingleton();
 
+	// Track which features need to be saved
+	std::set<std::string> allFeatureNames;
+	
+	// Collect features from current settings
 	for (const auto& [featureName, featureJson] : settings.featureSettings) {
-		// Always call save so that empty objects are persisted as removals.
-		weatherManager->SaveSettingsToWeather(weather, featureName, featureJson);
+		allFeatureNames.insert(featureName);
+	}
+	
+	// Collect features from original settings (to detect deletions)
+	for (const auto& [featureName, featureJson] : originalSettings.featureSettings) {
+		allFeatureNames.insert(featureName);
+	}
+	
+	// Save or clear each feature
+	for (const auto& featureName : allFeatureNames) {
+		auto currentIt = settings.featureSettings.find(featureName);
+		
+		if (currentIt != settings.featureSettings.end()) {
+			// Feature exists in current settings - save it
+			weatherManager->SaveSettingsToWeather(weather, featureName, currentIt->second);
+		} else {
+			// Feature was removed from settings - clear it by saving empty object
+			weatherManager->SaveSettingsToWeather(weather, featureName, json::object());
+		}
 	}
 }
 

--- a/src/WeatherEditor/Weather/WeatherWidget.cpp
+++ b/src/WeatherEditor/Weather/WeatherWidget.cpp
@@ -464,7 +464,9 @@ void WeatherWidget::LoadSettings()
 		settings = vanillaSettings;
 	}
 	InitializeInheritFlags();
-	LoadFeatureSettings();
+	if (!js.empty()) {
+		LoadFeatureSettings();
+	}
 	originalSettings = settings;
 	ApplyChanges();
 }
@@ -603,13 +605,8 @@ void WeatherWidget::SetWeatherValues()
 	}
 	weather->cloudLayerDisabledBits = disabledBits;
 
-	// Save feature settings
+	// If this weather is currently active, immediately apply feature settings to game memory
 	auto* weatherManager = WeatherManager::GetSingleton();
-	for (const auto& [featureName, featureSettings] : settings.featureSettings) {
-		weatherManager->SaveSettingsToWeather(weather, featureName, featureSettings);
-	}
-
-	// If this weather is currently active, immediately apply feature settings
 	auto currentWeathers = weatherManager->GetCurrentWeathers();
 	if (currentWeathers.currentWeather == weather) {
 		auto* globalRegistry = WeatherVariables::GlobalWeatherRegistry::GetSingleton();
@@ -1581,8 +1578,51 @@ void WeatherWidget::ApplyChanges()
 
 void WeatherWidget::RevertChanges()
 {
+	auto* weatherManager = WeatherManager::GetSingleton();
+	auto currentWeathers = weatherManager->GetCurrentWeathers();
+	bool isCurrentWeather = (weather == currentWeathers.currentWeather);
+
+	// If this weather is currently active, reset any enabled feature overrides
+	// back to user default settings before clearing them
+	if (isCurrentWeather) {
+		auto* globalRegistry = WeatherVariables::GlobalWeatherRegistry::GetSingleton();
+		
+		// Collect features that were enabled and need to be reset
+		for (const auto& [featureName, featureSettings] : settings.featureSettings) {
+			bool enabled = featureSettings.value("__enabled", false);
+			if (enabled && globalRegistry->HasWeatherSupport(featureName)) {
+				// End any active transition for this feature
+				globalRegistry->EndFeatureTransition(featureName);
+				
+				// Reset all variables in this feature to user defaults
+				auto* featureRegistry = globalRegistry->GetFeatureRegistry(featureName);
+				if (featureRegistry) {
+					for (const auto& var : featureRegistry->GetVariables()) {
+						var->SetToUserSettings();
+					}
+				}
+			}
+		}
+	}
+
+	// Clear any cached feature overrides for this weather
+	weatherManager->ClearAllFeatureSettingsForWeather(weather);
+
 	settings = vanillaSettings;
 	ApplyChanges();
+}
+
+void WeatherWidget::Delete()
+{
+	// Clear the WeatherManager cache for this weather so that
+	// Widget::Delete() -> LoadSettings() won't reload stale data
+	auto* weatherManager = WeatherManager::GetSingleton();
+	weatherManager->ClearAllFeatureSettingsForWeather(weather);
+
+	// Clear local feature settings so they don't persist in memory
+	settings.featureSettings.clear();
+
+	Widget::Delete();
 }
 
 bool WeatherWidget::Settings::operator==(const Settings& o) const

--- a/src/WeatherEditor/Weather/WeatherWidget.cpp
+++ b/src/WeatherEditor/Weather/WeatherWidget.cpp
@@ -1461,21 +1461,21 @@ void WeatherWidget::SaveFeatureSettings()
 
 	// Track which features need to be saved
 	std::set<std::string> allFeatureNames;
-	
+
 	// Collect features from current settings
 	for (const auto& [featureName, featureJson] : settings.featureSettings) {
 		allFeatureNames.insert(featureName);
 	}
-	
+
 	// Collect features from original settings (to detect deletions)
 	for (const auto& [featureName, featureJson] : originalSettings.featureSettings) {
 		allFeatureNames.insert(featureName);
 	}
-	
+
 	// Save or clear each feature
 	for (const auto& featureName : allFeatureNames) {
 		auto currentIt = settings.featureSettings.find(featureName);
-		
+
 		if (currentIt != settings.featureSettings.end()) {
 			// Feature exists in current settings - save it
 			weatherManager->SaveSettingsToWeather(weather, featureName, currentIt->second);
@@ -1586,14 +1586,14 @@ void WeatherWidget::RevertChanges()
 	// back to user default settings before clearing them
 	if (isCurrentWeather) {
 		auto* globalRegistry = WeatherVariables::GlobalWeatherRegistry::GetSingleton();
-		
+
 		// Collect features that were enabled and need to be reset
 		for (const auto& [featureName, featureSettings] : settings.featureSettings) {
 			bool enabled = featureSettings.value("__enabled", false);
 			if (enabled && globalRegistry->HasWeatherSupport(featureName)) {
 				// End any active transition for this feature
 				globalRegistry->EndFeatureTransition(featureName);
-				
+
 				// Reset all variables in this feature to user defaults
 				auto* featureRegistry = globalRegistry->GetFeatureRegistry(featureName);
 				if (featureRegistry) {

--- a/src/WeatherEditor/Weather/WeatherWidget.cpp
+++ b/src/WeatherEditor/Weather/WeatherWidget.cpp
@@ -607,25 +607,19 @@ void WeatherWidget::SetWeatherValues()
 
 	// If this weather is currently active, immediately apply feature settings to game memory
 	auto* weatherManager = WeatherManager::GetSingleton();
-	auto currentWeathers = weatherManager->GetCurrentWeathers();
-	if (currentWeathers.currentWeather == weather) {
+	if (weatherManager->GetCurrentWeathers().currentWeather == weather) {
 		auto* globalRegistry = WeatherVariables::GlobalWeatherRegistry::GetSingleton();
-		for (const auto& [featureName, featureSettings] : settings.featureSettings) {
-			// Check if overrides are enabled for this feature
-			bool enabled = featureSettings.value("__enabled", false);
-			if (enabled && globalRegistry->HasWeatherSupport(featureName)) {
-				// Filter out the __enabled flag before applying
-				json filteredSettings = json::object();
-				for (auto it = featureSettings.begin(); it != featureSettings.end(); ++it) {
-					if (it.key() != "__enabled") {
-						filteredSettings[it.key()] = it.value();
-					}
-				}
+		json emptyWeather;
 
-				// Apply the weather-specific settings immediately
-				json emptyWeather;  // No previous weather during instant update
-				globalRegistry->UpdateFeatureFromWeathers(featureName, emptyWeather, filteredSettings, 1.0f);
+		for (const auto& [featureName, featureSettings] : settings.featureSettings) {
+			if (!featureSettings.value("__enabled", false) || !globalRegistry->HasWeatherSupport(featureName)) {
+				continue;
 			}
+
+			// Filter out __enabled flag and apply settings
+			json filteredSettings = featureSettings;
+			filteredSettings.erase("__enabled");
+			globalRegistry->UpdateFeatureFromWeathers(featureName, emptyWeather, filteredSettings, 1.0f);
 		}
 	}
 }
@@ -1459,30 +1453,22 @@ void WeatherWidget::SaveFeatureSettings()
 {
 	auto* weatherManager = WeatherManager::GetSingleton();
 
-	// Track which features need to be saved
+	// Collect all feature names from both current and original settings to detect deletions
 	std::set<std::string> allFeatureNames;
-	
-	// Collect features from current settings
-	for (const auto& [featureName, featureJson] : settings.featureSettings) {
+	for (const auto& [featureName, _] : settings.featureSettings) {
 		allFeatureNames.insert(featureName);
 	}
-	
-	// Collect features from original settings (to detect deletions)
-	for (const auto& [featureName, featureJson] : originalSettings.featureSettings) {
+	for (const auto& [featureName, _] : originalSettings.featureSettings) {
 		allFeatureNames.insert(featureName);
 	}
-	
-	// Save or clear each feature
+
+	// Save current settings or clear deleted features
 	for (const auto& featureName : allFeatureNames) {
-		auto currentIt = settings.featureSettings.find(featureName);
-		
-		if (currentIt != settings.featureSettings.end()) {
-			// Feature exists in current settings - save it
-			weatherManager->SaveSettingsToWeather(weather, featureName, currentIt->second);
-		} else {
-			// Feature was removed from settings - clear it by saving empty object
-			weatherManager->SaveSettingsToWeather(weather, featureName, json::object());
-		}
+		auto it = settings.featureSettings.find(featureName);
+		weatherManager->SaveSettingsToWeather(
+			weather,
+			featureName,
+			it != settings.featureSettings.end() ? it->second : json::object());
 	}
 }
 
@@ -1579,47 +1565,36 @@ void WeatherWidget::ApplyChanges()
 void WeatherWidget::RevertChanges()
 {
 	auto* weatherManager = WeatherManager::GetSingleton();
-	auto currentWeathers = weatherManager->GetCurrentWeathers();
-	bool isCurrentWeather = (weather == currentWeathers.currentWeather);
 
-	// If this weather is currently active, reset any enabled feature overrides
-	// back to user default settings before clearing them
-	if (isCurrentWeather) {
+	// If this weather is currently active, reset enabled feature overrides to user defaults
+	if (weather == weatherManager->GetCurrentWeathers().currentWeather) {
 		auto* globalRegistry = WeatherVariables::GlobalWeatherRegistry::GetSingleton();
-		
-		// Collect features that were enabled and need to be reset
+
 		for (const auto& [featureName, featureSettings] : settings.featureSettings) {
-			bool enabled = featureSettings.value("__enabled", false);
-			if (enabled && globalRegistry->HasWeatherSupport(featureName)) {
-				// End any active transition for this feature
-				globalRegistry->EndFeatureTransition(featureName);
-				
-				// Reset all variables in this feature to user defaults
-				auto* featureRegistry = globalRegistry->GetFeatureRegistry(featureName);
-				if (featureRegistry) {
-					for (const auto& var : featureRegistry->GetVariables()) {
-						var->SetToUserSettings();
-					}
+			if (!featureSettings.value("__enabled", false) || !globalRegistry->HasWeatherSupport(featureName)) {
+				continue;
+			}
+
+			globalRegistry->EndFeatureTransition(featureName);
+
+			if (auto* featureRegistry = globalRegistry->GetFeatureRegistry(featureName)) {
+				for (const auto& var : featureRegistry->GetVariables()) {
+					var->SetToUserSettings();
 				}
 			}
 		}
 	}
 
-	// Clear any cached feature overrides for this weather
 	weatherManager->ClearAllFeatureSettingsForWeather(weather);
-
 	settings = vanillaSettings;
 	ApplyChanges();
 }
 
 void WeatherWidget::Delete()
 {
-	// Clear the WeatherManager cache for this weather so that
-	// Widget::Delete() -> LoadSettings() won't reload stale data
+	// Clear cache and local settings before base Delete() to prevent reloading stale data
 	auto* weatherManager = WeatherManager::GetSingleton();
 	weatherManager->ClearAllFeatureSettingsForWeather(weather);
-
-	// Clear local feature settings so they don't persist in memory
 	settings.featureSettings.clear();
 
 	Widget::Delete();

--- a/src/WeatherEditor/Weather/WeatherWidget.h
+++ b/src/WeatherEditor/Weather/WeatherWidget.h
@@ -135,6 +135,7 @@ public:
 	void LoadWeatherValues();
 	void ApplyChanges() override;
 	void RevertChanges() override;
+	void Delete() override;
 	bool HasUnsavedChanges() const override;
 
 	// New methods for per-feature settings

--- a/src/WeatherEditor/Widget.h
+++ b/src/WeatherEditor/Widget.h
@@ -123,9 +123,9 @@ public:
 
 	void Save();
 	void Load();
-	void Delete();
 	bool HasSavedFile() const;
 
+	virtual void Delete();
 	virtual void LoadSettings() = 0;
 	virtual void SaveSettings() = 0;
 	virtual void ApplyChanges() = 0;

--- a/src/WeatherManager.cpp
+++ b/src/WeatherManager.cpp
@@ -293,6 +293,16 @@ bool WeatherManager::HasWeatherSettings(RE::TESWeather* weather) const
 	return perWeatherSettingsCache.find(weatherKey) != perWeatherSettingsCache.end();
 }
 
+void WeatherManager::ClearAllFeatureSettingsForWeather(RE::TESWeather* weather)
+{
+	if (!weather) {
+		return;
+	}
+
+	std::string weatherKey = GetWeatherKey(weather);
+	perWeatherSettingsCache.erase(weatherKey);
+}
+
 void WeatherManager::ClearCache()
 {
 	perWeatherSettingsCache.clear();

--- a/src/WeatherManager.h
+++ b/src/WeatherManager.h
@@ -40,6 +40,9 @@ public:
 	// Get the weather key for caching
 	static std::string GetWeatherKey(RE::TESWeather* weather);
 
+	// Clear all cached feature settings for a specific weather
+	void ClearAllFeatureSettingsForWeather(RE::TESWeather* weather);
+
 	// Check if settings exist for a weather
 	bool HasWeatherSettings(RE::TESWeather* weather) const;
 


### PR DESCRIPTION
Feature overrides for weather-specific settings (like IBL for specific weathers) were being saved to disk on every edit and persisting even after reverting or deleting. The revert button wasn't properly resetting feature values in game memory.

- Removed the constant disk writes after each change in the override settings
- Added guards to prevent loading stale data
- Ensured that all data is actually reverted to default settings, including CS setting overrides

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a widget delete action that clears all per-weather feature settings and removes the widget.
  * Manager can now clear cached feature settings for a specific weather.

* **Bug Fixes**
  * Revert now resets enabled feature overrides back to user defaults and clears related caches.
  * Loading/saving of feature settings improved to handle empty data, removed features, and enabled-only application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->