### PR TITLE
refactor: move all features to globals::game::calendar

### DIFF
--- a/src/Features/DynamicCubemaps.cpp
+++ b/src/Features/DynamicCubemaps.cpp
@@ -475,7 +475,7 @@ void DynamicCubemaps::UpdateCubemap()
 	TracyD3D11Zone(globals::state->tracyCtx, "Cubemap Update");
 
 	// Reset capture when game time jumps (wait menu, timescale changes, console commands)
-	if (auto calendar = RE::Calendar::GetSingleton()) {
+	if (auto calendar = globals::game::calendar) {
 		float currentHoursPassed = calendar->GetHoursPassed();
 		float hoursPassedDiff = std::abs(currentHoursPassed - previousHoursPassed);
 		previousHoursPassed = currentHoursPassed;

--- a/src/Features/SkySync.cpp
+++ b/src/Features/SkySync.cpp
@@ -358,14 +358,16 @@ void SkySync::ShadowFader::Update(const RE::Sun* sun, RE::NiPoint3 dirs[3], floa
 			fadePhase = Phase::FadeOut;
 	}
 
-	const auto calendar = RE::Calendar::GetSingleton();
-	const float currentHoursPassed = calendar->GetHoursPassed();
-	const float timeScale = calendar->GetTimescale();
-	const float hoursPassedDiff = abs(currentHoursPassed - previousHoursPassed);
-	previousHoursPassed = currentHoursPassed;
-	if (timeScale <= 0.0f || hoursPassedDiff >= 0.01f) {
-		fadePhase = Phase::None;
-		current = target;
+	float timeScale = 1.0f;
+	if (const auto calendar = globals::game::calendar) {
+		const float currentHoursPassed = calendar->GetHoursPassed();
+		timeScale = calendar->GetTimescale();
+		const float hoursPassedDiff = abs(currentHoursPassed - previousHoursPassed);
+		previousHoursPassed = currentHoursPassed;
+		if (timeScale <= 0.0f || hoursPassedDiff >= 0.01f) {
+			fadePhase = Phase::None;
+			current = target;
+		}
 	}
 
 	if (current == Caster::None) {

--- a/src/Features/SkySync.cpp
+++ b/src/Features/SkySync.cpp
@@ -362,7 +362,7 @@ void SkySync::ShadowFader::Update(const RE::Sun* sun, RE::NiPoint3 dirs[3], floa
 	if (const auto calendar = globals::game::calendar) {
 		const float currentHoursPassed = calendar->GetHoursPassed();
 		timeScale = calendar->GetTimescale();
-		const float hoursPassedDiff = abs(currentHoursPassed - previousHoursPassed);
+		const float hoursPassedDiff = std::abs(currentHoursPassed - previousHoursPassed);
 		previousHoursPassed = currentHoursPassed;
 		if (timeScale <= 0.0f || hoursPassedDiff >= 0.01f) {
 			fadePhase = Phase::None;

--- a/src/Features/SkySync.cpp
+++ b/src/Features/SkySync.cpp
@@ -358,7 +358,7 @@ void SkySync::ShadowFader::Update(const RE::Sun* sun, RE::NiPoint3 dirs[3], floa
 			fadePhase = Phase::FadeOut;
 	}
 
-	float timeScale = 1.0f;
+	float timeScale = 20.0f;
 	if (const auto calendar = globals::game::calendar) {
 		const float currentHoursPassed = calendar->GetHoursPassed();
 		timeScale = calendar->GetTimescale();


### PR DESCRIPTION
Applies to Sky Sync and Dynamic Cubemaps

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Made calendar access more robust so sky and cubemap logic safely handles missing calendar data.
* **Bug Fixes**
  * Prevents unintended cubemap/sky capture resets and erroneous fade changes when calendar information is unavailable, improving visual stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->