### PR TITLE
fix(weather editor): move esc key to native input system

### DIFF
--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -1078,10 +1078,14 @@ void Menu::ProcessInputEventQueue()
 					}
 				}
 
-				// Close menu with ESC if no editor window is open
+				// Handle ESC key for menu and editor window
 				auto* editorWindow = EditorWindow::GetSingleton();
-				if (key == VK_ESCAPE && IsEnabled && editorWindow && !editorWindow->open) {
-					IsEnabled = false;
+				if (key == VK_ESCAPE) {
+					if (editorWindow && editorWindow->open && editorWindow->ShouldHandleEscapeKey()) {
+						editorWindow->open = false;
+					} else if (IsEnabled && (!editorWindow || !editorWindow->open)) {
+						IsEnabled = false;
+					}
 				}
 			}
 

--- a/src/WeatherEditor/EditorWindow.cpp
+++ b/src/WeatherEditor/EditorWindow.cpp
@@ -711,11 +711,6 @@ void EditorWindow::RenderUI()
 	// Increase background opacity for all editor windows
 	ImGui::PushStyleVar(ImGuiStyleVar_Alpha, 1.0f);
 
-	// Check for Escape key to close editor (but not if a popup is open)
-	if (ImGui::IsKeyPressed(ImGuiKey_Escape, false) && !ImGui::IsPopupOpen("", ImGuiPopupFlags_AnyPopupId | ImGuiPopupFlags_AnyPopupLevel)) {
-		open = false;
-	}
-
 	// Check for Ctrl+Z to undo
 	if ((ImGui::IsKeyDown(ImGuiKey_LeftCtrl) || ImGui::IsKeyDown(ImGuiKey_RightCtrl)) && ImGui::IsKeyPressed(ImGuiKey_Z, false)) {
 		if (CanUndo()) {
@@ -1632,6 +1627,11 @@ void EditorWindow::RestoreVanityCamera()
 		vanityCameraDisabled = false;
 		logger::info("Vanity camera restored (delay: {})", savedVanityCameraDelay);
 	}
+}
+
+bool EditorWindow::ShouldHandleEscapeKey() const
+{
+	return !ImGui::IsPopupOpen("", ImGuiPopupFlags_AnyPopupId | ImGuiPopupFlags_AnyPopupLevel);
 }
 
 void EditorWindow::PushUndoState(Widget* widget)

--- a/src/WeatherEditor/EditorWindow.h
+++ b/src/WeatherEditor/EditorWindow.h
@@ -89,6 +89,9 @@ public:
 	/// Draw the full time controls panel (pause, game time, timescale).
 	void DrawTimeControls();
 
+	// Check if ESC key should close the editor (no popups open)
+	bool ShouldHandleEscapeKey() const;
+
 	void DisableVanityCamera();
 	void RestoreVanityCamera();
 


### PR DESCRIPTION
Moved the handling of the esc key for the weather editor to the system that the rest of CS uses, rather than imgui, so that 1 esc key press doesn't close both the CS menu and the editor.