### PR TITLE
feat(weather editor): enable snapping to viewport

### DIFF
--- a/src/WeatherEditor/EditorWindow.cpp
+++ b/src/WeatherEditor/EditorWindow.cpp
@@ -1145,7 +1145,7 @@ void EditorWindow::RenderUI()
 		ImGui::EndMainMenuBar();
 	}
 
-	// Establish a viewport-wide DockSpace so all editor windows
+	// Establish a viewport-wide DockSpace so all editor windows are snappable and dockable
 	ImGui::DockSpaceOverViewport(nullptr, ImGuiDockNodeFlags_PassthruCentralNode);
 
 	auto width = ImGui::GetIO().DisplaySize.x;

--- a/src/WeatherEditor/EditorWindow.cpp
+++ b/src/WeatherEditor/EditorWindow.cpp
@@ -1145,6 +1145,9 @@ void EditorWindow::RenderUI()
 		ImGui::EndMainMenuBar();
 	}
 
+	// Establish a viewport-wide DockSpace so all editor windows
+	ImGui::DockSpaceOverViewport(nullptr, ImGuiDockNodeFlags_PassthruCentralNode);
+
 	auto width = ImGui::GetIO().DisplaySize.x;
 	auto height = ImGui::GetIO().DisplaySize.y;
 	auto viewportWidth = width * 0.5f;                // Make the viewport take up 50% of the width

--- a/src/WeatherEditor/EditorWindow.cpp
+++ b/src/WeatherEditor/EditorWindow.cpp
@@ -1865,7 +1865,7 @@ void EditorWindow::RenderNotifications()
 
 		if (ImGui::Begin(std::format("##Notification{}", (void*)&notif).c_str(),
 				nullptr,
-				ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoFocusOnAppearing | ImGuiWindowFlags_NoNav)) {
+				ImGuiWindowFlags_NoDecoration | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoSavedSettings | ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoFocusOnAppearing | ImGuiWindowFlags_NoNav | ImGuiWindowFlags_NoDocking)) {
 			ImVec4 colorWithAlpha = notif.color;
 			colorWithAlpha.w *= alpha;
 			ImGui::PushStyleColor(ImGuiCol_Text, colorWithAlpha);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added viewport-wide docking to the editor, letting users arrange, resize, and customize panel layouts across the full viewport for a more flexible, persistent workspace.

* **Bug Fixes / UI Improvements**
  * Notification windows no longer accept docking, ensuring notifications stay separate, visible, and behave consistently without being attached to other panels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->