### PR TITLE
fix(weather editor): guard against loadorder changes

### DIFF
--- a/src/WeatherEditor/Widget.h
+++ b/src/WeatherEditor/Widget.h
@@ -30,11 +30,12 @@ public:
 
 	virtual std::string GetEditorID() const
 	{
-		// If cachedEditorID looks like a fallback ID, try to get the real one
-		if (cachedEditorID.find("VolumetricLighting_") == 0 && form) {
+		// If using a fallback ID, retry getting the real EditorID
+		if (isFallbackEditorID && form) {
 			const char* editorID = form->GetFormEditorID();
 			if (editorID && editorID[0] != '\0') {
 				const_cast<Widget*>(this)->cachedEditorID = editorID;
+				const_cast<Widget*>(this)->isFallbackEditorID = false;
 				return editorID;
 			}
 		}
@@ -83,28 +84,33 @@ public:
 			}
 		}
 
-		// Fallback to FormID-based names
+		// Fallback: use SPID-format filename (0xLocalFormID~PluginName) for load-order independence
+		const auto* file = form->GetFile();
+		const auto spidID = file
+		                        ? std::format("0x{:X}~{}", form->GetLocalFormID(), file->GetFilename())
+		                        : std::format("0x{:X}", form->GetLocalFormID());
 		auto formType = form->GetFormType();
 		switch (formType) {
 		case RE::FormType::ImageSpace:
-			cachedEditorID = std::format("ImageSpace_{:08X}", form->GetFormID());
+			cachedEditorID = std::format("IS_{}", spidID);
 			break;
 		case RE::FormType::VolumetricLighting:
-			cachedEditorID = std::format("VolumetricLighting_{:08X}", form->GetFormID());
+			cachedEditorID = std::format("VL_{}", spidID);
 			break;
 		case RE::FormType::ShaderParticleGeometryData:
-			cachedEditorID = std::format("ShaderParticleGeometry_{:08X}", form->GetFormID());
+			cachedEditorID = std::format("Particle_{}", spidID);
 			break;
 		case RE::FormType::LensFlare:
-			cachedEditorID = std::format("LensFlare_{:08X}", form->GetFormID());
+			cachedEditorID = std::format("LensFlare_{}", spidID);
 			break;
 		case RE::FormType::ReferenceEffect:
-			cachedEditorID = std::format("VisualEffect_{:08X}", form->GetFormID());
+			cachedEditorID = std::format("VisualEffect_{}", spidID);
 			break;
 		default:
-			cachedEditorID = std::format("Form_{:08X}", form->GetFormID());
+			cachedEditorID = std::format("Form_{}", spidID);
 			break;
 		}
+		isFallbackEditorID = true;
 	}
 
 	virtual void DrawWidget() = 0;
@@ -148,6 +154,7 @@ public:
 
 protected:
 	std::string cachedEditorID;
+	bool isFallbackEditorID = false;
 	virtual void DrawMenu();
 	std::string GetFolderName();
 };

--- a/src/WeatherEditor/Widget.h
+++ b/src/WeatherEditor/Widget.h
@@ -62,6 +62,7 @@ public:
 	{
 		if (!form) {
 			cachedEditorID = "Invalid";
+			isFallbackEditorID = false;
 			return;
 		}
 
@@ -69,6 +70,7 @@ public:
 		const char* editorID = form->GetFormEditorID();
 		if (editorID && editorID[0] != '\0') {
 			cachedEditorID = editorID;
+			isFallbackEditorID = false;
 			return;
 		}
 
@@ -79,6 +81,7 @@ public:
 			for (const auto& [name, f] : *map) {
 				if (f == form) {
 					cachedEditorID = std::string(name.c_str());
+					isFallbackEditorID = false;
 					return;
 				}
 			}

--- a/src/WeatherEditor/Widget.h
+++ b/src/WeatherEditor/Widget.h
@@ -86,9 +86,7 @@ public:
 
 		// Fallback: use SPID-format filename (0xLocalFormID~PluginName) for load-order independence
 		const auto* file = form->GetFile();
-		const auto spidID = file
-		                        ? std::format("0x{:X}~{}", form->GetLocalFormID(), file->GetFilename())
-		                        : std::format("0x{:X}", form->GetLocalFormID());
+		const auto spidID = file ? std::format("0x{:X}~{}", form->GetLocalFormID(), file->GetFilename()) : std::format("0x{:X}", form->GetLocalFormID());
 		auto formType = form->GetFormType();
 		switch (formType) {
 		case RE::FormType::ImageSpace:

--- a/src/WeatherEditor/Widget.h
+++ b/src/WeatherEditor/Widget.h
@@ -34,8 +34,8 @@ public:
 		if (isFallbackEditorID && form) {
 			const char* editorID = form->GetFormEditorID();
 			if (editorID && editorID[0] != '\0') {
-				const_cast<Widget*>(this)->cachedEditorID = editorID;
-				const_cast<Widget*>(this)->isFallbackEditorID = false;
+				cachedEditorID = editorID;
+				isFallbackEditorID = false;
 				return editorID;
 			}
 		}
@@ -153,8 +153,8 @@ public:
 	json js = json();
 
 protected:
-	std::string cachedEditorID;
-	bool isFallbackEditorID = false;
+	mutable std::string cachedEditorID;
+	mutable bool isFallbackEditorID = false;
 	virtual void DrawMenu();
 	std::string GetFolderName();
 };


### PR DESCRIPTION
Previously we were saving json files in a format that could change depending on the load order, especially with VL where the EditorID can't be found without extra dependencies. This change adopts the SPID config format to save files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved editor ID resolution in the Weather Editor to produce more consistent fallback IDs when originals are unavailable.
  * Added caching and retry behavior so real editor IDs are picked up when they become available later.
  * Standardized fallback ID formatting across content types for more reliable and predictable identification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->