### PR TITLE
feat(weather editor): highlight enabled cloud layers

### DIFF
--- a/src/WeatherEditor/Weather/WeatherWidget.cpp
+++ b/src/WeatherEditor/Weather/WeatherWidget.cpp
@@ -998,17 +998,39 @@ void WeatherWidget::DrawCloudSettings()
 	bool changed = false;
 	for (int i = 0; i < TESWeather::kTotalLayers; i++) {
 		std::string layer = std::format("Layer {}", i);
+		bool layerEnabled = settings.clouds[i].enabled;
 
 		ImGuiTreeNodeFlags flags = ImGuiTreeNodeFlags_OpenOnArrow | ImGuiTreeNodeFlags_OpenOnDoubleClick;
-		if (settings.clouds[i].enabled && !settings.clouds[i].texturePath.empty()) {
-			flags |= ImGuiTreeNodeFlags_DefaultOpen;
+
+		if (!layerEnabled) {
+			ImGui::PushStyleColor(ImGuiCol_Header, ImGui::GetStyleColorVec4(ImGuiCol_FrameBg));
+			ImGui::PushStyleColor(ImGuiCol_HeaderHovered, ImGui::GetStyleColorVec4(ImGuiCol_FrameBgHovered));
+			ImGui::PushStyleColor(ImGuiCol_HeaderActive, ImGui::GetStyleColorVec4(ImGuiCol_FrameBgActive));
 		}
 
-		if (ImGui::CollapsingHeader(layer.c_str(), flags)) {
+		// Label is constant so the storage ID never changes — open/closed state always persists.
+		// [Enabled] badge is overlaid on the header via the draw list instead of altering the label.
+		float headerScreenY = ImGui::GetCursorScreenPos().y;
+		bool layerOpen = ImGui::CollapsingHeader(layer.c_str(), flags);
+
+		if (!layerEnabled)
+			ImGui::PopStyleColor(3);
+
+		if (layerEnabled) {
+			constexpr char kEnabledBadge[] = "[Enabled]";
+			const ImVec2 badgeSize = ImGui::CalcTextSize(kEnabledBadge);
+			const float headerHeight = ImGui::GetFrameHeight();
+			const ImVec2 badgePos = {
+				ImGui::GetWindowPos().x + ImGui::GetWindowWidth() - badgeSize.x -
+				    ImGui::GetStyle().ScrollbarSize - ImGui::GetStyle().WindowPadding.x,
+				headerScreenY + (headerHeight - badgeSize.y) * 0.5f
+			};
+			ImGui::GetWindowDrawList()->AddText(badgePos, ImGui::GetColorU32(ImGuiCol_CheckMark), kEnabledBadge);
+		}
+
+		if (layerOpen) {
 			ImGui::Indent(10.0f);
 			ImGui::Spacing();
-
-			bool layerEnabled = settings.clouds[i].enabled;
 
 			// Begin horizontal layout for enable checkbox and sliders on left, texture on right
 			ImGui::BeginGroup();

--- a/src/WeatherEditor/Weather/WeatherWidget.cpp
+++ b/src/WeatherEditor/Weather/WeatherWidget.cpp
@@ -1126,7 +1126,6 @@ void WeatherWidget::DrawCloudSettings()
 			}
 		}
 	} else if (changed && editorWindow->settings.autoApplyChanges) {
-		editorWindow->PushUndoState(this);
 		ApplyChanges();
 	}
 }

--- a/src/WeatherEditor/Weather/WeatherWidget.cpp
+++ b/src/WeatherEditor/Weather/WeatherWidget.cpp
@@ -1022,7 +1022,7 @@ void WeatherWidget::DrawCloudSettings()
 			const float headerHeight = ImGui::GetFrameHeight();
 			const ImVec2 badgePos = {
 				ImGui::GetWindowPos().x + ImGui::GetWindowWidth() - badgeSize.x -
-				    ImGui::GetStyle().ScrollbarSize - ImGui::GetStyle().WindowPadding.x,
+					ImGui::GetStyle().ScrollbarSize - ImGui::GetStyle().WindowPadding.x,
 				headerScreenY + (headerHeight - badgeSize.y) * 0.5f
 			};
 			ImGui::GetWindowDrawList()->AddText(badgePos, ImGui::GetColorU32(ImGuiCol_CheckMark), kEnabledBadge);

--- a/src/WeatherEditor/Weather/WeatherWidget.cpp
+++ b/src/WeatherEditor/Weather/WeatherWidget.cpp
@@ -997,13 +997,15 @@ void WeatherWidget::DrawCloudSettings()
 
 	bool changed = false;
 	bool enableChanged = false;
+
+	// OpenOnArrow|OpenOnDoubleClick prevents accidental collapse when clicking
+	// the [Enabled] badge area that overlaps the right side of the header.
+	constexpr ImGuiTreeNodeFlags flags = ImGuiTreeNodeFlags_OpenOnArrow | ImGuiTreeNodeFlags_OpenOnDoubleClick;
+	constexpr char kEnabledBadge[] = "[Enabled]";
+
 	for (int i = 0; i < TESWeather::kTotalLayers; i++) {
 		std::string layer = std::format("Layer {}", i);
 		bool layerEnabled = settings.clouds[i].enabled;
-
-		// OpenOnArrow|OpenOnDoubleClick prevents accidental collapse when clicking
-		// the [Enabled] badge area that overlaps the right side of the header.
-		ImGuiTreeNodeFlags flags = ImGuiTreeNodeFlags_OpenOnArrow | ImGuiTreeNodeFlags_OpenOnDoubleClick;
 
 		if (!layerEnabled) {
 			ImGui::PushStyleColor(ImGuiCol_Header, ImGui::GetStyleColorVec4(ImGuiCol_FrameBg));
@@ -1020,7 +1022,6 @@ void WeatherWidget::DrawCloudSettings()
 			ImGui::PopStyleColor(3);
 
 		if (layerEnabled) {
-			constexpr char kEnabledBadge[] = "[Enabled]";
 			const ImVec2 badgeSize = ImGui::CalcTextSize(kEnabledBadge);
 			const float headerHeight = ImGui::GetFrameHeight();
 			const ImVec2 badgePos = {

--- a/src/WeatherEditor/Weather/WeatherWidget.cpp
+++ b/src/WeatherEditor/Weather/WeatherWidget.cpp
@@ -1021,8 +1021,7 @@ void WeatherWidget::DrawCloudSettings()
 			const ImVec2 badgeSize = ImGui::CalcTextSize(kEnabledBadge);
 			const float headerHeight = ImGui::GetFrameHeight();
 			const ImVec2 badgePos = {
-				ImGui::GetWindowPos().x + ImGui::GetWindowWidth() - badgeSize.x -
-				    ImGui::GetStyle().ScrollbarSize - ImGui::GetStyle().WindowPadding.x,
+				ImGui::GetWindowPos().x + ImGui::GetContentRegionMax().x - badgeSize.x,
 				headerScreenY + (headerHeight - badgeSize.y) * 0.5f
 			};
 			ImGui::GetWindowDrawList()->AddText(badgePos, ImGui::GetColorU32(ImGuiCol_CheckMark), kEnabledBadge);
@@ -1038,7 +1037,7 @@ void WeatherWidget::DrawCloudSettings()
 			if (ImGui::Checkbox(std::format("Enable##{}", layer).c_str(), &layerEnabled)) {
 				settings.clouds[i].enabled = layerEnabled;
 				// Always apply cloud enable/disable immediately for instant feedback
-				EditorWindow::GetSingleton()->PushUndoState(this);
+				editorWindow->PushUndoState(this);
 				ApplyChanges();
 
 				// Force weather re-application if locked to make cloud changes visible immediately
@@ -1073,20 +1072,11 @@ void WeatherWidget::DrawCloudSettings()
 					ImGui::BeginGroup();
 					float textureSize = 128.0f;
 					ImGui::Image((void*)texture, ImVec2(textureSize, textureSize));
-					// Small grey subtext below image
-					ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(0.5f, 0.5f, 0.5f, 1.0f));
-					ImGui::PushFont(ImGui::GetFont());
-					ImGui::SetWindowFontScale(0.8f);
-					float textWidth = ImGui::CalcTextSize(settings.clouds[i].texturePath.c_str()).x;
-					if (textWidth > textureSize) {
-						ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + textureSize);
-						ImGui::TextWrapped("%s", settings.clouds[i].texturePath.c_str());
-						ImGui::PopTextWrapPos();
-					} else {
-						ImGui::Text("%s", settings.clouds[i].texturePath.c_str());
-					}
-					ImGui::SetWindowFontScale(1.0f);
-					ImGui::PopFont();
+					// Small grey subtext below image, clamped to texture width
+					ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
+					ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + textureSize);
+					ImGui::TextWrapped("%s", settings.clouds[i].texturePath.c_str());
+					ImGui::PopTextWrapPos();
 					ImGui::PopStyleColor();
 					ImGui::EndGroup();
 				}

--- a/src/WeatherEditor/Weather/WeatherWidget.cpp
+++ b/src/WeatherEditor/Weather/WeatherWidget.cpp
@@ -996,10 +996,13 @@ void WeatherWidget::DrawCloudSettings()
 	WeatherWidget* parentWidget = hasParent ? GetParent() : nullptr;
 
 	bool changed = false;
+	bool enableChanged = false;
 	for (int i = 0; i < TESWeather::kTotalLayers; i++) {
 		std::string layer = std::format("Layer {}", i);
 		bool layerEnabled = settings.clouds[i].enabled;
 
+		// OpenOnArrow|OpenOnDoubleClick prevents accidental collapse when clicking
+		// the [Enabled] badge area that overlaps the right side of the header.
 		ImGuiTreeNodeFlags flags = ImGuiTreeNodeFlags_OpenOnArrow | ImGuiTreeNodeFlags_OpenOnDoubleClick;
 
 		if (!layerEnabled) {
@@ -1036,17 +1039,7 @@ void WeatherWidget::DrawCloudSettings()
 
 			if (ImGui::Checkbox(std::format("Enable##{}", layer).c_str(), &layerEnabled)) {
 				settings.clouds[i].enabled = layerEnabled;
-				// Always apply cloud enable/disable immediately for instant feedback
-				editorWindow->PushUndoState(this);
-				ApplyChanges();
-
-				// Force weather re-application if locked to make cloud changes visible immediately
-				if (editorWindow->IsWeatherLocked() && editorWindow->GetLockedWeather() == weather) {
-					if (auto sky = RE::Sky::GetSingleton()) {
-						sky->ForceWeather(weather, false);
-					}
-				}
-
+				enableChanged = true;
 				changed = true;
 			}
 
@@ -1123,8 +1116,17 @@ void WeatherWidget::DrawCloudSettings()
 			ImGui::Unindent(10.0f);
 		}
 	}
-	if (changed && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
-		EditorWindow::GetSingleton()->PushUndoState(this);
+	if (enableChanged) {
+		// Apply enable/disable immediately for instant feedback, regardless of autoApplyChanges.
+		editorWindow->PushUndoState(this);
+		ApplyChanges();
+		if (editorWindow->IsWeatherLocked() && editorWindow->GetLockedWeather() == weather) {
+			if (auto sky = RE::Sky::GetSingleton()) {
+				sky->ForceWeather(weather, false);
+			}
+		}
+	} else if (changed && editorWindow->settings.autoApplyChanges) {
+		editorWindow->PushUndoState(this);
 		ApplyChanges();
 	}
 }

--- a/src/WeatherEditor/Weather/WeatherWidget.cpp
+++ b/src/WeatherEditor/Weather/WeatherWidget.cpp
@@ -1123,7 +1123,7 @@ void WeatherWidget::DrawCloudSettings()
 		ApplyChanges();
 		if (editorWindow->IsWeatherLocked() && editorWindow->GetLockedWeather() == weather) {
 			if (auto sky = RE::Sky::GetSingleton()) {
-				sky->ForceWeather(weather, false);
+				sky->ForceWeather(weather, true);  // override=true for immediate application; matches "instant feedback" intent above
 			}
 		}
 	} else if (changed && editorWindow->settings.autoApplyChanges) {


### PR DESCRIPTION
- menu starts out collapsed
- enabled cloud layers are marked with a blue header and text
- disabled layers are dark.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-layer persistent open/closed state, an [Enabled] badge overlay, and arrow/double-click controls to reduce accidental collapse.

* **Bug Fixes**
  * Toggling a layer applies changes immediately with an undo entry and updates active weather when applicable.
  * Disabled layers are visually de-emphasized via adjusted header styling.

* **Refactor**
  * Texture subtext now uses disabled styling with width-clamped wrapping for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->