### PR TITLE
fix(exponential height fog): disable by default

### DIFF
--- a/src/Features/ExponentialHeightFog.h
+++ b/src/Features/ExponentialHeightFog.h
@@ -33,7 +33,7 @@ struct ExponentialHeightFog : Feature
 
 	struct alignas(16) Settings
 	{
-		uint enabled = 1;
+		uint enabled = 0;
 		uint useDynamicCubemaps = 0;
 		float startDistance = 0.0f;
 		float fogHeight = 0.0f;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Exponential Height Fog now disabled by default instead of enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->