### PR TITLE
feat(weather editor): add delete json button to objects window

### DIFF
--- a/src/WeatherEditor/EditorWindow.cpp
+++ b/src/WeatherEditor/EditorWindow.cpp
@@ -274,16 +274,24 @@ void EditorWindow::ShowObjectsWindow()
 			}
 
 			// Stable user IDs for sortable columns — used instead of ColumnIndex so reordering/insertion won't break sorting.
-			enum ColumnID : ImGuiID { ColFav = 0, ColEditorID, ColFormID, ColFile, ColStatus, ColJson };
+			enum ColumnID : ImGuiID
+			{
+				ColFav = 0,
+				ColEditorID,
+				ColFormID,
+				ColFile,
+				ColStatus,
+				ColJson
+			};
 
 			// Create a table for the right column with "Name" and "ID" headers. Different weights to prevent truncation.
 			if (ImGui::BeginTable("DetailsTable", 6, ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg | ImGuiTableFlags_SizingStretchProp | ImGuiTableFlags_Sortable)) {
-				ImGui::TableSetupColumn("Fav", ImGuiTableColumnFlags_WidthFixed | ImGuiTableColumnFlags_NoSort, 38.0f, ColFav);     // Favorite indicator
-				ImGui::TableSetupColumn("Editor ID", ImGuiTableColumnFlags_WidthStretch, 3.5f, ColEditorID);                        // Largest - weather/template names
-				ImGui::TableSetupColumn("Form ID", ImGuiTableColumnFlags_WidthFixed, 90.0f, ColFormID);                              // Fixed - 8 hex chars
-				ImGui::TableSetupColumn("File", ImGuiTableColumnFlags_WidthStretch, 2.0f, ColFile);                                  // Medium - plugin names
-				ImGui::TableSetupColumn("Status", ImGuiTableColumnFlags_WidthStretch, 1.5f, ColStatus);                              // Smaller - status text
-				ImGui::TableSetupColumn("json", ImGuiTableColumnFlags_WidthFixed, 55.0f, ColJson);                                   // JSON file / delete
+				ImGui::TableSetupColumn("Fav", ImGuiTableColumnFlags_WidthFixed | ImGuiTableColumnFlags_NoSort, 38.0f, ColFav);  // Favorite indicator
+				ImGui::TableSetupColumn("Editor ID", ImGuiTableColumnFlags_WidthStretch, 3.5f, ColEditorID);                     // Largest - weather/template names
+				ImGui::TableSetupColumn("Form ID", ImGuiTableColumnFlags_WidthFixed, 90.0f, ColFormID);                          // Fixed - 8 hex chars
+				ImGui::TableSetupColumn("File", ImGuiTableColumnFlags_WidthStretch, 2.0f, ColFile);                              // Medium - plugin names
+				ImGui::TableSetupColumn("Status", ImGuiTableColumnFlags_WidthStretch, 1.5f, ColStatus);                          // Smaller - status text
+				ImGui::TableSetupColumn("json", ImGuiTableColumnFlags_WidthFixed, 55.0f, ColJson);                               // JSON file / delete
 
 				ImGui::TableHeadersRow();
 

--- a/src/WeatherEditor/EditorWindow.cpp
+++ b/src/WeatherEditor/EditorWindow.cpp
@@ -690,7 +690,6 @@ void EditorWindow::ShowObjectsWindow()
 
 	// Confirmation modal for json deletion - must be outside BeginChild so the modal can block the root window
 	if (pendingDeleteWidget) {
-		auto* pendingWidget = pendingDeleteWidget;
 		if (pendingDeletePopupRequested) {
 			ImGui::OpenPopup("ListDeleteConfirmation");
 			pendingDeletePopupRequested = false;

--- a/src/WeatherEditor/EditorWindow.cpp
+++ b/src/WeatherEditor/EditorWindow.cpp
@@ -289,7 +289,14 @@ void EditorWindow::ShowObjectsWindow()
 					if (sortSpecs->SpecsDirty) {
 						if (sortSpecs->SpecsCount > 0) {
 							const ImGuiTableColumnSortSpecs& spec = sortSpecs->Specs[0];
-							currentSortColumn = static_cast<SortColumn>(spec.ColumnIndex);
+							switch (spec.ColumnIndex) {
+							case 1: currentSortColumn = SortColumn::EditorID; break;
+							case 2: currentSortColumn = SortColumn::FormID; break;
+							case 3: currentSortColumn = SortColumn::File; break;
+							case 4: currentSortColumn = SortColumn::Status; break;
+							case 5: currentSortColumn = SortColumn::JsonAttachment; break;
+							default: currentSortColumn = SortColumn::None; break;
+							}
 							sortAscending = (spec.SortDirection == ImGuiSortDirection_Ascending);
 						} else {
 							currentSortColumn = SortColumn::None;
@@ -341,7 +348,7 @@ void EditorWindow::ShowObjectsWindow()
 							{
 								bool aHasJson = HasCachedJsonAttachment(a);
 								bool bHasJson = HasCachedJsonAttachment(b);
-								comparison = static_cast<int>(bHasJson) - static_cast<int>(aHasJson);
+								comparison = static_cast<int>(aHasJson) - static_cast<int>(bHasJson);
 								break;
 							}
 						default:
@@ -350,6 +357,25 @@ void EditorWindow::ShowObjectsWindow()
 						return sortAscending ? (comparison < 0) : (comparison > 0);
 					});
 				}
+
+				// Helper lambda: renders the JSON delete button column for a widget
+				auto drawJsonDeleteButton = [&](Widget* widget) {
+					ImGui::TableNextColumn();
+					if (HasCachedJsonAttachment(widget)) {
+						auto* menu = globals::menu;
+						if (menu && menu->uiIcons.deleteSettings.texture) {
+							const float iconSize = ImGui::GetFrameHeight() * 0.85f;
+							auto _style = Util::ErrorButtonStyle();
+							ImGui::SetNextItemAllowOverlap();
+							if (ImGui::ImageButton(std::format("##jsondel_{}", widget->GetFormID()).c_str(), menu->uiIcons.deleteSettings.texture, { iconSize, iconSize })) {
+								pendingDeleteWidget = widget;
+								pendingDeletePopupRequested = true;
+							}
+							if (ImGui::IsItemHovered())
+								ImGui::SetTooltip("Delete JSON file");
+						}
+					}
+				};
 
 				// Special handling for Cell Lighting category
 				if (selectedCategory == "Cell Lighting") {
@@ -526,21 +552,7 @@ void EditorWindow::ShowObjectsWindow()
 						}
 
 						// json / delete column
-						ImGui::TableNextColumn();
-						if (HasCachedJsonAttachment(sortedWidgets[i])) {
-							auto* menu = globals::menu;
-							if (menu && menu->uiIcons.deleteSettings.texture) {
-								const float iconSize = ImGui::GetFrameHeight() * 0.85f;
-								{
-									auto _style = Util::ErrorButtonStyle();
-									ImGui::SetNextItemAllowOverlap();
-									if (ImGui::ImageButton(std::format("##jsondel_cur_{}", sortedWidgets[i]->GetFormID()).c_str(), menu->uiIcons.deleteSettings.texture, { iconSize, iconSize }))
-										pendingDeleteWidget = sortedWidgets[i];
-								}
-								if (ImGui::IsItemHovered())
-									ImGui::SetTooltip("Delete json file");
-							}
-						}
+						drawJsonDeleteButton(sortedWidgets[i]);
 					}
 				}
 
@@ -664,21 +676,7 @@ void EditorWindow::ShowObjectsWindow()
 					}
 
 					// json / delete column
-					ImGui::TableNextColumn();
-					if (HasCachedJsonAttachment(sortedWidgets[i])) {
-						auto* menu = globals::menu;
-						if (menu && menu->uiIcons.deleteSettings.texture) {
-							const float iconSize = ImGui::GetFrameHeight() * 0.85f;
-							{
-								auto _style = Util::ErrorButtonStyle();
-								ImGui::SetNextItemAllowOverlap();
-								if (ImGui::ImageButton(std::format("##jsondel_{}", sortedWidgets[i]->GetFormID()).c_str(), menu->uiIcons.deleteSettings.texture, { iconSize, iconSize }))
-									pendingDeleteWidget = sortedWidgets[i];
-							}
-							if (ImGui::IsItemHovered())
-								ImGui::SetTooltip("Delete json file");
-						}
-					}
+					drawJsonDeleteButton(sortedWidgets[i]);
 				}
 
 				ImGui::EndTable();  // End DetailsTable
@@ -693,10 +691,12 @@ void EditorWindow::ShowObjectsWindow()
 	// Confirmation modal for json deletion - must be outside BeginChild so the modal can block the root window
 	if (pendingDeleteWidget) {
 		auto* pendingWidget = pendingDeleteWidget;
-		ImGui::OpenPopup("ListDeleteConfirmation");
+		if (pendingDeletePopupRequested) {
+			ImGui::OpenPopup("ListDeleteConfirmation");
+			pendingDeletePopupRequested = false;
+		}
 		pendingDeleteWidget->DrawDeleteConfirmationModal("ListDeleteConfirmation");
 		if (!ImGui::IsPopupOpen("ListDeleteConfirmation")) {
-			InvalidateJsonAttachmentCache(pendingWidget);
 			pendingDeleteWidget = nullptr;
 		}
 	}

--- a/src/WeatherEditor/EditorWindow.cpp
+++ b/src/WeatherEditor/EditorWindow.cpp
@@ -290,12 +290,24 @@ void EditorWindow::ShowObjectsWindow()
 						if (sortSpecs->SpecsCount > 0) {
 							const ImGuiTableColumnSortSpecs& spec = sortSpecs->Specs[0];
 							switch (spec.ColumnIndex) {
-							case 1: currentSortColumn = SortColumn::EditorID; break;
-							case 2: currentSortColumn = SortColumn::FormID; break;
-							case 3: currentSortColumn = SortColumn::File; break;
-							case 4: currentSortColumn = SortColumn::Status; break;
-							case 5: currentSortColumn = SortColumn::JsonAttachment; break;
-							default: currentSortColumn = SortColumn::None; break;
+							case 1:
+								currentSortColumn = SortColumn::EditorID;
+								break;
+							case 2:
+								currentSortColumn = SortColumn::FormID;
+								break;
+							case 3:
+								currentSortColumn = SortColumn::File;
+								break;
+							case 4:
+								currentSortColumn = SortColumn::Status;
+								break;
+							case 5:
+								currentSortColumn = SortColumn::JsonAttachment;
+								break;
+							default:
+								currentSortColumn = SortColumn::None;
+								break;
 							}
 							sortAscending = (spec.SortDirection == ImGuiSortDirection_Ascending);
 						} else {

--- a/src/WeatherEditor/EditorWindow.cpp
+++ b/src/WeatherEditor/EditorWindow.cpp
@@ -274,12 +274,13 @@ void EditorWindow::ShowObjectsWindow()
 			}
 
 			// Create a table for the right column with "Name" and "ID" headers. Different weights to prevent truncation.
-			if (ImGui::BeginTable("DetailsTable", 5, ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg | ImGuiTableFlags_SizingStretchProp | ImGuiTableFlags_Sortable)) {
-				ImGui::TableSetupColumn("Fav", ImGuiTableColumnFlags_WidthFixed | ImGuiTableColumnFlags_NoSort, 25.0f);  // Favorite indicator
+			if (ImGui::BeginTable("DetailsTable", 6, ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg | ImGuiTableFlags_SizingStretchProp | ImGuiTableFlags_Sortable)) {
+				ImGui::TableSetupColumn("Fav", ImGuiTableColumnFlags_WidthFixed | ImGuiTableColumnFlags_NoSort, 38.0f);  // Favorite indicator
 				ImGui::TableSetupColumn("Editor ID", ImGuiTableColumnFlags_WidthStretch, 3.5f);                          // Largest - weather/template names
-				ImGui::TableSetupColumn("Form ID", ImGuiTableColumnFlags_WidthFixed, 80.0f);                             // Fixed - 8 hex chars
+				ImGui::TableSetupColumn("Form ID", ImGuiTableColumnFlags_WidthFixed, 90.0f);                             // Fixed - 8 hex chars
 				ImGui::TableSetupColumn("File", ImGuiTableColumnFlags_WidthStretch, 2.0f);                               // Medium - plugin names
 				ImGui::TableSetupColumn("Status", ImGuiTableColumnFlags_WidthStretch, 1.5f);                             // Smaller - status text
+				ImGui::TableSetupColumn("json", ImGuiTableColumnFlags_WidthFixed, 55.0f);                               // JSON file / delete
 
 				ImGui::TableHeadersRow();
 
@@ -313,6 +314,7 @@ void EditorWindow::ShowObjectsWindow()
 				for (const auto& w : widgets) {
 					sortedWidgets.push_back(w.get());
 				}
+				RefreshJsonAttachmentCache(sortedWidgets);
 				if (currentSortColumn != SortColumn::None) {
 					std::sort(sortedWidgets.begin(), sortedWidgets.end(), [this](Widget* a, Widget* b) {
 						int comparison = 0;
@@ -333,6 +335,13 @@ void EditorWindow::ShowObjectsWindow()
 								std::string statusA = (markerA != settings.markedRecords.end()) ? markerA->second : "";
 								std::string statusB = (markerB != settings.markedRecords.end()) ? markerB->second : "";
 								comparison = _stricmp(statusA.c_str(), statusB.c_str());
+								break;
+							}
+						case SortColumn::JsonAttachment:
+							{
+								bool aHasJson = HasCachedJsonAttachment(a);
+								bool bHasJson = HasCachedJsonAttachment(b);
+								comparison = static_cast<int>(bHasJson) - static_cast<int>(aHasJson);
 								break;
 							}
 						default:
@@ -405,6 +414,9 @@ void EditorWindow::ShowObjectsWindow()
 							// Status column
 							ImGui::TableNextColumn();
 							ImGui::Text("Interior Cell");
+
+							// json column (empty for cells - no standalone json)
+							ImGui::TableNextColumn();
 						} else {
 							// Show message that cell lighting is only for interior cells
 							ImGui::TableNextRow();
@@ -467,7 +479,7 @@ void EditorWindow::ShowObjectsWindow()
 
 						// Editor ID column with [CURRENT] prefix
 						bool isSelected = sortedWidgets[i]->IsOpen();
-						if (ImGui::Selectable(editorLabel.c_str(), isSelected, ImGuiSelectableFlags_SpanAllColumns | ImGuiSelectableFlags_AllowDoubleClick)) {
+						if (ImGui::Selectable(editorLabel.c_str(), isSelected, ImGuiSelectableFlags_SpanAllColumns | ImGuiSelectableFlags_AllowDoubleClick | ImGuiSelectableFlags_AllowOverlap)) {
 							if (ImGui::IsMouseDoubleClicked(0)) {
 								sortedWidgets[i]->SetOpen(true);
 								AddToRecent(sortedWidgets[i]->GetEditorID(), selectedCategory);
@@ -512,6 +524,23 @@ void EditorWindow::ShowObjectsWindow()
 						if (markedRecord != settings.markedRecords.end()) {
 							ImGui::Text("%s", markedRecord->second.c_str());
 						}
+
+						// json / delete column
+						ImGui::TableNextColumn();
+						if (HasCachedJsonAttachment(sortedWidgets[i])) {
+							auto* menu = globals::menu;
+							if (menu && menu->uiIcons.deleteSettings.texture) {
+								const float iconSize = ImGui::GetFrameHeight() * 0.85f;
+								{
+									auto _style = Util::ErrorButtonStyle();
+									ImGui::SetNextItemAllowOverlap();
+									if (ImGui::ImageButton(std::format("##jsondel_cur_{}", sortedWidgets[i]->GetFormID()).c_str(), menu->uiIcons.deleteSettings.texture, { iconSize, iconSize }))
+										pendingDeleteWidget = sortedWidgets[i];
+								}
+								if (ImGui::IsItemHovered())
+									ImGui::SetTooltip("Delete json file");
+							}
+						}
 					}
 				}
 
@@ -555,7 +584,7 @@ void EditorWindow::ShowObjectsWindow()
 
 					// Editor ID column
 					bool isSelected = sortedWidgets[i]->IsOpen();
-					if (ImGui::Selectable(editorLabel.c_str(), isSelected, ImGuiSelectableFlags_SpanAllColumns | ImGuiSelectableFlags_AllowDoubleClick)) {
+					if (ImGui::Selectable(editorLabel.c_str(), isSelected, ImGuiSelectableFlags_SpanAllColumns | ImGuiSelectableFlags_AllowDoubleClick | ImGuiSelectableFlags_AllowOverlap)) {
 						if (ImGui::IsMouseDoubleClicked(0)) {
 							sortedWidgets[i]->SetOpen(true);
 							AddToRecent(sortedWidgets[i]->GetEditorID(), selectedCategory);
@@ -633,6 +662,23 @@ void EditorWindow::ShowObjectsWindow()
 					if (markedRecord != settings.markedRecords.end()) {
 						ImGui::Text("%s", markedRecord->second.c_str());
 					}
+
+					// json / delete column
+					ImGui::TableNextColumn();
+					if (HasCachedJsonAttachment(sortedWidgets[i])) {
+						auto* menu = globals::menu;
+						if (menu && menu->uiIcons.deleteSettings.texture) {
+							const float iconSize = ImGui::GetFrameHeight() * 0.85f;
+							{
+								auto _style = Util::ErrorButtonStyle();
+								ImGui::SetNextItemAllowOverlap();
+								if (ImGui::ImageButton(std::format("##jsondel_{}", sortedWidgets[i]->GetFormID()).c_str(), menu->uiIcons.deleteSettings.texture, { iconSize, iconSize }))
+									pendingDeleteWidget = sortedWidgets[i];
+							}
+							if (ImGui::IsItemHovered())
+								ImGui::SetTooltip("Delete json file");
+						}
+					}
 				}
 
 				ImGui::EndTable();  // End DetailsTable
@@ -643,6 +689,17 @@ void EditorWindow::ShowObjectsWindow()
 
 		ImGui::EndTable();  // End ObjectTable
 	}  // End if BeginTable("ObjectTable")
+
+	// Confirmation modal for json deletion - must be outside BeginChild so the modal can block the root window
+	if (pendingDeleteWidget) {
+		auto* pendingWidget = pendingDeleteWidget;
+		ImGui::OpenPopup("ListDeleteConfirmation");
+		pendingDeleteWidget->DrawDeleteConfirmationModal("ListDeleteConfirmation");
+		if (!ImGui::IsPopupOpen("ListDeleteConfirmation")) {
+			InvalidateJsonAttachmentCache(pendingWidget);
+			pendingDeleteWidget = nullptr;
+		}
+	}
 
 	// End the window
 	ImGui::End();
@@ -1127,6 +1184,7 @@ void EditorWindow::SetupResources()
 {
 	Load();
 	PaletteWindow::GetSingleton()->Load();
+	InvalidateJsonAttachmentCache();
 
 	// Populate all widget collections using WidgetFactory templates
 	WidgetFactory::PopulateWidgets<WeatherWidget, RE::TESWeather>(weatherWidgets);
@@ -1774,6 +1832,43 @@ void EditorWindow::RenderNotifications()
 
 		ImGui::PopStyleVar(2);
 	}
+}
+
+void EditorWindow::RefreshJsonAttachmentCache(const std::vector<Widget*>& widgets)
+{
+	for (auto* widget : widgets) {
+		if (!widget) {
+			continue;
+		}
+		if (!jsonAttachmentCache.contains(widget)) {
+			jsonAttachmentCache.emplace(widget, widget->HasSavedFile());
+		}
+	}
+}
+
+bool EditorWindow::HasCachedJsonAttachment(Widget* widget) const
+{
+	if (!widget) {
+		return false;
+	}
+	if (auto it = jsonAttachmentCache.find(widget); it != jsonAttachmentCache.end()) {
+		return it->second;
+	}
+	return false;
+}
+
+void EditorWindow::InvalidateJsonAttachmentCache(Widget* widget)
+{
+	if (widget) {
+		jsonAttachmentCache.erase(widget);
+		return;
+	}
+	jsonAttachmentCache.clear();
+}
+
+void EditorWindow::OnWidgetJsonAttachmentChanged(Widget* widget)
+{
+	InvalidateJsonAttachmentCache(widget);
 }
 
 void EditorWindow::AddToRecent(const std::string& widgetId, const std::string& category)

--- a/src/WeatherEditor/EditorWindow.cpp
+++ b/src/WeatherEditor/EditorWindow.cpp
@@ -280,7 +280,7 @@ void EditorWindow::ShowObjectsWindow()
 				ImGui::TableSetupColumn("Form ID", ImGuiTableColumnFlags_WidthFixed, 90.0f);                             // Fixed - 8 hex chars
 				ImGui::TableSetupColumn("File", ImGuiTableColumnFlags_WidthStretch, 2.0f);                               // Medium - plugin names
 				ImGui::TableSetupColumn("Status", ImGuiTableColumnFlags_WidthStretch, 1.5f);                             // Smaller - status text
-				ImGui::TableSetupColumn("json", ImGuiTableColumnFlags_WidthFixed, 55.0f);                               // JSON file / delete
+				ImGui::TableSetupColumn("json", ImGuiTableColumnFlags_WidthFixed, 55.0f);                                // JSON file / delete
 
 				ImGui::TableHeadersRow();
 

--- a/src/WeatherEditor/EditorWindow.cpp
+++ b/src/WeatherEditor/EditorWindow.cpp
@@ -273,14 +273,17 @@ void EditorWindow::ShowObjectsWindow()
 				}
 			}
 
+			// Stable user IDs for sortable columns — used instead of ColumnIndex so reordering/insertion won't break sorting.
+			enum ColumnID : ImGuiID { ColFav = 0, ColEditorID, ColFormID, ColFile, ColStatus, ColJson };
+
 			// Create a table for the right column with "Name" and "ID" headers. Different weights to prevent truncation.
 			if (ImGui::BeginTable("DetailsTable", 6, ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg | ImGuiTableFlags_SizingStretchProp | ImGuiTableFlags_Sortable)) {
-				ImGui::TableSetupColumn("Fav", ImGuiTableColumnFlags_WidthFixed | ImGuiTableColumnFlags_NoSort, 38.0f);  // Favorite indicator
-				ImGui::TableSetupColumn("Editor ID", ImGuiTableColumnFlags_WidthStretch, 3.5f);                          // Largest - weather/template names
-				ImGui::TableSetupColumn("Form ID", ImGuiTableColumnFlags_WidthFixed, 90.0f);                             // Fixed - 8 hex chars
-				ImGui::TableSetupColumn("File", ImGuiTableColumnFlags_WidthStretch, 2.0f);                               // Medium - plugin names
-				ImGui::TableSetupColumn("Status", ImGuiTableColumnFlags_WidthStretch, 1.5f);                             // Smaller - status text
-				ImGui::TableSetupColumn("json", ImGuiTableColumnFlags_WidthFixed, 55.0f);                                // JSON file / delete
+				ImGui::TableSetupColumn("Fav", ImGuiTableColumnFlags_WidthFixed | ImGuiTableColumnFlags_NoSort, 38.0f, ColFav);     // Favorite indicator
+				ImGui::TableSetupColumn("Editor ID", ImGuiTableColumnFlags_WidthStretch, 3.5f, ColEditorID);                        // Largest - weather/template names
+				ImGui::TableSetupColumn("Form ID", ImGuiTableColumnFlags_WidthFixed, 90.0f, ColFormID);                              // Fixed - 8 hex chars
+				ImGui::TableSetupColumn("File", ImGuiTableColumnFlags_WidthStretch, 2.0f, ColFile);                                  // Medium - plugin names
+				ImGui::TableSetupColumn("Status", ImGuiTableColumnFlags_WidthStretch, 1.5f, ColStatus);                              // Smaller - status text
+				ImGui::TableSetupColumn("json", ImGuiTableColumnFlags_WidthFixed, 55.0f, ColJson);                                   // JSON file / delete
 
 				ImGui::TableHeadersRow();
 
@@ -289,20 +292,20 @@ void EditorWindow::ShowObjectsWindow()
 					if (sortSpecs->SpecsDirty) {
 						if (sortSpecs->SpecsCount > 0) {
 							const ImGuiTableColumnSortSpecs& spec = sortSpecs->Specs[0];
-							switch (spec.ColumnIndex) {
-							case 1:
+							switch (spec.ColumnUserID) {
+							case ColEditorID:
 								currentSortColumn = SortColumn::EditorID;
 								break;
-							case 2:
+							case ColFormID:
 								currentSortColumn = SortColumn::FormID;
 								break;
-							case 3:
+							case ColFile:
 								currentSortColumn = SortColumn::File;
 								break;
-							case 4:
+							case ColStatus:
 								currentSortColumn = SortColumn::Status;
 								break;
-							case 5:
+							case ColJson:
 								currentSortColumn = SortColumn::JsonAttachment;
 								break;
 							default:
@@ -379,7 +382,9 @@ void EditorWindow::ShowObjectsWindow()
 							const float iconSize = ImGui::GetFrameHeight() * 0.85f;
 							auto _style = Util::ErrorButtonStyle();
 							ImGui::SetNextItemAllowOverlap();
-							if (ImGui::ImageButton(std::format("##jsondel_{}", widget->GetFormID()).c_str(), menu->uiIcons.deleteSettings.texture, { iconSize, iconSize })) {
+							char idBuf[32];
+							snprintf(idBuf, sizeof(idBuf), "##jsondel_%s", widget->GetFormID().c_str());
+							if (ImGui::ImageButton(idBuf, menu->uiIcons.deleteSettings.texture, { iconSize, iconSize })) {
 								pendingDeleteWidget = widget;
 								pendingDeletePopupRequested = true;
 							}

--- a/src/WeatherEditor/EditorWindow.h
+++ b/src/WeatherEditor/EditorWindow.h
@@ -174,7 +174,6 @@ public:
 	void AddToRecent(const std::string& widgetId, const std::string& category);
 	void ToggleFavorite(const std::string& widgetId);
 	bool IsFavorite(const std::string& widgetId) const;
-	void OnWidgetJsonAttachmentChanged(Widget* widget);
 	void SaveSessionWidgets();
 	void RestoreSessionWidgets();
 
@@ -184,6 +183,8 @@ public:
 	~EditorWindow();
 
 private:
+	friend class Widget;
+
 	void SaveAll();
 	void SaveSettings();
 	void LoadSettings();
@@ -218,7 +219,9 @@ private:
 	bool sortAscending = true;
 
 	Widget* pendingDeleteWidget = nullptr;
+	bool pendingDeletePopupRequested = false;
 
+	void OnWidgetJsonAttachmentChanged(Widget* widget);
 	std::unordered_map<Widget*, bool> jsonAttachmentCache;
 	void RefreshJsonAttachmentCache(const std::vector<Widget*>& widgets);
 	bool HasCachedJsonAttachment(Widget* widget) const;

--- a/src/WeatherEditor/EditorWindow.h
+++ b/src/WeatherEditor/EditorWindow.h
@@ -13,6 +13,8 @@
 #include "WeatherUtils.h"
 #include "Widget.h"
 
+#include <unordered_map>
+
 class EditorWindow
 {
 public:
@@ -172,6 +174,7 @@ public:
 	void AddToRecent(const std::string& widgetId, const std::string& category);
 	void ToggleFavorite(const std::string& widgetId);
 	bool IsFavorite(const std::string& widgetId) const;
+	void OnWidgetJsonAttachmentChanged(Widget* widget);
 	void SaveSessionWidgets();
 	void RestoreSessionWidgets();
 
@@ -208,8 +211,16 @@ private:
 		EditorID,
 		FormID,
 		File,
-		Status
+		Status,
+		JsonAttachment
 	};
 	SortColumn currentSortColumn = SortColumn::None;
 	bool sortAscending = true;
+
+	Widget* pendingDeleteWidget = nullptr;
+
+	std::unordered_map<Widget*, bool> jsonAttachmentCache;
+	void RefreshJsonAttachmentCache(const std::vector<Widget*>& widgets);
+	bool HasCachedJsonAttachment(Widget* widget) const;
+	void InvalidateJsonAttachmentCache(Widget* widget = nullptr);
 };

--- a/src/WeatherEditor/Widget.cpp
+++ b/src/WeatherEditor/Widget.cpp
@@ -16,7 +16,6 @@ bool Widget::MatchesSearch(const std::string& text) const
 
 void Widget::Save()
 {
-	EditorWindow::GetSingleton()->OnWidgetJsonAttachmentChanged(this);
 	SaveSettings();
 	const std::string filePath = std::format("{}\\{}", Util::PathHelpers::GetCommunityShaderPath().string(), GetFolderName());
 	const std::string file = std::format("{}\\{}.json", filePath, GetEditorID());
@@ -60,6 +59,7 @@ void Widget::Save()
 		}
 
 		settingsFile.close();
+		EditorWindow::GetSingleton()->OnWidgetJsonAttachmentChanged(this);
 
 	} catch (const nlohmann::json::exception& e) {
 		logger::error("{}: JSON error while saving settings: {}", GetEditorID(), e.what());
@@ -72,7 +72,6 @@ void Widget::Save()
 
 void Widget::Load()
 {
-	EditorWindow::GetSingleton()->OnWidgetJsonAttachmentChanged(this);
 	std::string filePath = std::format("{}\\{}\\{}.json", Util::PathHelpers::GetCommunityShaderPath().string(), GetFolderName(), GetEditorID());
 
 	if (!std::filesystem::exists(filePath)) {
@@ -147,7 +146,6 @@ void Widget::Load()
 
 void Widget::Delete()
 {
-	EditorWindow::GetSingleton()->OnWidgetJsonAttachmentChanged(this);
 	std::string filePath = std::format("{}\\{}\\{}.json", Util::PathHelpers::GetCommunityShaderPath().string(), GetFolderName(), GetEditorID());
 
 	if (!std::filesystem::exists(filePath)) {
@@ -164,6 +162,8 @@ void Widget::Delete()
 
 		// Apply the vanilla values to the game
 		ApplyChanges();
+
+		EditorWindow::GetSingleton()->OnWidgetJsonAttachmentChanged(this);
 
 		EditorWindow::GetSingleton()->ShowNotification(
 			std::format("Deleted {} - reverted to vanilla values", GetEditorID()),

--- a/src/WeatherEditor/Widget.cpp
+++ b/src/WeatherEditor/Widget.cpp
@@ -16,6 +16,7 @@ bool Widget::MatchesSearch(const std::string& text) const
 
 void Widget::Save()
 {
+	EditorWindow::GetSingleton()->OnWidgetJsonAttachmentChanged(this);
 	SaveSettings();
 	const std::string filePath = std::format("{}\\{}", Util::PathHelpers::GetCommunityShaderPath().string(), GetFolderName());
 	const std::string file = std::format("{}\\{}.json", filePath, GetEditorID());
@@ -71,6 +72,7 @@ void Widget::Save()
 
 void Widget::Load()
 {
+	EditorWindow::GetSingleton()->OnWidgetJsonAttachmentChanged(this);
 	std::string filePath = std::format("{}\\{}\\{}.json", Util::PathHelpers::GetCommunityShaderPath().string(), GetFolderName(), GetEditorID());
 
 	if (!std::filesystem::exists(filePath)) {
@@ -145,6 +147,7 @@ void Widget::Load()
 
 void Widget::Delete()
 {
+	EditorWindow::GetSingleton()->OnWidgetJsonAttachmentChanged(this);
 	std::string filePath = std::format("{}\\{}\\{}.json", Util::PathHelpers::GetCommunityShaderPath().string(), GetFolderName(), GetEditorID());
 
 	if (!std::filesystem::exists(filePath)) {
@@ -202,14 +205,14 @@ void Widget::DrawMenu()
 	DrawDeleteConfirmationModal();
 }
 
-void Widget::DrawDeleteConfirmationModal()
+void Widget::DrawDeleteConfirmationModal(const char* popupId)
 {
-	if (!ImGui::IsPopupOpen("DeleteConfirmation"))
+	if (!ImGui::IsPopupOpen(popupId))
 		return;
 	if (deleteConfirmationFrame == ImGui::GetFrameCount())
 		return;
 
-	if (ImGui::BeginPopupModal("DeleteConfirmation", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
+	if (ImGui::BeginPopupModal(popupId, nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
 		deleteConfirmationFrame = ImGui::GetFrameCount();
 		ImGui::Text("Are you sure you want to delete the saved settings file?");
 		ImGui::Spacing();
@@ -345,12 +348,11 @@ void Widget::DrawWidgetHeader(const char* searchId, bool showApply, bool showSav
 
 			if (HasSavedFile() && menu->uiIcons.deleteSettings.texture) {
 				ImGui::SameLine();
-				ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.7f, 0.3f, 0.2f, 1.0f));
-				ImGui::PushStyleColor(ImGuiCol_ButtonHovered, ImVec4(0.9f, 0.4f, 0.3f, 1.0f));
-				if (ImGui::ImageButton((std::string(searchId) + "_Delete").c_str(), menu->uiIcons.deleteSettings.texture, buttonSize)) {
-					ImGui::OpenPopup("DeleteConfirmation");
+				{
+					auto _style = Util::ErrorButtonStyle();
+					if (ImGui::ImageButton((std::string(searchId) + "_Delete").c_str(), menu->uiIcons.deleteSettings.texture, buttonSize))
+						ImGui::OpenPopup("DeleteConfirmation");
 				}
-				ImGui::PopStyleColor(2);
 				if (ImGui::IsItemHovered())
 					ImGui::SetTooltip("Delete saved file");
 			}

--- a/src/WeatherEditor/Widget.h
+++ b/src/WeatherEditor/Widget.h
@@ -142,13 +142,14 @@ public:
 
 	bool MatchesSearch(const std::string& text) const;
 
+	void DrawDeleteConfirmationModal(const char* popupId = "DeleteConfirmation");
+
 	json js = json();
 
 protected:
 	std::string cachedEditorID;
 	virtual void DrawMenu();
 	std::string GetFolderName();
-	void DrawDeleteConfirmationModal();
 };
 
 // Simple widget for caching form data without full widget functionality


### PR DESCRIPTION
- Shows which objects have a json file active
- Allows deletion of the json file without openign the object widget
- Sorting functionality

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * JSON attachment management with per-widget caching and visual indicators in the widget list
  * New JSON column in the widget details table for visibility
  * JSON-aware sorting to prioritize widgets with attachments

* **Bug Fixes / Improvements**
  * Inline JSON delete action with confirmation modal and improved delete workflow
  * Cache invalidation on resource updates and after widget changes to keep state consistent
  * Improved multi-column row interactions and delete-button styling for more reliable UX
<!-- end of auto-generated comment: release notes by coderabbit.ai -->