### PR TITLE
refactor(weather-editor): cleanup and consolidate widget json serialization

### DIFF
--- a/src/WeatherEditor/EditorWindow.cpp
+++ b/src/WeatherEditor/EditorWindow.cpp
@@ -584,7 +584,7 @@ void EditorWindow::ShowObjectsWindow()
 				if (currentCellLightingTemplate && m_selectedCategory == "Lighting Template") {
 					for (int i = 0; i < sortedWidgets.size(); ++i) {
 						auto* ltWidget = dynamic_cast<LightingTemplateWidget*>(sortedWidgets[i]);
-						if (!ltWidget || ltWidget->lightingTemplate != currentCellLightingTemplate)
+						if (!ltWidget || ltWidget->GetLightingTemplate() != currentCellLightingTemplate)
 							continue;
 
 						if (!shouldShowWidget(sortedWidgets[i]))
@@ -667,7 +667,7 @@ void EditorWindow::ShowObjectsWindow()
 					// Skip current cell's lighting template if already shown
 					if (currentCellLightingTemplate && m_selectedCategory == "Lighting Template") {
 						auto* ltWidget = dynamic_cast<LightingTemplateWidget*>(sortedWidgets[i]);
-						if (ltWidget && ltWidget->lightingTemplate == currentCellLightingTemplate)
+						if (ltWidget && ltWidget->GetLightingTemplate() == currentCellLightingTemplate)
 							continue;
 					}
 

--- a/src/WeatherEditor/EditorWindow.cpp
+++ b/src/WeatherEditor/EditorWindow.cpp
@@ -509,7 +509,7 @@ void EditorWindow::ShowObjectsWindow()
 							if (Util::TableRowSelectable(label.c_str(), isOpen, ImGuiSelectableFlags_SpanAllColumns | ImGuiSelectableFlags_AllowDoubleClick)) {
 								if (ImGui::IsMouseDoubleClicked(0)) {
 									// Open or reuse the cell lighting widget
-									if (currentCellLightingWidget && currentCellLightingWidget->cell == cell) {
+									if (currentCellLightingWidget && currentCellLightingWidget->GetCell() == cell) {
 										currentCellLightingWidget->SetOpen(true);
 									} else {
 										currentCellLightingWidget = std::make_unique<CellLightingWidget>(cell);
@@ -522,7 +522,7 @@ void EditorWindow::ShowObjectsWindow()
 
 							// Enter key to open
 							if (isOpen && ImGui::IsKeyPressed(ImGuiKey_Enter)) {
-								if (currentCellLightingWidget && currentCellLightingWidget->cell == cell) {
+								if (currentCellLightingWidget && currentCellLightingWidget->GetCell() == cell) {
 									currentCellLightingWidget->SetOpen(true);
 								}
 							}
@@ -975,7 +975,7 @@ void EditorWindow::RenderUI()
 				if (ImGui::MenuItem("Edit Current Cell Lighting")) {
 					// Check if widget already exists
 					bool found = false;
-					if (currentCellLightingWidget && currentCellLightingWidget->cell == player->parentCell) {
+					if (currentCellLightingWidget && currentCellLightingWidget->GetCell() == player->parentCell) {
 						currentCellLightingWidget->SetOpen(true);
 						found = true;
 					}

--- a/src/WeatherEditor/Weather/CellLightingWidget.cpp
+++ b/src/WeatherEditor/Weather/CellLightingWidget.cpp
@@ -46,12 +46,12 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 
 void CellLightingWidget::DrawWidget()
 {
-	WeatherUtils::SetCurrentWidget(this);
 	ImGui::SetNextWindowSizeConstraints(ImVec2(600, 0), ImVec2(FLT_MAX, FLT_MAX));
 	if (!ImGui::Begin(GetEditorID().c_str(), &open, ImGuiWindowFlags_NoSavedSettings | kStickyHeaderFlags)) {
 		ImGui::End();
 		return;
 	}
+	WeatherUtils::SetCurrentWidget(this);
 	DrawWidgetHeader("##CellLightingSearch", true, true);
 
 	if (!cell || !cell->IsInteriorCell()) {
@@ -204,15 +204,16 @@ void CellLightingWidget::LoadSettings()
 	if (!lighting)
 		return;
 
-	try {
-		if (!js.empty()) {
-			settings = js;
-		} else {
+	settings = vanillaSettings;
+	if (!js.empty()) {
+		try {
+			nlohmann::json merged = vanillaSettings;
+			merged.merge_patch(js);
+			settings = merged.get<Settings>();
+		} catch (const std::exception& e) {
+			logger::error("CellLighting {}: Failed to load from JSON: {}", GetEditorID(), e.what());
 			settings = vanillaSettings;
 		}
-	} catch (const std::exception& e) {
-		logger::error("CellLighting {}: Failed to load from JSON: {}", GetEditorID(), e.what());
-		settings = vanillaSettings;
 	}
 
 	originalSettings = settings;

--- a/src/WeatherEditor/Weather/CellLightingWidget.cpp
+++ b/src/WeatherEditor/Weather/CellLightingWidget.cpp
@@ -48,9 +48,11 @@ void CellLightingWidget::DrawWidget()
 {
 	WeatherUtils::SetCurrentWidget(this);
 	ImGui::SetNextWindowSizeConstraints(ImVec2(600, 0), ImVec2(FLT_MAX, FLT_MAX));
-	if (ImGui::Begin(GetEditorID().c_str(), &open, ImGuiWindowFlags_NoSavedSettings | kStickyHeaderFlags)) {
-		DrawWidgetHeader("##CellLightingSearch", true, true);
+	if (!ImGui::Begin(GetEditorID().c_str(), &open, ImGuiWindowFlags_NoSavedSettings | kStickyHeaderFlags)) {
+		ImGui::End();
+		return;
 	}
+	DrawWidgetHeader("##CellLightingSearch", true, true);
 
 	if (!cell || !cell->IsInteriorCell()) {
 		auto& palette = Menu::GetSingleton()->GetTheme().StatusPalette;
@@ -189,7 +191,7 @@ void CellLightingWidget::DrawWidget()
 		if (changed && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
 			ApplyChanges();
 		}
-	}
+	}  // end interior cell else-branch
 	ImGui::End();
 }
 

--- a/src/WeatherEditor/Weather/CellLightingWidget.cpp
+++ b/src/WeatherEditor/Weather/CellLightingWidget.cpp
@@ -1,6 +1,7 @@
 #include "CellLightingWidget.h"
 #include "../EditorWindow.h"
 #include "../WeatherUtils.h"
+#include "Menu.h"
 
 void CellLightingWidget::DrawWidget()
 {
@@ -11,10 +12,11 @@ void CellLightingWidget::DrawWidget()
 	}
 
 	if (!cell || !cell->IsInteriorCell()) {
-		ImGui::TextColored(ImVec4(1.0f, 0.7f, 0.0f, 1.0f), "This cell is not an interior cell.");
+		auto& palette = Menu::GetSingleton()->GetTheme().StatusPalette;
+		ImGui::TextColored(palette.Warning, "This cell is not an interior cell.");
 		ImGui::TextWrapped("Cell lighting properties only apply to interior cells.");
 	} else if (!cell->GetLighting()) {
-		ImGui::TextColored(ImVec4(1.0f, 0.0f, 0.0f, 1.0f), "No lighting data available for this cell.");
+		ImGui::TextColored(Menu::GetSingleton()->GetTheme().StatusPalette.Error, "No lighting data available for this cell.");
 	} else {
 		bool changed = false;
 

--- a/src/WeatherEditor/Weather/CellLightingWidget.cpp
+++ b/src/WeatherEditor/Weather/CellLightingWidget.cpp
@@ -3,6 +3,47 @@
 #include "../WeatherUtils.h"
 #include "Menu.h"
 
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
+	CellLightingWidget::DALC,
+	xPlus, xMinus,
+	yPlus, yMinus,
+	zPlus, zMinus,
+	specular,
+	fresnelPower)
+
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
+	CellLightingWidget::Inherit,
+	ambientColor,
+	directionalColor,
+	fogColor,
+	fogNear,
+	fogFar,
+	directionalRotation,
+	directionalFade,
+	clipDistance,
+	fogPower,
+	fogMax,
+	lightFadeDistances)
+
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
+	CellLightingWidget::Settings,
+	ambient,
+	directional,
+	fogColorNear,
+	fogColorFar,
+	fogNear,
+	fogFar,
+	fogPower,
+	fogClamp,
+	directionalFade,
+	clipDist,
+	lightFadeStart,
+	lightFadeEnd,
+	directionalXY,
+	directionalZ,
+	dalc,
+	inherit)
+
 void CellLightingWidget::DrawWidget()
 {
 	WeatherUtils::SetCurrentWidget(this);
@@ -63,21 +104,21 @@ void CellLightingWidget::DrawWidget()
 				BeginScrollableContent("##DAmbientScroll");
 				ImGui::SeparatorText("Directional Ambient Lighting (DALC)");
 
-				if (WeatherUtils::DrawColorEdit("X+ (Right)", settings.directionalXPlus))
+				if (WeatherUtils::DrawColorEdit("X+ (Right)", settings.dalc.xPlus))
 					changed = true;
-				if (WeatherUtils::DrawColorEdit("X- (Left)", settings.directionalXMinus))
+				if (WeatherUtils::DrawColorEdit("X- (Left)", settings.dalc.xMinus))
 					changed = true;
-				if (WeatherUtils::DrawColorEdit("Y+ (Front)", settings.directionalYPlus))
+				if (WeatherUtils::DrawColorEdit("Y+ (Front)", settings.dalc.yPlus))
 					changed = true;
-				if (WeatherUtils::DrawColorEdit("Y- (Back)", settings.directionalYMinus))
+				if (WeatherUtils::DrawColorEdit("Y- (Back)", settings.dalc.yMinus))
 					changed = true;
-				if (WeatherUtils::DrawColorEdit("Z+ (Up)", settings.directionalZPlus))
+				if (WeatherUtils::DrawColorEdit("Z+ (Up)", settings.dalc.zPlus))
 					changed = true;
-				if (WeatherUtils::DrawColorEdit("Z- (Down)", settings.directionalZMinus))
+				if (WeatherUtils::DrawColorEdit("Z- (Down)", settings.dalc.zMinus))
 					changed = true;
-				if (WeatherUtils::DrawColorEdit("Specular", settings.directionalSpecular))
+				if (WeatherUtils::DrawColorEdit("Specular", settings.dalc.specular))
 					changed = true;
-				if (WeatherUtils::DrawSliderFloat("Fresnel Power", settings.fresnelPower, 0.0f, 10.0f))
+				if (WeatherUtils::DrawSliderFloat("Fresnel Power", settings.dalc.fresnelPower, 0.0f, 10.0f))
 					changed = true;
 
 				EndScrollableContent();
@@ -115,27 +156,27 @@ void CellLightingWidget::DrawWidget()
 				ImGui::TextWrapped("These flags control which lighting properties are inherited from the cell's lighting template.");
 				ImGui::Separator();
 
-				if (ImGui::Checkbox("Inherit Ambient Color", &settings.inheritAmbientColor))
+				if (ImGui::Checkbox("Inherit Ambient Color", &settings.inherit.ambientColor))
 					changed = true;
-				if (ImGui::Checkbox("Inherit Directional Color", &settings.inheritDirectionalColor))
+				if (ImGui::Checkbox("Inherit Directional Color", &settings.inherit.directionalColor))
 					changed = true;
-				if (ImGui::Checkbox("Inherit Fog Color", &settings.inheritFogColor))
+				if (ImGui::Checkbox("Inherit Fog Color", &settings.inherit.fogColor))
 					changed = true;
-				if (ImGui::Checkbox("Inherit Fog Near", &settings.inheritFogNear))
+				if (ImGui::Checkbox("Inherit Fog Near", &settings.inherit.fogNear))
 					changed = true;
-				if (ImGui::Checkbox("Inherit Fog Far", &settings.inheritFogFar))
+				if (ImGui::Checkbox("Inherit Fog Far", &settings.inherit.fogFar))
 					changed = true;
-				if (ImGui::Checkbox("Inherit Directional Rotation", &settings.inheritDirectionalRotation))
+				if (ImGui::Checkbox("Inherit Directional Rotation", &settings.inherit.directionalRotation))
 					changed = true;
-				if (ImGui::Checkbox("Inherit Directional Fade", &settings.inheritDirectionalFade))
+				if (ImGui::Checkbox("Inherit Directional Fade", &settings.inherit.directionalFade))
 					changed = true;
-				if (ImGui::Checkbox("Inherit Clip Distance", &settings.inheritClipDistance))
+				if (ImGui::Checkbox("Inherit Clip Distance", &settings.inherit.clipDistance))
 					changed = true;
-				if (ImGui::Checkbox("Inherit Fog Power", &settings.inheritFogPower))
+				if (ImGui::Checkbox("Inherit Fog Power", &settings.inherit.fogPower))
 					changed = true;
-				if (ImGui::Checkbox("Inherit Fog Max (Clamp)", &settings.inheritFogMax))
+				if (ImGui::Checkbox("Inherit Fog Max (Clamp)", &settings.inherit.fogMax))
 					changed = true;
-				if (ImGui::Checkbox("Inherit Light Fade Distances", &settings.inheritLightFadeDistances))
+				if (ImGui::Checkbox("Inherit Light Fade Distances", &settings.inherit.lightFadeDistances))
 					changed = true;
 
 				EndScrollableContent();
@@ -161,113 +202,14 @@ void CellLightingWidget::LoadSettings()
 	if (!lighting)
 		return;
 
-	// Try to load from JSON first
-	if (!js.empty()) {
-		settings = vanillaSettings;
-		try {
-			if (js.contains("ambient")) {
-				auto arr = js["ambient"];
-				if (arr.is_array() && arr.size() == 3) {
-					settings.ambient = { arr[0], arr[1], arr[2] };
-				}
-			}
-			if (js.contains("directional")) {
-				auto arr = js["directional"];
-				if (arr.is_array() && arr.size() == 3) {
-					settings.directional = { arr[0], arr[1], arr[2] };
-				}
-			}
-			if (js.contains("fogColorNear")) {
-				auto arr = js["fogColorNear"];
-				if (arr.is_array() && arr.size() == 3) {
-					settings.fogColorNear = { arr[0], arr[1], arr[2] };
-				}
-			}
-			if (js.contains("fogColorFar")) {
-				auto arr = js["fogColorFar"];
-				if (arr.is_array() && arr.size() == 3) {
-					settings.fogColorFar = { arr[0], arr[1], arr[2] };
-				}
-			}
-			if (js.contains("fogNear"))
-				settings.fogNear = js["fogNear"];
-			if (js.contains("fogFar"))
-				settings.fogFar = js["fogFar"];
-			if (js.contains("fogPower"))
-				settings.fogPower = js["fogPower"];
-			if (js.contains("fogClamp"))
-				settings.fogClamp = js["fogClamp"];
-			if (js.contains("directionalFade"))
-				settings.directionalFade = js["directionalFade"];
-			if (js.contains("clipDist"))
-				settings.clipDist = js["clipDist"];
-			if (js.contains("lightFadeStart"))
-				settings.lightFadeStart = js["lightFadeStart"];
-			if (js.contains("lightFadeEnd"))
-				settings.lightFadeEnd = js["lightFadeEnd"];
-			if (js.contains("directionalXY"))
-				settings.directionalXY = js["directionalXY"];
-			if (js.contains("directionalZ"))
-				settings.directionalZ = js["directionalZ"];
-
-			if (js.contains("dalc")) {
-				auto& dalc = js["dalc"];
-				if (dalc.contains("xPlus") && dalc["xPlus"].is_array() && dalc["xPlus"].size() == 3) {
-					settings.directionalXPlus = { dalc["xPlus"][0], dalc["xPlus"][1], dalc["xPlus"][2] };
-				}
-				if (dalc.contains("xMinus") && dalc["xMinus"].is_array() && dalc["xMinus"].size() == 3) {
-					settings.directionalXMinus = { dalc["xMinus"][0], dalc["xMinus"][1], dalc["xMinus"][2] };
-				}
-				if (dalc.contains("yPlus") && dalc["yPlus"].is_array() && dalc["yPlus"].size() == 3) {
-					settings.directionalYPlus = { dalc["yPlus"][0], dalc["yPlus"][1], dalc["yPlus"][2] };
-				}
-				if (dalc.contains("yMinus") && dalc["yMinus"].is_array() && dalc["yMinus"].size() == 3) {
-					settings.directionalYMinus = { dalc["yMinus"][0], dalc["yMinus"][1], dalc["yMinus"][2] };
-				}
-				if (dalc.contains("zPlus") && dalc["zPlus"].is_array() && dalc["zPlus"].size() == 3) {
-					settings.directionalZPlus = { dalc["zPlus"][0], dalc["zPlus"][1], dalc["zPlus"][2] };
-				}
-				if (dalc.contains("zMinus") && dalc["zMinus"].is_array() && dalc["zMinus"].size() == 3) {
-					settings.directionalZMinus = { dalc["zMinus"][0], dalc["zMinus"][1], dalc["zMinus"][2] };
-				}
-				if (dalc.contains("specular") && dalc["specular"].is_array() && dalc["specular"].size() == 3) {
-					settings.directionalSpecular = { dalc["specular"][0], dalc["specular"][1], dalc["specular"][2] };
-				}
-				if (dalc.contains("fresnelPower"))
-					settings.fresnelPower = dalc["fresnelPower"];
-			}
-
-			if (js.contains("inherit")) {
-				auto& inherit = js["inherit"];
-				if (inherit.contains("ambientColor"))
-					settings.inheritAmbientColor = inherit["ambientColor"];
-				if (inherit.contains("directionalColor"))
-					settings.inheritDirectionalColor = inherit["directionalColor"];
-				if (inherit.contains("fogColor"))
-					settings.inheritFogColor = inherit["fogColor"];
-				if (inherit.contains("fogNear"))
-					settings.inheritFogNear = inherit["fogNear"];
-				if (inherit.contains("fogFar"))
-					settings.inheritFogFar = inherit["fogFar"];
-				if (inherit.contains("directionalRotation"))
-					settings.inheritDirectionalRotation = inherit["directionalRotation"];
-				if (inherit.contains("directionalFade"))
-					settings.inheritDirectionalFade = inherit["directionalFade"];
-				if (inherit.contains("clipDistance"))
-					settings.inheritClipDistance = inherit["clipDistance"];
-				if (inherit.contains("fogPower"))
-					settings.inheritFogPower = inherit["fogPower"];
-				if (inherit.contains("fogMax"))
-					settings.inheritFogMax = inherit["fogMax"];
-				if (inherit.contains("lightFadeDistances"))
-					settings.inheritLightFadeDistances = inherit["lightFadeDistances"];
-			}
-
-		} catch (const std::exception& e) {
-			logger::error("CellLighting {}: Failed to load from JSON: {}", GetEditorID(), e.what());
+	try {
+		if (!js.empty()) {
+			settings = js;
+		} else {
 			settings = vanillaSettings;
 		}
-	} else {
+	} catch (const std::exception& e) {
+		logger::error("CellLighting {}: Failed to load from JSON: {}", GetEditorID(), e.what());
 		settings = vanillaSettings;
 	}
 
@@ -302,66 +244,32 @@ void CellLightingWidget::LoadFromGameSettings()
 	settings.directionalZ = lighting->directionalZ;
 
 	auto& dalc = lighting->directionalAmbientLightingColors;
-	ColorToFloat3(dalc.directional.x.max, settings.directionalXPlus);
-	ColorToFloat3(dalc.directional.x.min, settings.directionalXMinus);
-	ColorToFloat3(dalc.directional.y.max, settings.directionalYPlus);
-	ColorToFloat3(dalc.directional.y.min, settings.directionalYMinus);
-	ColorToFloat3(dalc.directional.z.max, settings.directionalZPlus);
-	ColorToFloat3(dalc.directional.z.min, settings.directionalZMinus);
-	ColorToFloat3(dalc.specular, settings.directionalSpecular);
-	settings.fresnelPower = dalc.fresnelPower;
+	ColorToFloat3(dalc.directional.x.max, settings.dalc.xPlus);
+	ColorToFloat3(dalc.directional.x.min, settings.dalc.xMinus);
+	ColorToFloat3(dalc.directional.y.max, settings.dalc.yPlus);
+	ColorToFloat3(dalc.directional.y.min, settings.dalc.yMinus);
+	ColorToFloat3(dalc.directional.z.max, settings.dalc.zPlus);
+	ColorToFloat3(dalc.directional.z.min, settings.dalc.zMinus);
+	ColorToFloat3(dalc.specular, settings.dalc.specular);
+	settings.dalc.fresnelPower = dalc.fresnelPower;
 
 	auto flags = lighting->lightingTemplateInheritanceFlags;
-	settings.inheritAmbientColor = flags.any(RE::INTERIOR_DATA::Inherit::kAmbientColor);
-	settings.inheritDirectionalColor = flags.any(RE::INTERIOR_DATA::Inherit::kDirectionalColor);
-	settings.inheritFogColor = flags.any(RE::INTERIOR_DATA::Inherit::kFogColor);
-	settings.inheritFogNear = flags.any(RE::INTERIOR_DATA::Inherit::kFogNear);
-	settings.inheritFogFar = flags.any(RE::INTERIOR_DATA::Inherit::kFogFar);
-	settings.inheritDirectionalRotation = flags.any(RE::INTERIOR_DATA::Inherit::kDirectionalRotation);
-	settings.inheritDirectionalFade = flags.any(RE::INTERIOR_DATA::Inherit::kDirectionalFade);
-	settings.inheritClipDistance = flags.any(RE::INTERIOR_DATA::Inherit::kClipDistance);
-	settings.inheritFogPower = flags.any(RE::INTERIOR_DATA::Inherit::kFogPower);
-	settings.inheritFogMax = flags.any(RE::INTERIOR_DATA::Inherit::kFogMax);
-	settings.inheritLightFadeDistances = flags.any(RE::INTERIOR_DATA::Inherit::kLightFadeDistances);
+	settings.inherit.ambientColor = flags.any(RE::INTERIOR_DATA::Inherit::kAmbientColor);
+	settings.inherit.directionalColor = flags.any(RE::INTERIOR_DATA::Inherit::kDirectionalColor);
+	settings.inherit.fogColor = flags.any(RE::INTERIOR_DATA::Inherit::kFogColor);
+	settings.inherit.fogNear = flags.any(RE::INTERIOR_DATA::Inherit::kFogNear);
+	settings.inherit.fogFar = flags.any(RE::INTERIOR_DATA::Inherit::kFogFar);
+	settings.inherit.directionalRotation = flags.any(RE::INTERIOR_DATA::Inherit::kDirectionalRotation);
+	settings.inherit.directionalFade = flags.any(RE::INTERIOR_DATA::Inherit::kDirectionalFade);
+	settings.inherit.clipDistance = flags.any(RE::INTERIOR_DATA::Inherit::kClipDistance);
+	settings.inherit.fogPower = flags.any(RE::INTERIOR_DATA::Inherit::kFogPower);
+	settings.inherit.fogMax = flags.any(RE::INTERIOR_DATA::Inherit::kFogMax);
+	settings.inherit.lightFadeDistances = flags.any(RE::INTERIOR_DATA::Inherit::kLightFadeDistances);
 }
 
 void CellLightingWidget::SaveSettings()
 {
-	js["ambient"] = { settings.ambient.x, settings.ambient.y, settings.ambient.z };
-	js["directional"] = { settings.directional.x, settings.directional.y, settings.directional.z };
-	js["fogColorNear"] = { settings.fogColorNear.x, settings.fogColorNear.y, settings.fogColorNear.z };
-	js["fogColorFar"] = { settings.fogColorFar.x, settings.fogColorFar.y, settings.fogColorFar.z };
-	js["fogNear"] = settings.fogNear;
-	js["fogFar"] = settings.fogFar;
-	js["fogPower"] = settings.fogPower;
-	js["fogClamp"] = settings.fogClamp;
-	js["directionalFade"] = settings.directionalFade;
-	js["clipDist"] = settings.clipDist;
-	js["lightFadeStart"] = settings.lightFadeStart;
-	js["lightFadeEnd"] = settings.lightFadeEnd;
-	js["directionalXY"] = settings.directionalXY;
-	js["directionalZ"] = settings.directionalZ;
-
-	js["dalc"]["xPlus"] = { settings.directionalXPlus.x, settings.directionalXPlus.y, settings.directionalXPlus.z };
-	js["dalc"]["xMinus"] = { settings.directionalXMinus.x, settings.directionalXMinus.y, settings.directionalXMinus.z };
-	js["dalc"]["yPlus"] = { settings.directionalYPlus.x, settings.directionalYPlus.y, settings.directionalYPlus.z };
-	js["dalc"]["yMinus"] = { settings.directionalYMinus.x, settings.directionalYMinus.y, settings.directionalYMinus.z };
-	js["dalc"]["zPlus"] = { settings.directionalZPlus.x, settings.directionalZPlus.y, settings.directionalZPlus.z };
-	js["dalc"]["zMinus"] = { settings.directionalZMinus.x, settings.directionalZMinus.y, settings.directionalZMinus.z };
-	js["dalc"]["specular"] = { settings.directionalSpecular.x, settings.directionalSpecular.y, settings.directionalSpecular.z };
-	js["dalc"]["fresnelPower"] = settings.fresnelPower;
-
-	js["inherit"]["ambientColor"] = settings.inheritAmbientColor;
-	js["inherit"]["directionalColor"] = settings.inheritDirectionalColor;
-	js["inherit"]["fogColor"] = settings.inheritFogColor;
-	js["inherit"]["fogNear"] = settings.inheritFogNear;
-	js["inherit"]["fogFar"] = settings.inheritFogFar;
-	js["inherit"]["directionalRotation"] = settings.inheritDirectionalRotation;
-	js["inherit"]["directionalFade"] = settings.inheritDirectionalFade;
-	js["inherit"]["clipDistance"] = settings.inheritClipDistance;
-	js["inherit"]["fogPower"] = settings.inheritFogPower;
-	js["inherit"]["fogMax"] = settings.inheritFogMax;
-	js["inherit"]["lightFadeDistances"] = settings.inheritLightFadeDistances;
+	js = settings;
 	originalSettings = settings;
 }
 
@@ -396,38 +304,38 @@ void CellLightingWidget::ApplyChanges()
 
 	// Apply directional ambient lighting colors
 	auto& dalc = lighting->directionalAmbientLightingColors;
-	Float3ToColor(settings.directionalXPlus, dalc.directional.x.max);
-	Float3ToColor(settings.directionalXMinus, dalc.directional.x.min);
-	Float3ToColor(settings.directionalYPlus, dalc.directional.y.max);
-	Float3ToColor(settings.directionalYMinus, dalc.directional.y.min);
-	Float3ToColor(settings.directionalZPlus, dalc.directional.z.max);
-	Float3ToColor(settings.directionalZMinus, dalc.directional.z.min);
-	Float3ToColor(settings.directionalSpecular, dalc.specular);
-	dalc.fresnelPower = settings.fresnelPower;
+	Float3ToColor(settings.dalc.xPlus, dalc.directional.x.max);
+	Float3ToColor(settings.dalc.xMinus, dalc.directional.x.min);
+	Float3ToColor(settings.dalc.yPlus, dalc.directional.y.max);
+	Float3ToColor(settings.dalc.yMinus, dalc.directional.y.min);
+	Float3ToColor(settings.dalc.zPlus, dalc.directional.z.max);
+	Float3ToColor(settings.dalc.zMinus, dalc.directional.z.min);
+	Float3ToColor(settings.dalc.specular, dalc.specular);
+	dalc.fresnelPower = settings.dalc.fresnelPower;
 
 	// Apply inheritance flags
 	lighting->lightingTemplateInheritanceFlags.reset();
-	if (settings.inheritAmbientColor)
+	if (settings.inherit.ambientColor)
 		lighting->lightingTemplateInheritanceFlags.set(RE::INTERIOR_DATA::Inherit::kAmbientColor);
-	if (settings.inheritDirectionalColor)
+	if (settings.inherit.directionalColor)
 		lighting->lightingTemplateInheritanceFlags.set(RE::INTERIOR_DATA::Inherit::kDirectionalColor);
-	if (settings.inheritFogColor)
+	if (settings.inherit.fogColor)
 		lighting->lightingTemplateInheritanceFlags.set(RE::INTERIOR_DATA::Inherit::kFogColor);
-	if (settings.inheritFogNear)
+	if (settings.inherit.fogNear)
 		lighting->lightingTemplateInheritanceFlags.set(RE::INTERIOR_DATA::Inherit::kFogNear);
-	if (settings.inheritFogFar)
+	if (settings.inherit.fogFar)
 		lighting->lightingTemplateInheritanceFlags.set(RE::INTERIOR_DATA::Inherit::kFogFar);
-	if (settings.inheritDirectionalRotation)
+	if (settings.inherit.directionalRotation)
 		lighting->lightingTemplateInheritanceFlags.set(RE::INTERIOR_DATA::Inherit::kDirectionalRotation);
-	if (settings.inheritDirectionalFade)
+	if (settings.inherit.directionalFade)
 		lighting->lightingTemplateInheritanceFlags.set(RE::INTERIOR_DATA::Inherit::kDirectionalFade);
-	if (settings.inheritClipDistance)
+	if (settings.inherit.clipDistance)
 		lighting->lightingTemplateInheritanceFlags.set(RE::INTERIOR_DATA::Inherit::kClipDistance);
-	if (settings.inheritFogPower)
+	if (settings.inherit.fogPower)
 		lighting->lightingTemplateInheritanceFlags.set(RE::INTERIOR_DATA::Inherit::kFogPower);
-	if (settings.inheritFogMax)
+	if (settings.inherit.fogMax)
 		lighting->lightingTemplateInheritanceFlags.set(RE::INTERIOR_DATA::Inherit::kFogMax);
-	if (settings.inheritLightFadeDistances)
+	if (settings.inherit.lightFadeDistances)
 		lighting->lightingTemplateInheritanceFlags.set(RE::INTERIOR_DATA::Inherit::kLightFadeDistances);
 }
 

--- a/src/WeatherEditor/Weather/CellLightingWidget.h
+++ b/src/WeatherEditor/Weather/CellLightingWidget.h
@@ -25,14 +25,38 @@ public:
 	void RevertChanges() override;
 	bool HasUnsavedChanges() const override;
 
-	RE::TESObjectCELL* cell = nullptr;
+	// Public types required by NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT macro
+	struct DALC
+	{
+		float3 xPlus = { 1.0f, 1.0f, 1.0f };
+		float3 xMinus = { 1.0f, 1.0f, 1.0f };
+		float3 yPlus = { 1.0f, 1.0f, 1.0f };
+		float3 yMinus = { 1.0f, 1.0f, 1.0f };
+		float3 zPlus = { 1.0f, 1.0f, 1.0f };
+		float3 zMinus = { 1.0f, 1.0f, 1.0f };
+		float3 specular = { 1.0f, 1.0f, 1.0f };
+		float fresnelPower = 1.0f;
+		bool operator==(const DALC&) const = default;
+	};
 
-private:
-	void LoadFromGameSettings();
+	struct Inherit
+	{
+		bool ambientColor = false;
+		bool directionalColor = false;
+		bool fogColor = false;
+		bool fogNear = false;
+		bool fogFar = false;
+		bool directionalRotation = false;
+		bool directionalFade = false;
+		bool clipDistance = false;
+		bool fogPower = false;
+		bool fogMax = false;
+		bool lightFadeDistances = false;
+		bool operator==(const Inherit&) const = default;
+	};
 
 	struct Settings
 	{
-		// INTERIOR_DATA properties
 		float3 ambient = { 1.0f, 1.0f, 1.0f };
 		float3 directional = { 1.0f, 1.0f, 1.0f };
 		float3 fogColorNear = { 1.0f, 1.0f, 1.0f };
@@ -47,31 +71,15 @@ private:
 		float lightFadeEnd = 5000.0f;
 		uint32_t directionalXY = 0;
 		uint32_t directionalZ = 0;
-
-		// Directional ambient lighting colors (DALC equivalent)
-		float3 directionalXPlus = { 1.0f, 1.0f, 1.0f };
-		float3 directionalXMinus = { 1.0f, 1.0f, 1.0f };
-		float3 directionalYPlus = { 1.0f, 1.0f, 1.0f };
-		float3 directionalYMinus = { 1.0f, 1.0f, 1.0f };
-		float3 directionalZPlus = { 1.0f, 1.0f, 1.0f };
-		float3 directionalZMinus = { 1.0f, 1.0f, 1.0f };
-		float3 directionalSpecular = { 1.0f, 1.0f, 1.0f };
-		float fresnelPower = 1.0f;
-
-		// Inheritance flags
-		bool inheritAmbientColor = false;
-		bool inheritDirectionalColor = false;
-		bool inheritFogColor = false;
-		bool inheritFogNear = false;
-		bool inheritFogFar = false;
-		bool inheritDirectionalRotation = false;
-		bool inheritDirectionalFade = false;
-		bool inheritClipDistance = false;
-		bool inheritFogPower = false;
-		bool inheritFogMax = false;
-		bool inheritLightFadeDistances = false;
+		DALC dalc;
+		Inherit inherit;
 		bool operator==(const Settings&) const = default;
 	};
+
+private:
+	void LoadFromGameSettings();
+
+	RE::TESObjectCELL* cell = nullptr;
 
 	Settings settings;
 	Settings vanillaSettings;

--- a/src/WeatherEditor/Weather/CellLightingWidget.h
+++ b/src/WeatherEditor/Weather/CellLightingWidget.h
@@ -25,6 +25,8 @@ public:
 	void RevertChanges() override;
 	bool HasUnsavedChanges() const override;
 
+	[[nodiscard]] RE::TESObjectCELL* GetCell() const { return cell; }
+
 	// Public types required by NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT macro
 	struct DALC
 	{

--- a/src/WeatherEditor/Weather/ImageSpaceWidget.cpp
+++ b/src/WeatherEditor/Weather/ImageSpaceWidget.cpp
@@ -120,29 +120,29 @@ void ImageSpaceWidget::LoadFromGameSettings()
 	auto& data = imageSpace->data;
 
 	// HDR
-	settings.hdrEyeAdaptSpeed = data.hdr.eyeAdaptSpeed;
+	settings.hdrEyeAdaptSpeed  = data.hdr.eyeAdaptSpeed;
 	settings.hdrBloomBlurRadius = data.hdr.bloomBlurRadius;
 	settings.hdrBloomThreshold = data.hdr.bloomThreshold;
-	settings.hdrBloomScale = data.hdr.bloomScale;
-	settings.hdrWhite = data.hdr.white;
-	settings.hdrSunlightScale = data.hdr.sunlightScale;
-	settings.hdrSkyScale = data.hdr.skyScale;
+	settings.hdrBloomScale     = data.hdr.bloomScale;
+	settings.hdrWhite          = data.hdr.white;
+	settings.hdrSunlightScale  = data.hdr.sunlightScale;
+	settings.hdrSkyScale       = data.hdr.skyScale;
 
 	// Cinematic
 	settings.cinematicSaturation = data.cinematic.saturation;
 	settings.cinematicBrightness = data.cinematic.brightness;
-	settings.cinematicContrast = data.cinematic.contrast;
+	settings.cinematicContrast   = data.cinematic.contrast;
 
 	// Tint
 	settings.tintColor.x = data.tint.color.red;
 	settings.tintColor.y = data.tint.color.green;
 	settings.tintColor.z = data.tint.color.blue;
-	settings.tintAmount = data.tint.amount;
+	settings.tintAmount  = data.tint.amount;
 
 	// Depth of Field
 	settings.dofStrength = data.depthOfField.strength;
 	settings.dofDistance = data.depthOfField.distance;
-	settings.dofRange = data.depthOfField.range;
+	settings.dofRange    = data.depthOfField.range;
 }
 
 void ImageSpaceWidget::ApplyChanges()
@@ -152,30 +152,35 @@ void ImageSpaceWidget::ApplyChanges()
 
 	auto& data = imageSpace->data;
 
+	// Clamp/sanitize all fields; reject non-finite values by substituting the low bound
+	auto safeClamp = [](float v, float lo, float hi) {
+		return std::isfinite(v) ? std::clamp(v, lo, hi) : lo;
+	};
+
 	// HDR
-	data.hdr.eyeAdaptSpeed = settings.hdrEyeAdaptSpeed;
-	data.hdr.bloomBlurRadius = settings.hdrBloomBlurRadius;
-	data.hdr.bloomThreshold = settings.hdrBloomThreshold;
-	data.hdr.bloomScale = settings.hdrBloomScale;
-	data.hdr.white = settings.hdrWhite;
-	data.hdr.sunlightScale = settings.hdrSunlightScale;
-	data.hdr.skyScale = settings.hdrSkyScale;
+	data.hdr.eyeAdaptSpeed    = safeClamp(settings.hdrEyeAdaptSpeed,    0.0f,     10.0f);
+	data.hdr.bloomBlurRadius  = safeClamp(settings.hdrBloomBlurRadius,  0.0f,     10.0f);
+	data.hdr.bloomThreshold   = safeClamp(settings.hdrBloomThreshold,   0.0f,     10.0f);
+	data.hdr.bloomScale       = safeClamp(settings.hdrBloomScale,       0.0f,     10.0f);
+	data.hdr.white            = safeClamp(settings.hdrWhite,            0.0f,     10.0f);
+	data.hdr.sunlightScale    = safeClamp(settings.hdrSunlightScale,    0.0f,     50.0f);
+	data.hdr.skyScale         = safeClamp(settings.hdrSkyScale,         0.0f,     10.0f);
 
 	// Cinematic
-	data.cinematic.saturation = settings.cinematicSaturation;
-	data.cinematic.brightness = settings.cinematicBrightness;
-	data.cinematic.contrast = settings.cinematicContrast;
+	data.cinematic.saturation = safeClamp(settings.cinematicSaturation, 0.0f,      2.0f);
+	data.cinematic.brightness = safeClamp(settings.cinematicBrightness, 0.0f,      2.0f);
+	data.cinematic.contrast   = safeClamp(settings.cinematicContrast,   0.0f,      2.0f);
 
 	// Tint
-	data.tint.color.red = settings.tintColor.x;
-	data.tint.color.green = settings.tintColor.y;
-	data.tint.color.blue = settings.tintColor.z;
-	data.tint.amount = settings.tintAmount;
+	data.tint.color.red   = safeClamp(settings.tintColor.x, 0.0f, 1.0f);
+	data.tint.color.green = safeClamp(settings.tintColor.y, 0.0f, 1.0f);
+	data.tint.color.blue  = safeClamp(settings.tintColor.z, 0.0f, 1.0f);
+	data.tint.amount      = safeClamp(settings.tintAmount,  0.0f, 1.0f);
 
 	// Depth of Field
-	data.depthOfField.strength = settings.dofStrength;
-	data.depthOfField.distance = settings.dofDistance;
-	data.depthOfField.range = settings.dofRange;
+	data.depthOfField.strength = safeClamp(settings.dofStrength, 0.0f,     10.0f);
+	data.depthOfField.distance = safeClamp(settings.dofDistance, 0.0f, 10000.0f);
+	data.depthOfField.range    = safeClamp(settings.dofRange,    0.0f, 10000.0f);
 }
 
 void ImageSpaceWidget::RevertChanges()

--- a/src/WeatherEditor/Weather/ImageSpaceWidget.cpp
+++ b/src/WeatherEditor/Weather/ImageSpaceWidget.cpp
@@ -23,7 +23,6 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 
 void ImageSpaceWidget::DrawWidget()
 {
-	WeatherUtils::SetCurrentWidget(this);
 	auto editorWindow = EditorWindow::GetSingleton();
 
 	ImGui::SetNextWindowSizeConstraints(ImVec2(600, 0), ImVec2(FLT_MAX, FLT_MAX));
@@ -31,6 +30,7 @@ void ImageSpaceWidget::DrawWidget()
 		ImGui::End();
 		return;
 	}
+	WeatherUtils::SetCurrentWidget(this);
 	// Draw header with search and Save/Load/Delete buttons
 	DrawWidgetHeader("##ImageSpaceSearch", false, true);
 
@@ -87,8 +87,10 @@ void ImageSpaceWidget::DrawWidget()
 
 void ImageSpaceWidget::LoadSettings()
 {
-	if (!imageSpace)
+	if (!imageSpace) {
+		logger::warn("ImageSpaceWidget {}: imageSpace is null, skipping LoadSettings", GetEditorID());
 		return;
+	}
 
 	try {
 		if (!js.empty() && js.contains("Settings") && js["Settings"].is_object()) {

--- a/src/WeatherEditor/Weather/ImageSpaceWidget.cpp
+++ b/src/WeatherEditor/Weather/ImageSpaceWidget.cpp
@@ -120,29 +120,29 @@ void ImageSpaceWidget::LoadFromGameSettings()
 	auto& data = imageSpace->data;
 
 	// HDR
-	settings.hdrEyeAdaptSpeed  = data.hdr.eyeAdaptSpeed;
+	settings.hdrEyeAdaptSpeed = data.hdr.eyeAdaptSpeed;
 	settings.hdrBloomBlurRadius = data.hdr.bloomBlurRadius;
 	settings.hdrBloomThreshold = data.hdr.bloomThreshold;
-	settings.hdrBloomScale     = data.hdr.bloomScale;
-	settings.hdrWhite          = data.hdr.white;
-	settings.hdrSunlightScale  = data.hdr.sunlightScale;
-	settings.hdrSkyScale       = data.hdr.skyScale;
+	settings.hdrBloomScale = data.hdr.bloomScale;
+	settings.hdrWhite = data.hdr.white;
+	settings.hdrSunlightScale = data.hdr.sunlightScale;
+	settings.hdrSkyScale = data.hdr.skyScale;
 
 	// Cinematic
 	settings.cinematicSaturation = data.cinematic.saturation;
 	settings.cinematicBrightness = data.cinematic.brightness;
-	settings.cinematicContrast   = data.cinematic.contrast;
+	settings.cinematicContrast = data.cinematic.contrast;
 
 	// Tint
 	settings.tintColor.x = data.tint.color.red;
 	settings.tintColor.y = data.tint.color.green;
 	settings.tintColor.z = data.tint.color.blue;
-	settings.tintAmount  = data.tint.amount;
+	settings.tintAmount = data.tint.amount;
 
 	// Depth of Field
 	settings.dofStrength = data.depthOfField.strength;
 	settings.dofDistance = data.depthOfField.distance;
-	settings.dofRange    = data.depthOfField.range;
+	settings.dofRange = data.depthOfField.range;
 }
 
 void ImageSpaceWidget::ApplyChanges()
@@ -158,29 +158,29 @@ void ImageSpaceWidget::ApplyChanges()
 	};
 
 	// HDR
-	data.hdr.eyeAdaptSpeed    = safeClamp(settings.hdrEyeAdaptSpeed,    0.0f,     10.0f);
-	data.hdr.bloomBlurRadius  = safeClamp(settings.hdrBloomBlurRadius,  0.0f,     10.0f);
-	data.hdr.bloomThreshold   = safeClamp(settings.hdrBloomThreshold,   0.0f,     10.0f);
-	data.hdr.bloomScale       = safeClamp(settings.hdrBloomScale,       0.0f,     10.0f);
-	data.hdr.white            = safeClamp(settings.hdrWhite,            0.0f,     10.0f);
-	data.hdr.sunlightScale    = safeClamp(settings.hdrSunlightScale,    0.0f,     50.0f);
-	data.hdr.skyScale         = safeClamp(settings.hdrSkyScale,         0.0f,     10.0f);
+	data.hdr.eyeAdaptSpeed = safeClamp(settings.hdrEyeAdaptSpeed, 0.0f, 10.0f);
+	data.hdr.bloomBlurRadius = safeClamp(settings.hdrBloomBlurRadius, 0.0f, 10.0f);
+	data.hdr.bloomThreshold = safeClamp(settings.hdrBloomThreshold, 0.0f, 10.0f);
+	data.hdr.bloomScale = safeClamp(settings.hdrBloomScale, 0.0f, 10.0f);
+	data.hdr.white = safeClamp(settings.hdrWhite, 0.0f, 10.0f);
+	data.hdr.sunlightScale = safeClamp(settings.hdrSunlightScale, 0.0f, 50.0f);
+	data.hdr.skyScale = safeClamp(settings.hdrSkyScale, 0.0f, 10.0f);
 
 	// Cinematic
-	data.cinematic.saturation = safeClamp(settings.cinematicSaturation, 0.0f,      2.0f);
-	data.cinematic.brightness = safeClamp(settings.cinematicBrightness, 0.0f,      2.0f);
-	data.cinematic.contrast   = safeClamp(settings.cinematicContrast,   0.0f,      2.0f);
+	data.cinematic.saturation = safeClamp(settings.cinematicSaturation, 0.0f, 2.0f);
+	data.cinematic.brightness = safeClamp(settings.cinematicBrightness, 0.0f, 2.0f);
+	data.cinematic.contrast = safeClamp(settings.cinematicContrast, 0.0f, 2.0f);
 
 	// Tint
-	data.tint.color.red   = safeClamp(settings.tintColor.x, 0.0f, 1.0f);
+	data.tint.color.red = safeClamp(settings.tintColor.x, 0.0f, 1.0f);
 	data.tint.color.green = safeClamp(settings.tintColor.y, 0.0f, 1.0f);
-	data.tint.color.blue  = safeClamp(settings.tintColor.z, 0.0f, 1.0f);
-	data.tint.amount      = safeClamp(settings.tintAmount,  0.0f, 1.0f);
+	data.tint.color.blue = safeClamp(settings.tintColor.z, 0.0f, 1.0f);
+	data.tint.amount = safeClamp(settings.tintAmount, 0.0f, 1.0f);
 
 	// Depth of Field
-	data.depthOfField.strength = safeClamp(settings.dofStrength, 0.0f,     10.0f);
+	data.depthOfField.strength = safeClamp(settings.dofStrength, 0.0f, 10.0f);
 	data.depthOfField.distance = safeClamp(settings.dofDistance, 0.0f, 10000.0f);
-	data.depthOfField.range    = safeClamp(settings.dofRange,    0.0f, 10000.0f);
+	data.depthOfField.range = safeClamp(settings.dofRange, 0.0f, 10000.0f);
 }
 
 void ImageSpaceWidget::RevertChanges()

--- a/src/WeatherEditor/Weather/ImageSpaceWidget.cpp
+++ b/src/WeatherEditor/Weather/ImageSpaceWidget.cpp
@@ -27,12 +27,15 @@ void ImageSpaceWidget::DrawWidget()
 	auto editorWindow = EditorWindow::GetSingleton();
 
 	ImGui::SetNextWindowSizeConstraints(ImVec2(600, 0), ImVec2(FLT_MAX, FLT_MAX));
-	if (ImGui::Begin(GetEditorID().c_str(), &open, ImGuiWindowFlags_NoSavedSettings | kStickyHeaderFlags)) {
-		// Draw header with search and Save/Load/Delete buttons
-		DrawWidgetHeader("##ImageSpaceSearch", false, true);
+	if (!ImGui::Begin(GetEditorID().c_str(), &open, ImGuiWindowFlags_NoSavedSettings | kStickyHeaderFlags)) {
+		ImGui::End();
+		return;
 	}
-	BeginScrollableContent("##ISScroll");
-	{
+	// Draw header with search and Save/Load/Delete buttons
+	DrawWidgetHeader("##ImageSpaceSearch", false, true);
+
+		BeginScrollableContent("##ISScroll");
+		{
 		// Draw all settings in a unified table
 		if (PropertyDrawer::BeginTable("ImageSpaceSettings", 200.0f)) {
 			bool changed = false;
@@ -77,8 +80,8 @@ void ImageSpaceWidget::DrawWidget()
 				ApplyChanges();
 			}
 		}
-	}
-	EndScrollableContent();
+		}
+		EndScrollableContent();
 	ImGui::End();
 }
 

--- a/src/WeatherEditor/Weather/ImageSpaceWidget.cpp
+++ b/src/WeatherEditor/Weather/ImageSpaceWidget.cpp
@@ -34,8 +34,8 @@ void ImageSpaceWidget::DrawWidget()
 	// Draw header with search and Save/Load/Delete buttons
 	DrawWidgetHeader("##ImageSpaceSearch", false, true);
 
-		BeginScrollableContent("##ISScroll");
-		{
+	BeginScrollableContent("##ISScroll");
+	{
 		// Draw all settings in a unified table
 		if (PropertyDrawer::BeginTable("ImageSpaceSettings", 200.0f)) {
 			bool changed = false;
@@ -80,8 +80,8 @@ void ImageSpaceWidget::DrawWidget()
 				ApplyChanges();
 			}
 		}
-		}
-		EndScrollableContent();
+	}
+	EndScrollableContent();
 	ImGui::End();
 }
 

--- a/src/WeatherEditor/Weather/ImageSpaceWidget.cpp
+++ b/src/WeatherEditor/Weather/ImageSpaceWidget.cpp
@@ -2,9 +2,6 @@
 
 #include "../EditorWindow.h"
 #include "../WeatherUtils.h"
-#include "Util.h"
-
-#include <filesystem>
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	ImageSpaceWidget::Settings,
@@ -23,10 +20,6 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	dofStrength,
 	dofDistance,
 	dofRange)
-
-ImageSpaceWidget::~ImageSpaceWidget()
-{
-}
 
 void ImageSpaceWidget::DrawWidget()
 {
@@ -91,6 +84,9 @@ void ImageSpaceWidget::DrawWidget()
 
 void ImageSpaceWidget::LoadSettings()
 {
+	if (!imageSpace)
+		return;
+
 	try {
 		if (!js.empty() && js.contains("Settings") && js["Settings"].is_object()) {
 			settings = js["Settings"];
@@ -111,40 +107,7 @@ void ImageSpaceWidget::SaveSettings()
 	originalSettings = settings;
 }
 
-void ImageSpaceWidget::SetImageSpaceValues()
-{
-	if (!imageSpace)
-		return;
-
-	auto& data = imageSpace->data;
-
-	// HDR
-	data.hdr.eyeAdaptSpeed = settings.hdrEyeAdaptSpeed;
-	data.hdr.bloomBlurRadius = settings.hdrBloomBlurRadius;
-	data.hdr.bloomThreshold = settings.hdrBloomThreshold;
-	data.hdr.bloomScale = settings.hdrBloomScale;
-	data.hdr.white = settings.hdrWhite;
-	data.hdr.sunlightScale = settings.hdrSunlightScale;
-	data.hdr.skyScale = settings.hdrSkyScale;
-
-	// Cinematic
-	data.cinematic.saturation = settings.cinematicSaturation;
-	data.cinematic.brightness = settings.cinematicBrightness;
-	data.cinematic.contrast = settings.cinematicContrast;
-
-	// Tint
-	data.tint.color.red = settings.tintColor.x;
-	data.tint.color.green = settings.tintColor.y;
-	data.tint.color.blue = settings.tintColor.z;
-	data.tint.amount = settings.tintAmount;
-
-	// Depth of Field
-	data.depthOfField.strength = settings.dofStrength;
-	data.depthOfField.distance = settings.dofDistance;
-	data.depthOfField.range = settings.dofRange;
-}
-
-void ImageSpaceWidget::LoadImageSpaceValues()
+void ImageSpaceWidget::LoadFromGameSettings()
 {
 	if (!imageSpace)
 		return;
@@ -177,14 +140,37 @@ void ImageSpaceWidget::LoadImageSpaceValues()
 	settings.dofRange = data.depthOfField.range;
 }
 
-void ImageSpaceWidget::LoadFromGameSettings()
-{
-	LoadImageSpaceValues();
-}
-
 void ImageSpaceWidget::ApplyChanges()
 {
-	SetImageSpaceValues();
+	if (!imageSpace)
+		return;
+
+	auto& data = imageSpace->data;
+
+	// HDR
+	data.hdr.eyeAdaptSpeed = settings.hdrEyeAdaptSpeed;
+	data.hdr.bloomBlurRadius = settings.hdrBloomBlurRadius;
+	data.hdr.bloomThreshold = settings.hdrBloomThreshold;
+	data.hdr.bloomScale = settings.hdrBloomScale;
+	data.hdr.white = settings.hdrWhite;
+	data.hdr.sunlightScale = settings.hdrSunlightScale;
+	data.hdr.skyScale = settings.hdrSkyScale;
+
+	// Cinematic
+	data.cinematic.saturation = settings.cinematicSaturation;
+	data.cinematic.brightness = settings.cinematicBrightness;
+	data.cinematic.contrast = settings.cinematicContrast;
+
+	// Tint
+	data.tint.color.red = settings.tintColor.x;
+	data.tint.color.green = settings.tintColor.y;
+	data.tint.color.blue = settings.tintColor.z;
+	data.tint.amount = settings.tintAmount;
+
+	// Depth of Field
+	data.depthOfField.strength = settings.dofStrength;
+	data.depthOfField.distance = settings.dofDistance;
+	data.depthOfField.range = settings.dofRange;
 }
 
 void ImageSpaceWidget::RevertChanges()

--- a/src/WeatherEditor/Weather/ImageSpaceWidget.h
+++ b/src/WeatherEditor/Weather/ImageSpaceWidget.h
@@ -5,21 +5,29 @@
 class ImageSpaceWidget : public Widget
 {
 public:
-	RE::TESImageSpace* imageSpace = nullptr;
-
-	ImageSpaceWidget(RE::TESImageSpace* a_imageSpace)
+	ImageSpaceWidget(RE::TESImageSpace* a_imageSpace) :
+		imageSpace(a_imageSpace)
 	{
 		if (!a_imageSpace) {
 			logger::error("ImageSpaceWidget created with null pointer");
 			return;
 		}
 		form = a_imageSpace;
-		imageSpace = a_imageSpace;
 		LoadFromGameSettings();
 		vanillaSettings = settings;
 		originalSettings = settings;
 	}
 
+	~ImageSpaceWidget() override = default;
+
+	void DrawWidget() override;
+	void LoadSettings() override;
+	void SaveSettings() override;
+	void ApplyChanges() override;
+	void RevertChanges() override;
+	bool HasUnsavedChanges() const override;
+
+	// Public type required by NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT macro
 	struct Settings
 	{
 		// HDR Settings
@@ -47,20 +55,12 @@ public:
 		bool operator==(const Settings&) const = default;
 	};
 
+private:
+	void LoadFromGameSettings();
+
+	RE::TESImageSpace* imageSpace = nullptr;
+
 	Settings settings;
 	Settings vanillaSettings;
 	Settings originalSettings;
-
-	~ImageSpaceWidget();
-
-	virtual void DrawWidget() override;
-	virtual void LoadSettings() override;
-	virtual void SaveSettings() override;
-	virtual bool HasUnsavedChanges() const override;
-
-	void SetImageSpaceValues();
-	void LoadImageSpaceValues();
-	void LoadFromGameSettings();
-	void ApplyChanges() override;
-	void RevertChanges() override;
 };

--- a/src/WeatherEditor/Weather/LensFlareWidget.cpp
+++ b/src/WeatherEditor/Weather/LensFlareWidget.cpp
@@ -2,6 +2,11 @@
 #include "../EditorWindow.h"
 #include "../WeatherUtils.h"
 
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
+	LensFlareWidget::Settings,
+	fadeDistRadiusScale,
+	colorInfluence)
+
 void LensFlareWidget::DrawWidget()
 {
 	WeatherUtils::SetCurrentWidget(this);
@@ -32,18 +37,14 @@ void LensFlareWidget::LoadSettings()
 	if (!lensFlare)
 		return;
 
-	if (!js.empty()) {
-		settings = vanillaSettings;
-		try {
-			if (js.contains("fadeDistRadiusScale"))
-				settings.fadeDistRadiusScale = js["fadeDistRadiusScale"];
-			if (js.contains("colorInfluence"))
-				settings.colorInfluence = js["colorInfluence"];
-		} catch (const std::exception& e) {
-			logger::error("LensFlare {}: Failed to load from JSON: {}", GetEditorID(), e.what());
+	try {
+		if (!js.empty()) {
+			settings = js;
+		} else {
 			settings = vanillaSettings;
 		}
-	} else {
+	} catch (const std::exception& e) {
+		logger::error("LensFlare {}: Failed to load from JSON: {}", GetEditorID(), e.what());
 		settings = vanillaSettings;
 	}
 	originalSettings = settings;
@@ -60,8 +61,7 @@ void LensFlareWidget::LoadFromGameSettings()
 
 void LensFlareWidget::SaveSettings()
 {
-	js["fadeDistRadiusScale"] = settings.fadeDistRadiusScale;
-	js["colorInfluence"] = settings.colorInfluence;
+	js = settings;
 	originalSettings = settings;
 }
 

--- a/src/WeatherEditor/Weather/LensFlareWidget.cpp
+++ b/src/WeatherEditor/Weather/LensFlareWidget.cpp
@@ -11,24 +11,27 @@ void LensFlareWidget::DrawWidget()
 {
 	WeatherUtils::SetCurrentWidget(this);
 	ImGui::SetNextWindowSizeConstraints(ImVec2(600, 0), ImVec2(FLT_MAX, FLT_MAX));
-	if (ImGui::Begin(GetEditorID().c_str(), &open, ImGuiWindowFlags_NoSavedSettings | kStickyHeaderFlags)) {
-		DrawWidgetHeader("##LensFlareSearch", true, true);
+	if (!ImGui::Begin(GetEditorID().c_str(), &open, ImGuiWindowFlags_NoSavedSettings | kStickyHeaderFlags)) {
+		ImGui::End();
+		return;
 	}
-	BeginScrollableContent("##LFScroll");
-	bool changed = false;
+	DrawWidgetHeader("##LensFlareSearch", true, true);
 
-	ImGui::SeparatorText("Fade Distance");
-	if (WeatherUtils::DrawSliderFloat("Fade Dist Radius Scale", settings.fadeDistRadiusScale, 0.0f, 10.0f))
-		changed = true;
+		BeginScrollableContent("##LFScroll");
+		bool changed = false;
 
-	ImGui::SeparatorText("Color");
-	if (WeatherUtils::DrawSliderFloat("Color Influence", settings.colorInfluence, 0.0f, 1.0f))
-		changed = true;
+		ImGui::SeparatorText("Fade Distance");
+		if (WeatherUtils::DrawSliderFloat("Fade Dist Radius Scale", settings.fadeDistRadiusScale, 0.0f, 10.0f))
+			changed = true;
 
-	if (changed && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
-		ApplyChanges();
-	}
-	EndScrollableContent();
+		ImGui::SeparatorText("Color");
+		if (WeatherUtils::DrawSliderFloat("Color Influence", settings.colorInfluence, 0.0f, 1.0f))
+			changed = true;
+
+		if (changed && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
+			ApplyChanges();
+		}
+		EndScrollableContent();
 	ImGui::End();
 }
 

--- a/src/WeatherEditor/Weather/LensFlareWidget.cpp
+++ b/src/WeatherEditor/Weather/LensFlareWidget.cpp
@@ -17,21 +17,21 @@ void LensFlareWidget::DrawWidget()
 	}
 	DrawWidgetHeader("##LensFlareSearch", true, true);
 
-		BeginScrollableContent("##LFScroll");
-		bool changed = false;
+	BeginScrollableContent("##LFScroll");
+	bool changed = false;
 
-		ImGui::SeparatorText("Fade Distance");
-		if (WeatherUtils::DrawSliderFloat("Fade Dist Radius Scale", settings.fadeDistRadiusScale, 0.0f, 10.0f))
-			changed = true;
+	ImGui::SeparatorText("Fade Distance");
+	if (WeatherUtils::DrawSliderFloat("Fade Dist Radius Scale", settings.fadeDistRadiusScale, 0.0f, 10.0f))
+		changed = true;
 
-		ImGui::SeparatorText("Color");
-		if (WeatherUtils::DrawSliderFloat("Color Influence", settings.colorInfluence, 0.0f, 1.0f))
-			changed = true;
+	ImGui::SeparatorText("Color");
+	if (WeatherUtils::DrawSliderFloat("Color Influence", settings.colorInfluence, 0.0f, 1.0f))
+		changed = true;
 
-		if (changed && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
-			ApplyChanges();
-		}
-		EndScrollableContent();
+	if (changed && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
+		ApplyChanges();
+	}
+	EndScrollableContent();
 	ImGui::End();
 }
 

--- a/src/WeatherEditor/Weather/LensFlareWidget.cpp
+++ b/src/WeatherEditor/Weather/LensFlareWidget.cpp
@@ -9,12 +9,12 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 
 void LensFlareWidget::DrawWidget()
 {
-	WeatherUtils::SetCurrentWidget(this);
 	ImGui::SetNextWindowSizeConstraints(ImVec2(600, 0), ImVec2(FLT_MAX, FLT_MAX));
 	if (!ImGui::Begin(GetEditorID().c_str(), &open, ImGuiWindowFlags_NoSavedSettings | kStickyHeaderFlags)) {
 		ImGui::End();
 		return;
 	}
+	WeatherUtils::SetCurrentWidget(this);
 	DrawWidgetHeader("##LensFlareSearch", true, true);
 
 	BeginScrollableContent("##LFScroll");
@@ -40,16 +40,22 @@ void LensFlareWidget::LoadSettings()
 	if (!lensFlare)
 		return;
 
-	try {
-		if (!js.empty()) {
-			settings = js;
-		} else {
+	settings = vanillaSettings;
+	if (!js.empty()) {
+		try {
+			nlohmann::json merged = vanillaSettings;
+			merged.merge_patch(js);
+			settings = merged.get<Settings>();
+		} catch (const std::exception& e) {
+			logger::error("LensFlare {}: Failed to load from JSON: {}", GetEditorID(), e.what());
 			settings = vanillaSettings;
 		}
-	} catch (const std::exception& e) {
-		logger::error("LensFlare {}: Failed to load from JSON: {}", GetEditorID(), e.what());
-		settings = vanillaSettings;
 	}
+
+	// Validate and clamp fields to safe ranges
+	settings.fadeDistRadiusScale = std::clamp(settings.fadeDistRadiusScale, 0.0f, 10.0f);
+	settings.colorInfluence = std::clamp(settings.colorInfluence, 0.0f, 1.0f);
+
 	originalSettings = settings;
 	ApplyChanges();
 }

--- a/src/WeatherEditor/Weather/LensFlareWidget.cpp
+++ b/src/WeatherEditor/Weather/LensFlareWidget.cpp
@@ -4,25 +4,24 @@
 
 void LensFlareWidget::DrawWidget()
 {
+	WeatherUtils::SetCurrentWidget(this);
 	ImGui::SetNextWindowSizeConstraints(ImVec2(600, 0), ImVec2(FLT_MAX, FLT_MAX));
 	if (ImGui::Begin(GetEditorID().c_str(), &open, ImGuiWindowFlags_NoSavedSettings | kStickyHeaderFlags)) {
 		DrawWidgetHeader("##LensFlareSearch", true, true);
 	}
 	BeginScrollableContent("##LFScroll");
-	{
-		bool changed = false;
+	bool changed = false;
 
-		ImGui::SeparatorText("Fade Distance");
-		if (ImGui::SliderFloat("Fade Dist Radius Scale", &settings.fadeDistRadiusScale, 0.0f, 10.0f))
-			changed = true;
+	ImGui::SeparatorText("Fade Distance");
+	if (WeatherUtils::DrawSliderFloat("Fade Dist Radius Scale", settings.fadeDistRadiusScale, 0.0f, 10.0f))
+		changed = true;
 
-		ImGui::SeparatorText("Color");
-		if (ImGui::SliderFloat("Color Influence", &settings.colorInfluence, 0.0f, 1.0f))
-			changed = true;
+	ImGui::SeparatorText("Color");
+	if (WeatherUtils::DrawSliderFloat("Color Influence", settings.colorInfluence, 0.0f, 1.0f))
+		changed = true;
 
-		if (changed && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
-			ApplyChanges();
-		}
+	if (changed && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
+		ApplyChanges();
 	}
 	EndScrollableContent();
 	ImGui::End();

--- a/src/WeatherEditor/Weather/LensFlareWidget.h
+++ b/src/WeatherEditor/Weather/LensFlareWidget.h
@@ -25,17 +25,18 @@ public:
 	void RevertChanges() override;
 	bool HasUnsavedChanges() const override;
 
-	RE::BGSLensFlare* lensFlare = nullptr;
-
-private:
-	void LoadFromGameSettings();
-
+	// Public type required by NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT macro
 	struct Settings
 	{
 		float fadeDistRadiusScale = 1.0f;
 		float colorInfluence = 0.2f;
 		bool operator==(const Settings&) const = default;
 	};
+
+private:
+	void LoadFromGameSettings();
+
+	RE::BGSLensFlare* lensFlare = nullptr;
 
 	Settings settings;
 	Settings vanillaSettings;

--- a/src/WeatherEditor/Weather/LightingTemplateWidget.cpp
+++ b/src/WeatherEditor/Weather/LightingTemplateWidget.cpp
@@ -5,7 +5,7 @@
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(LightingTemplateWidget::DirectionalColor, max, min)
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(LightingTemplateWidget::DALC, specular, fresnelPower, directional)
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(LightingTemplateWidget::Settings,
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(LightingTemplateWidget::Settings,
 	ambient,
 	directional,
 	fogColorNear,
@@ -24,12 +24,12 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(LightingTemplateWidget::Settings,
 
 void LightingTemplateWidget::DrawWidget()
 {
-	WeatherUtils::SetCurrentWidget(this);
 	ImGui::SetNextWindowSizeConstraints(ImVec2(600, 0), ImVec2(FLT_MAX, FLT_MAX));
 	if (!ImGui::Begin(GetEditorID().c_str(), &open, ImGuiWindowFlags_NoSavedSettings | kStickyHeaderFlags)) {
 		ImGui::End();
 		return;
 	}
+	WeatherUtils::SetCurrentWidget(this);
 	DrawWidgetHeader("##LightingTemplateSearch", false, true);
 
 	bool changed = false;
@@ -255,10 +255,16 @@ void LightingTemplateWidget::LoadFromGameSettings()
 
 void LightingTemplateWidget::LoadSettings()
 {
+	settings = vanillaSettings;
 	if (!js.empty()) {
-		settings = js;
-	} else {
-		settings = vanillaSettings;
+		try {
+			nlohmann::json merged = vanillaSettings;
+			merged.merge_patch(js);
+			settings = merged.get<Settings>();
+		} catch (const nlohmann::json::exception& e) {
+			logger::error("LightingTemplate {}: Failed to load from JSON: {}", GetEditorID(), e.what());
+			settings = vanillaSettings;
+		}
 	}
 	originalSettings = settings;
 	ApplyChanges();

--- a/src/WeatherEditor/Weather/LightingTemplateWidget.cpp
+++ b/src/WeatherEditor/Weather/LightingTemplateWidget.cpp
@@ -253,6 +253,34 @@ void LightingTemplateWidget::LoadFromGameSettings()
 	ColorToFloat3(dalc.directional.z.min, settings.dalc.directional[2].min);
 }
 
+static void ValidateSettings(LightingTemplateWidget::Settings& s, const LightingTemplateWidget::Settings& vanilla)
+{
+	auto safeF = [](float v, float fallback) { return std::isfinite(v) ? v : fallback; };
+	auto safeF3 = [](float3 v, float3 fallback) {
+		return (std::isfinite(v.x) && std::isfinite(v.y) && std::isfinite(v.z)) ? v : fallback;
+	};
+	s.ambient         = safeF3(s.ambient,         vanilla.ambient);
+	s.directional     = safeF3(s.directional,     vanilla.directional);
+	s.fogColorNear    = safeF3(s.fogColorNear,    vanilla.fogColorNear);
+	s.fogColorFar     = safeF3(s.fogColorFar,     vanilla.fogColorFar);
+	s.fogNear         = safeF(s.fogNear,           vanilla.fogNear);
+	s.fogFar          = safeF(s.fogFar,            vanilla.fogFar);
+	s.directionalXY   = safeF(s.directionalXY,     vanilla.directionalXY);
+	s.directionalZ    = safeF(s.directionalZ,      vanilla.directionalZ);
+	s.directionalFade = safeF(s.directionalFade,   vanilla.directionalFade);
+	s.clipDist        = safeF(s.clipDist,           vanilla.clipDist);
+	s.fogPower        = safeF(s.fogPower,           vanilla.fogPower);
+	s.fogClamp        = safeF(s.fogClamp,           vanilla.fogClamp);
+	s.lightFadeStart  = safeF(s.lightFadeStart,     vanilla.lightFadeStart);
+	s.lightFadeEnd    = safeF(s.lightFadeEnd,       vanilla.lightFadeEnd);
+	s.dalc.fresnelPower = safeF(s.dalc.fresnelPower, vanilla.dalc.fresnelPower);
+	s.dalc.specular     = safeF3(s.dalc.specular,    vanilla.dalc.specular);
+	for (int i = 0; i < 3; i++) {
+		s.dalc.directional[i].max = safeF3(s.dalc.directional[i].max, vanilla.dalc.directional[i].max);
+		s.dalc.directional[i].min = safeF3(s.dalc.directional[i].min, vanilla.dalc.directional[i].min);
+	}
+}
+
 void LightingTemplateWidget::LoadSettings()
 {
 	settings = vanillaSettings;
@@ -261,6 +289,7 @@ void LightingTemplateWidget::LoadSettings()
 			nlohmann::json merged = vanillaSettings;
 			merged.merge_patch(js);
 			settings = merged.get<Settings>();
+			ValidateSettings(settings, vanillaSettings);
 		} catch (const nlohmann::json::exception& e) {
 			logger::error("LightingTemplate {}: Failed to load from JSON: {}", GetEditorID(), e.what());
 			settings = vanillaSettings;

--- a/src/WeatherEditor/Weather/LightingTemplateWidget.cpp
+++ b/src/WeatherEditor/Weather/LightingTemplateWidget.cpp
@@ -32,9 +32,9 @@ void LightingTemplateWidget::DrawWidget()
 	}
 	DrawWidgetHeader("##LightingTemplateSearch", false, true);
 
-		bool changed = false;
+	bool changed = false;
 
-		if (ImGui::BeginTabBar("LightingTemplateSettingsTabs")) {
+	if (ImGui::BeginTabBar("LightingTemplateSettingsTabs")) {
 		if (ImGui::BeginTabItem("Basic")) {
 			BeginScrollableContent("##BasicScroll");
 			changed |= DrawBasicSettings();
@@ -56,12 +56,12 @@ void LightingTemplateWidget::DrawWidget()
 			ImGui::EndTabItem();
 		}
 
-			ImGui::EndTabBar();
-		}
+		ImGui::EndTabBar();
+	}
 
-		if (changed && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
-			ApplyChanges();
-		}
+	if (changed && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
+		ApplyChanges();
+	}
 	ImGui::End();
 }
 

--- a/src/WeatherEditor/Weather/LightingTemplateWidget.cpp
+++ b/src/WeatherEditor/Weather/LightingTemplateWidget.cpp
@@ -259,22 +259,22 @@ static void ValidateSettings(LightingTemplateWidget::Settings& s, const Lighting
 	auto safeF3 = [](float3 v, float3 fallback) {
 		return (std::isfinite(v.x) && std::isfinite(v.y) && std::isfinite(v.z)) ? v : fallback;
 	};
-	s.ambient         = safeF3(s.ambient,         vanilla.ambient);
-	s.directional     = safeF3(s.directional,     vanilla.directional);
-	s.fogColorNear    = safeF3(s.fogColorNear,    vanilla.fogColorNear);
-	s.fogColorFar     = safeF3(s.fogColorFar,     vanilla.fogColorFar);
-	s.fogNear         = safeF(s.fogNear,           vanilla.fogNear);
-	s.fogFar          = safeF(s.fogFar,            vanilla.fogFar);
-	s.directionalXY   = safeF(s.directionalXY,     vanilla.directionalXY);
-	s.directionalZ    = safeF(s.directionalZ,      vanilla.directionalZ);
-	s.directionalFade = safeF(s.directionalFade,   vanilla.directionalFade);
-	s.clipDist        = safeF(s.clipDist,           vanilla.clipDist);
-	s.fogPower        = safeF(s.fogPower,           vanilla.fogPower);
-	s.fogClamp        = safeF(s.fogClamp,           vanilla.fogClamp);
-	s.lightFadeStart  = safeF(s.lightFadeStart,     vanilla.lightFadeStart);
-	s.lightFadeEnd    = safeF(s.lightFadeEnd,       vanilla.lightFadeEnd);
+	s.ambient = safeF3(s.ambient, vanilla.ambient);
+	s.directional = safeF3(s.directional, vanilla.directional);
+	s.fogColorNear = safeF3(s.fogColorNear, vanilla.fogColorNear);
+	s.fogColorFar = safeF3(s.fogColorFar, vanilla.fogColorFar);
+	s.fogNear = safeF(s.fogNear, vanilla.fogNear);
+	s.fogFar = safeF(s.fogFar, vanilla.fogFar);
+	s.directionalXY = safeF(s.directionalXY, vanilla.directionalXY);
+	s.directionalZ = safeF(s.directionalZ, vanilla.directionalZ);
+	s.directionalFade = safeF(s.directionalFade, vanilla.directionalFade);
+	s.clipDist = safeF(s.clipDist, vanilla.clipDist);
+	s.fogPower = safeF(s.fogPower, vanilla.fogPower);
+	s.fogClamp = safeF(s.fogClamp, vanilla.fogClamp);
+	s.lightFadeStart = safeF(s.lightFadeStart, vanilla.lightFadeStart);
+	s.lightFadeEnd = safeF(s.lightFadeEnd, vanilla.lightFadeEnd);
 	s.dalc.fresnelPower = safeF(s.dalc.fresnelPower, vanilla.dalc.fresnelPower);
-	s.dalc.specular     = safeF3(s.dalc.specular,    vanilla.dalc.specular);
+	s.dalc.specular = safeF3(s.dalc.specular, vanilla.dalc.specular);
 	for (int i = 0; i < 3; i++) {
 		s.dalc.directional[i].max = safeF3(s.dalc.directional[i].max, vanilla.dalc.directional[i].max);
 		s.dalc.directional[i].min = safeF3(s.dalc.directional[i].min, vanilla.dalc.directional[i].min);

--- a/src/WeatherEditor/Weather/LightingTemplateWidget.cpp
+++ b/src/WeatherEditor/Weather/LightingTemplateWidget.cpp
@@ -26,12 +26,15 @@ void LightingTemplateWidget::DrawWidget()
 {
 	WeatherUtils::SetCurrentWidget(this);
 	ImGui::SetNextWindowSizeConstraints(ImVec2(600, 0), ImVec2(FLT_MAX, FLT_MAX));
-	if (ImGui::Begin(GetEditorID().c_str(), &open, ImGuiWindowFlags_NoSavedSettings | kStickyHeaderFlags)) {
-		DrawWidgetHeader("##LightingTemplateSearch", false, true);
+	if (!ImGui::Begin(GetEditorID().c_str(), &open, ImGuiWindowFlags_NoSavedSettings | kStickyHeaderFlags)) {
+		ImGui::End();
+		return;
 	}
-	bool changed = false;
+	DrawWidgetHeader("##LightingTemplateSearch", false, true);
 
-	if (ImGui::BeginTabBar("LightingTemplateSettingsTabs")) {
+		bool changed = false;
+
+		if (ImGui::BeginTabBar("LightingTemplateSettingsTabs")) {
 		if (ImGui::BeginTabItem("Basic")) {
 			BeginScrollableContent("##BasicScroll");
 			changed |= DrawBasicSettings();
@@ -53,12 +56,12 @@ void LightingTemplateWidget::DrawWidget()
 			ImGui::EndTabItem();
 		}
 
-		ImGui::EndTabBar();
-	}
+			ImGui::EndTabBar();
+		}
 
-	if (changed && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
-		ApplyChanges();
-	}
+		if (changed && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
+			ApplyChanges();
+		}
 	ImGui::End();
 }
 
@@ -189,8 +192,8 @@ void LightingTemplateWidget::ApplyChanges()
 
 	data.fogNear = settings.fogNear;
 	data.fogFar = settings.fogFar;
-	data.directionalXY = static_cast<std::uint32_t>(std::max(0.0f, std::round(settings.directionalXY)));
-	data.directionalZ = static_cast<std::uint32_t>(std::max(0.0f, std::round(settings.directionalZ)));
+	data.directionalXY = static_cast<std::uint32_t>(std::clamp(std::round(settings.directionalXY), 0.0f, static_cast<float>(std::numeric_limits<std::uint32_t>::max())));
+	data.directionalZ = static_cast<std::uint32_t>(std::clamp(std::round(settings.directionalZ), 0.0f, static_cast<float>(std::numeric_limits<std::uint32_t>::max())));
 	data.directionalFade = settings.directionalFade;
 	data.clipDist = settings.clipDist;
 	data.fogPower = settings.fogPower;
@@ -211,7 +214,7 @@ void LightingTemplateWidget::ApplyChanges()
 
 void LightingTemplateWidget::RevertChanges()
 {
-	settings = vanillaSettings;
+	settings = originalSettings;
 	ApplyChanges();
 }
 

--- a/src/WeatherEditor/Weather/LightingTemplateWidget.cpp
+++ b/src/WeatherEditor/Weather/LightingTemplateWidget.cpp
@@ -22,217 +22,160 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(LightingTemplateWidget::Settings,
 	lightFadeEnd,
 	dalc)
 
-LightingTemplateWidget::~LightingTemplateWidget()
-{
-}
-
 void LightingTemplateWidget::DrawWidget()
 {
 	WeatherUtils::SetCurrentWidget(this);
 	ImGui::SetNextWindowSizeConstraints(ImVec2(600, 0), ImVec2(FLT_MAX, FLT_MAX));
 	if (ImGui::Begin(GetEditorID().c_str(), &open, ImGuiWindowFlags_NoSavedSettings | kStickyHeaderFlags)) {
-		// Draw header with search and Save/Load/Delete buttons
 		DrawWidgetHeader("##LightingTemplateSearch", false, true);
 	}
-	if (ImGui::BeginTabBar("LightingTemplateSettingsTabs", ImGuiTabBarFlags_None)) {
+	bool changed = false;
+
+	if (ImGui::BeginTabBar("LightingTemplateSettingsTabs")) {
 		if (ImGui::BeginTabItem("Basic")) {
 			BeginScrollableContent("##BasicScroll");
-			DrawBasicSettings();
+			changed |= DrawBasicSettings();
 			EndScrollableContent();
 			ImGui::EndTabItem();
 		}
 
 		if (ImGui::BeginTabItem("Fog")) {
 			BeginScrollableContent("##FogScroll");
-			DrawFogSettings();
+			changed |= DrawFogSettings();
 			EndScrollableContent();
 			ImGui::EndTabItem();
 		}
 
 		if (ImGui::BeginTabItem("DALC")) {
 			BeginScrollableContent("##DALCScroll");
-			DrawDALCSettings();
+			changed |= DrawDALCSettings();
 			EndScrollableContent();
 			ImGui::EndTabItem();
 		}
 
 		ImGui::EndTabBar();
 	}
+
+	if (changed && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
+		ApplyChanges();
+	}
 	ImGui::End();
 }
 
-void LightingTemplateWidget::DrawBasicSettings()
+bool LightingTemplateWidget::DrawBasicSettings()
 {
 	bool changed = false;
 
-	if (ImGui::CollapsingHeader("Ambient & Directional", ImGuiTreeNodeFlags_DefaultOpen)) {
-		ImGui::Spacing();
-		if (MatchesSearch("Ambient Color") && WeatherUtils::DrawColorEdit("Ambient Color", settings.ambient))
-			changed = true;
-		if (MatchesSearch("Ambient Color"))
-			ImGui::Spacing();
-		if (MatchesSearch("Directional Color") && WeatherUtils::DrawColorEdit("Directional Color", settings.directional))
-			changed = true;
-		if (MatchesSearch("Directional Color"))
-			ImGui::Spacing();
-	}
+	ImGui::SeparatorText("Ambient & Directional");
+	if (WeatherUtils::DrawColorEdit("Ambient Color", settings.ambient))
+		changed = true;
+	if (WeatherUtils::DrawColorEdit("Directional Color", settings.directional))
+		changed = true;
 
-	if (ImGui::CollapsingHeader("Directional Settings", ImGuiTreeNodeFlags_DefaultOpen)) {
-		ImGui::Spacing();
-		if (MatchesSearch("Directional XY") && WeatherUtils::DrawSliderFloat("Directional XY", settings.directionalXY))
-			changed = true;
-		if (MatchesSearch("Directional XY"))
-			ImGui::Spacing();
-		if (MatchesSearch("Directional Z") && WeatherUtils::DrawSliderFloat("Directional Z", settings.directionalZ))
-			changed = true;
-		if (MatchesSearch("Directional Z"))
-			ImGui::Spacing();
-		if (MatchesSearch("Directional Fade") && WeatherUtils::DrawSliderFloat("Directional Fade", settings.directionalFade))
-			changed = true;
-		if (MatchesSearch("Directional Fade"))
-			ImGui::Spacing();
-	}
+	ImGui::SeparatorText("Directional Settings");
+	if (WeatherUtils::DrawSliderFloat("Directional XY", settings.directionalXY))
+		changed = true;
+	if (WeatherUtils::DrawSliderFloat("Directional Z", settings.directionalZ))
+		changed = true;
+	if (WeatherUtils::DrawSliderFloat("Directional Fade", settings.directionalFade))
+		changed = true;
 
-	if (ImGui::CollapsingHeader("Light Fade", ImGuiTreeNodeFlags_DefaultOpen)) {
-		ImGui::Spacing();
-		if (MatchesSearch("Light Fade Start") && WeatherUtils::DrawSliderFloat("Light Fade Start", settings.lightFadeStart))
-			changed = true;
-		if (MatchesSearch("Light Fade Start"))
-			ImGui::Spacing();
-		if (MatchesSearch("Light Fade End") && WeatherUtils::DrawSliderFloat("Light Fade End", settings.lightFadeEnd))
-			changed = true;
-		if (MatchesSearch("Light Fade End"))
-			ImGui::Spacing();
-	}
+	ImGui::SeparatorText("Light Fade");
+	if (WeatherUtils::DrawSliderFloat("Light Fade Start", settings.lightFadeStart))
+		changed = true;
+	if (WeatherUtils::DrawSliderFloat("Light Fade End", settings.lightFadeEnd))
+		changed = true;
 
-	if (ImGui::CollapsingHeader("Other", ImGuiTreeNodeFlags_DefaultOpen)) {
-		ImGui::Spacing();
-		if (MatchesSearch("Clip Distance") && WeatherUtils::DrawSliderFloat("Clip Distance", settings.clipDist))
-			changed = true;
-		if (MatchesSearch("Clip Distance"))
-			ImGui::Spacing();
-	}
+	ImGui::SeparatorText("Other");
+	if (WeatherUtils::DrawSliderFloat("Clip Distance", settings.clipDist))
+		changed = true;
 
-	if (changed && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
-		ApplyChanges();
-	}
+	return changed;
 }
 
-void LightingTemplateWidget::DrawFogSettings()
+bool LightingTemplateWidget::DrawFogSettings()
 {
 	bool changed = false;
 
-	ImGui::Spacing();
-	if (MatchesSearch("Fog Color Near") && WeatherUtils::DrawColorEdit("Fog Color Near", settings.fogColorNear))
+	ImGui::SeparatorText("Fog Colors");
+	if (WeatherUtils::DrawColorEdit("Fog Color Near", settings.fogColorNear))
 		changed = true;
-	if (MatchesSearch("Fog Color Near"))
-		ImGui::Spacing();
-	if (MatchesSearch("Fog Color Far") && WeatherUtils::DrawColorEdit("Fog Color Far", settings.fogColorFar))
+	if (WeatherUtils::DrawColorEdit("Fog Color Far", settings.fogColorFar))
 		changed = true;
-	if (MatchesSearch("Fog Color Far"))
-		ImGui::Spacing();
 
-	ImGui::Spacing();
-	if (MatchesSearch("Fog Near") && WeatherUtils::DrawSliderFloat("Fog Near", settings.fogNear))
+	ImGui::SeparatorText("Fog Distance");
+	if (WeatherUtils::DrawSliderFloat("Fog Near", settings.fogNear))
 		changed = true;
-	if (MatchesSearch("Fog Near"))
-		ImGui::Spacing();
-	if (MatchesSearch("Fog Far") && WeatherUtils::DrawSliderFloat("Fog Far", settings.fogFar))
+	if (WeatherUtils::DrawSliderFloat("Fog Far", settings.fogFar))
 		changed = true;
-	if (MatchesSearch("Fog Far"))
-		ImGui::Spacing();
 
-	ImGui::Spacing();
-	if (MatchesSearch("Fog Power") && WeatherUtils::DrawSliderFloat("Fog Power", settings.fogPower))
+	ImGui::SeparatorText("Fog Properties");
+	if (WeatherUtils::DrawSliderFloat("Fog Power", settings.fogPower))
 		changed = true;
-	if (MatchesSearch("Fog Power"))
-		ImGui::Spacing();
-	if (MatchesSearch("Fog Clamp") && WeatherUtils::DrawSliderFloat("Fog Clamp", settings.fogClamp))
+	if (WeatherUtils::DrawSliderFloat("Fog Clamp", settings.fogClamp))
 		changed = true;
-	if (MatchesSearch("Fog Clamp"))
-		ImGui::Spacing();
 
-	if (changed && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
-		ApplyChanges();
-	}
+	return changed;
 }
 
-void LightingTemplateWidget::DrawDALCSettings()
+bool LightingTemplateWidget::DrawDALCSettings()
 {
 	bool changed = false;
 
-	if (ImGui::CollapsingHeader("Basic DALC", ImGuiTreeNodeFlags_DefaultOpen)) {
-		ImGui::Spacing();
-		if (WeatherUtils::DrawColorEdit("Specular", settings.dalc.specular))
+	ImGui::SeparatorText("Basic DALC");
+	if (WeatherUtils::DrawColorEdit("Specular", settings.dalc.specular))
+		changed = true;
+	if (WeatherUtils::DrawSliderFloat("Fresnel Power", settings.dalc.fresnelPower))
+		changed = true;
+
+	ImGui::SeparatorText("Directional Colors (Time of Day)");
+	if (TOD::BeginTODTable("DALCDirectionalTable")) {
+		TOD::RenderTODHeader();
+		TOD::DrawTODSeparator();
+
+		// Prepare arrays for TOD rendering (map X,Y,Z to Sunrise,Day,Sunset,Night)
+		float3 maxColors[4];
+		float3 minColors[4];
+
+		// Map X (index 0) to Sunrise and Day
+		maxColors[TOD::Sunrise] = settings.dalc.directional[0].max;
+		maxColors[TOD::Day] = settings.dalc.directional[0].max;
+		minColors[TOD::Sunrise] = settings.dalc.directional[0].min;
+		minColors[TOD::Day] = settings.dalc.directional[0].min;
+
+		// Map Y (index 1) to Sunset
+		maxColors[TOD::Sunset] = settings.dalc.directional[1].max;
+		minColors[TOD::Sunset] = settings.dalc.directional[1].min;
+
+		// Map Z (index 2) to Night
+		maxColors[TOD::Night] = settings.dalc.directional[2].max;
+		minColors[TOD::Night] = settings.dalc.directional[2].min;
+
+		if (TOD::DrawTODColorRow("Positive Direction (+)", maxColors)) {
+			settings.dalc.directional[0].max = maxColors[TOD::Sunrise];
+			settings.dalc.directional[1].max = maxColors[TOD::Sunset];
+			settings.dalc.directional[2].max = maxColors[TOD::Night];
 			changed = true;
-		ImGui::Spacing();
-		if (WeatherUtils::DrawSliderFloat("Fresnel Power", settings.dalc.fresnelPower))
-			changed = true;
-		ImGui::Spacing();
-	}
-
-	if (ImGui::CollapsingHeader("Directional Colors (Time of Day)", ImGuiTreeNodeFlags_DefaultOpen)) {
-		// Note: The game engine uses X, Y, Z to represent time periods
-		// We map them to: X=Sunrise/Day, Y=Sunset, Z=Night for TOD display
-
-		if (TOD::BeginTODTable("DALCDirectionalTable")) {
-			TOD::RenderTODHeader();
-			TOD::DrawTODSeparator();
-
-			// Prepare arrays for TOD rendering (map X,Y,Z to Sunrise,Day,Sunset,Night)
-			float3 maxColors[4];
-			float3 minColors[4];
-
-			// Map X (index 0) to Sunrise and Day
-			maxColors[TOD::Sunrise] = settings.dalc.directional[0].max;
-			maxColors[TOD::Day] = settings.dalc.directional[0].max;
-			minColors[TOD::Sunrise] = settings.dalc.directional[0].min;
-			minColors[TOD::Day] = settings.dalc.directional[0].min;
-
-			// Map Y (index 1) to Sunset
-			maxColors[TOD::Sunset] = settings.dalc.directional[1].max;
-			minColors[TOD::Sunset] = settings.dalc.directional[1].min;
-
-			// Map Z (index 2) to Night
-			maxColors[TOD::Night] = settings.dalc.directional[2].max;
-			minColors[TOD::Night] = settings.dalc.directional[2].min;
-
-			if (TOD::DrawTODColorRow("Positive Direction (+)", maxColors)) {
-				settings.dalc.directional[0].max = maxColors[TOD::Sunrise];  // X from Sunrise
-				settings.dalc.directional[1].max = maxColors[TOD::Sunset];   // Y from Sunset
-				settings.dalc.directional[2].max = maxColors[TOD::Night];    // Z from Night
-				changed = true;
-			}
-
-			if (TOD::DrawTODColorRow("Negative Direction (-)", minColors)) {
-				settings.dalc.directional[0].min = minColors[TOD::Sunrise];  // X from Sunrise
-				settings.dalc.directional[1].min = minColors[TOD::Sunset];   // Y from Sunset
-				settings.dalc.directional[2].min = minColors[TOD::Night];    // Z from Night
-				changed = true;
-			}
-
-			TOD::EndTODTable();
 		}
+
+		if (TOD::DrawTODColorRow("Negative Direction (-)", minColors)) {
+			settings.dalc.directional[0].min = minColors[TOD::Sunrise];
+			settings.dalc.directional[1].min = minColors[TOD::Sunset];
+			settings.dalc.directional[2].min = minColors[TOD::Night];
+			changed = true;
+		}
+
+		TOD::EndTODTable();
 	}
 
-	if (changed && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
-		ApplyChanges();
-	}
+	return changed;
 }
 
 void LightingTemplateWidget::ApplyChanges()
 {
-	SetLightingTemplateValues();
-}
+	if (!lightingTemplate)
+		return;
 
-void LightingTemplateWidget::RevertChanges()
-{
-	settings = vanillaSettings;
-	ApplyChanges();
-}
-
-void LightingTemplateWidget::SetLightingTemplateValues()
-{
 	auto& data = lightingTemplate->data;
 	auto& dalc = lightingTemplate->directionalAmbientLightingColors;
 
@@ -257,15 +200,19 @@ void LightingTemplateWidget::SetLightingTemplateValues()
 
 	Float3ToColor(settings.dalc.directional[0].max, dalc.directional.x.max);
 	Float3ToColor(settings.dalc.directional[0].min, dalc.directional.x.min);
-
 	Float3ToColor(settings.dalc.directional[1].max, dalc.directional.y.max);
 	Float3ToColor(settings.dalc.directional[1].min, dalc.directional.y.min);
-
 	Float3ToColor(settings.dalc.directional[2].max, dalc.directional.z.max);
 	Float3ToColor(settings.dalc.directional[2].min, dalc.directional.z.min);
 }
 
-void LightingTemplateWidget::LoadLightingTemplateValues()
+void LightingTemplateWidget::RevertChanges()
+{
+	settings = vanillaSettings;
+	ApplyChanges();
+}
+
+void LightingTemplateWidget::LoadFromGameSettings()
 {
 	if (!lightingTemplate)
 		return;
@@ -294,17 +241,10 @@ void LightingTemplateWidget::LoadLightingTemplateValues()
 
 	ColorToFloat3(dalc.directional.x.max, settings.dalc.directional[0].max);
 	ColorToFloat3(dalc.directional.x.min, settings.dalc.directional[0].min);
-
 	ColorToFloat3(dalc.directional.y.max, settings.dalc.directional[1].max);
 	ColorToFloat3(dalc.directional.y.min, settings.dalc.directional[1].min);
-
 	ColorToFloat3(dalc.directional.z.max, settings.dalc.directional[2].max);
 	ColorToFloat3(dalc.directional.z.min, settings.dalc.directional[2].min);
-}
-
-void LightingTemplateWidget::LoadFromGameSettings()
-{
-	LoadLightingTemplateValues();
 }
 
 void LightingTemplateWidget::LoadSettings()

--- a/src/WeatherEditor/Weather/LightingTemplateWidget.cpp
+++ b/src/WeatherEditor/Weather/LightingTemplateWidget.cpp
@@ -152,14 +152,17 @@ bool LightingTemplateWidget::DrawDALCSettings()
 		minColors[TOD::Night] = settings.dalc.directional[2].min;
 
 		if (TOD::DrawTODColorRow("Positive Direction (+)", maxColors)) {
-			settings.dalc.directional[0].max = maxColors[TOD::Sunrise];
+			// Sunrise and Day both map to directional[0] - detect which column was actually edited
+			bool sunriseEdited = !(maxColors[TOD::Sunrise] == settings.dalc.directional[0].max);
+			settings.dalc.directional[0].max = sunriseEdited ? maxColors[TOD::Sunrise] : maxColors[TOD::Day];
 			settings.dalc.directional[1].max = maxColors[TOD::Sunset];
 			settings.dalc.directional[2].max = maxColors[TOD::Night];
 			changed = true;
 		}
 
 		if (TOD::DrawTODColorRow("Negative Direction (-)", minColors)) {
-			settings.dalc.directional[0].min = minColors[TOD::Sunrise];
+			bool sunriseEdited = !(minColors[TOD::Sunrise] == settings.dalc.directional[0].min);
+			settings.dalc.directional[0].min = sunriseEdited ? minColors[TOD::Sunrise] : minColors[TOD::Day];
 			settings.dalc.directional[1].min = minColors[TOD::Sunset];
 			settings.dalc.directional[2].min = minColors[TOD::Night];
 			changed = true;
@@ -186,8 +189,8 @@ void LightingTemplateWidget::ApplyChanges()
 
 	data.fogNear = settings.fogNear;
 	data.fogFar = settings.fogFar;
-	data.directionalXY = static_cast<std::uint32_t>(settings.directionalXY);
-	data.directionalZ = static_cast<std::uint32_t>(settings.directionalZ);
+	data.directionalXY = static_cast<std::uint32_t>(std::max(0.0f, std::round(settings.directionalXY)));
+	data.directionalZ = static_cast<std::uint32_t>(std::max(0.0f, std::round(settings.directionalZ)));
 	data.directionalFade = settings.directionalFade;
 	data.clipDist = settings.clipDist;
 	data.fogPower = settings.fogPower;

--- a/src/WeatherEditor/Weather/LightingTemplateWidget.h
+++ b/src/WeatherEditor/Weather/LightingTemplateWidget.h
@@ -5,21 +5,31 @@
 class LightingTemplateWidget : public Widget
 {
 public:
-	RE::BGSLightingTemplate* lightingTemplate = nullptr;
-
-	LightingTemplateWidget(RE::BGSLightingTemplate* a_lightingTemplate)
+	LightingTemplateWidget(RE::BGSLightingTemplate* a_lightingTemplate) :
+		lightingTemplate(a_lightingTemplate)
 	{
 		if (!a_lightingTemplate) {
 			logger::error("LightingTemplateWidget created with null pointer");
 			return;
 		}
 		form = a_lightingTemplate;
-		lightingTemplate = a_lightingTemplate;
 		LoadFromGameSettings();
 		vanillaSettings = settings;
 		originalSettings = settings;
 	}
 
+	~LightingTemplateWidget() override = default;
+
+	void DrawWidget() override;
+	void LoadSettings() override;
+	void SaveSettings() override;
+	void ApplyChanges() override;
+	void RevertChanges() override;
+	bool HasUnsavedChanges() const override;
+
+	RE::BGSLightingTemplate* GetLightingTemplate() const { return lightingTemplate; }
+
+	// Public types required by NLOHMANN macros
 	struct DirectionalColor
 	{
 		float3 min;
@@ -55,25 +65,15 @@ public:
 		bool operator==(const Settings&) const = default;
 	};
 
+private:
+	void LoadFromGameSettings();
+	bool DrawBasicSettings();
+	bool DrawFogSettings();
+	bool DrawDALCSettings();
+
+	RE::BGSLightingTemplate* lightingTemplate = nullptr;
+
 	Settings settings;
 	Settings vanillaSettings;
 	Settings originalSettings;
-
-	~LightingTemplateWidget();
-
-	virtual void DrawWidget() override;
-	virtual void LoadSettings() override;
-	virtual void SaveSettings() override;
-	virtual bool HasUnsavedChanges() const override;
-
-	void SetLightingTemplateValues();
-	void LoadLightingTemplateValues();
-	void LoadFromGameSettings();
-	void ApplyChanges() override;
-	void RevertChanges() override;
-
-private:
-	void DrawDALCSettings();
-	void DrawBasicSettings();
-	void DrawFogSettings();
 };

--- a/src/WeatherEditor/Weather/LightingTemplateWidget.h
+++ b/src/WeatherEditor/Weather/LightingTemplateWidget.h
@@ -10,6 +10,9 @@ public:
 	{
 		if (!a_lightingTemplate) {
 			logger::error("LightingTemplateWidget created with null pointer");
+			settings = {};
+			vanillaSettings = {};
+			originalSettings = {};
 			return;
 		}
 		form = a_lightingTemplate;

--- a/src/WeatherEditor/Weather/PrecipitationWidget.cpp
+++ b/src/WeatherEditor/Weather/PrecipitationWidget.cpp
@@ -22,88 +22,91 @@ void PrecipitationWidget::DrawWidget()
 {
 	WeatherUtils::SetCurrentWidget(this);
 	ImGui::SetNextWindowSizeConstraints(ImVec2(600, 0), ImVec2(FLT_MAX, FLT_MAX));
-	if (ImGui::Begin(GetEditorID().c_str(), &open, ImGuiWindowFlags_NoSavedSettings | kStickyHeaderFlags)) {
-		DrawWidgetHeader("##PrecipitationSearch", true, true);
+	if (!ImGui::Begin(GetEditorID().c_str(), &open, ImGuiWindowFlags_NoSavedSettings | kStickyHeaderFlags)) {
+		ImGui::End();
+		return;
 	}
-	bool changed = false;
+	DrawWidgetHeader("##PrecipitationSearch", true, true);
 
-	if (ImGui::BeginTabBar("PrecipitationTabs")) {
-		if (ImGui::BeginTabItem("Particle")) {
-			BeginScrollableContent("##ParticleScroll");
-			ImGui::SeparatorText("Particle Type");
-			static constexpr const char* kParticleTypes[] = { "Rain", "Snow" };
-			int currentType = static_cast<int>(settings.particleType);
-			if (ImGui::Combo("Type", &currentType, kParticleTypes, IM_ARRAYSIZE(kParticleTypes))) {
-				settings.particleType = static_cast<uint32_t>(currentType);
-				changed = true;
+		bool changed = false;
+
+		if (ImGui::BeginTabBar("PrecipitationTabs")) {
+			if (ImGui::BeginTabItem("Particle")) {
+				BeginScrollableContent("##ParticleScroll");
+				ImGui::SeparatorText("Particle Type");
+				static constexpr const char* kParticleTypes[] = { "Rain", "Snow" };
+				int currentType = static_cast<int>(settings.particleType);
+				if (ImGui::Combo("Type", &currentType, kParticleTypes, IM_ARRAYSIZE(kParticleTypes))) {
+					settings.particleType = static_cast<uint32_t>(currentType);
+					changed = true;
+				}
+
+				ImGui::SeparatorText("Particle Size");
+				if (WeatherUtils::DrawSliderFloat("Size X", settings.particleSizeX, 0.0f, 10.0f))
+					changed = true;
+				if (WeatherUtils::DrawSliderFloat("Size Y", settings.particleSizeY, 0.0f, 10.0f))
+					changed = true;
+
+				ImGui::SeparatorText("Velocity");
+				if (WeatherUtils::DrawSliderFloat("Gravity Velocity", settings.gravityVelocity, -100.0f, 100.0f))
+					changed = true;
+				if (WeatherUtils::DrawSliderFloat("Rotation Velocity", settings.rotationVelocity, -360.0f, 360.0f))
+					changed = true;
+
+				EndScrollableContent();
+				ImGui::EndTabItem();
 			}
 
-			ImGui::SeparatorText("Particle Size");
-			if (WeatherUtils::DrawSliderFloat("Size X", settings.particleSizeX, 0.0f, 10.0f))
-				changed = true;
-			if (WeatherUtils::DrawSliderFloat("Size Y", settings.particleSizeY, 0.0f, 10.0f))
-				changed = true;
+			if (ImGui::BeginTabItem("Position")) {
+				BeginScrollableContent("##PositionScroll");
+				ImGui::SeparatorText("Offset");
+				if (WeatherUtils::DrawSliderFloat("Center Offset Min", settings.centerOffsetMin, -1000.0f, 1000.0f))
+					changed = true;
+				if (WeatherUtils::DrawSliderFloat("Center Offset Max", settings.centerOffsetMax, -1000.0f, 1000.0f))
+					changed = true;
+				if (WeatherUtils::DrawSliderFloat("Start Rotation Range", settings.startRotationRange, 0.0f, 360.0f))
+					changed = true;
 
-			ImGui::SeparatorText("Velocity");
-			if (WeatherUtils::DrawSliderFloat("Gravity Velocity", settings.gravityVelocity, -100.0f, 100.0f))
-				changed = true;
-			if (WeatherUtils::DrawSliderFloat("Rotation Velocity", settings.rotationVelocity, -360.0f, 360.0f))
-				changed = true;
+				ImGui::SeparatorText("Volume");
+				if (WeatherUtils::DrawSliderFloat("Box Size", settings.boxSize, 0.0f, 10000.0f))
+					changed = true;
+				if (WeatherUtils::DrawSliderFloat("Particle Density", settings.particleDensity, 0.0f, 10.0f))
+					changed = true;
 
-			EndScrollableContent();
-			ImGui::EndTabItem();
+				EndScrollableContent();
+				ImGui::EndTabItem();
+			}
+
+			if (ImGui::BeginTabItem("Texture")) {
+				BeginScrollableContent("##TextureScroll");
+				ImGui::SeparatorText("Subtextures");
+				int numX = static_cast<int>(settings.numSubtexturesX);
+				int numY = static_cast<int>(settings.numSubtexturesY);
+				if (ImGui::InputInt("Num Subtextures X", &numX)) {
+					settings.numSubtexturesX = std::max(1, numX);
+					changed = true;
+				}
+				if (ImGui::InputInt("Num Subtextures Y", &numY)) {
+					settings.numSubtexturesY = std::max(1, numY);
+					changed = true;
+				}
+
+				ImGui::SeparatorText("Texture Path");
+				if (ImGui::InputText("Particle Texture", textureBuffer, sizeof(textureBuffer))) {
+					settings.particleTexture = textureBuffer;
+					changed = true;
+				}
+
+				EndScrollableContent();
+				ImGui::EndTabItem();
+			}
+
+			ImGui::EndTabBar();
 		}
 
-		if (ImGui::BeginTabItem("Position")) {
-			BeginScrollableContent("##PositionScroll");
-			ImGui::SeparatorText("Offset");
-			if (WeatherUtils::DrawSliderFloat("Center Offset Min", settings.centerOffsetMin, -1000.0f, 1000.0f))
-				changed = true;
-			if (WeatherUtils::DrawSliderFloat("Center Offset Max", settings.centerOffsetMax, -1000.0f, 1000.0f))
-				changed = true;
-			if (WeatherUtils::DrawSliderFloat("Start Rotation Range", settings.startRotationRange, 0.0f, 360.0f))
-				changed = true;
-
-			ImGui::SeparatorText("Volume");
-			if (WeatherUtils::DrawSliderFloat("Box Size", settings.boxSize, 0.0f, 10000.0f))
-				changed = true;
-			if (WeatherUtils::DrawSliderFloat("Particle Density", settings.particleDensity, 0.0f, 10.0f))
-				changed = true;
-
-			EndScrollableContent();
-			ImGui::EndTabItem();
+		if (changed && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
+			ApplyChanges();
 		}
-
-		if (ImGui::BeginTabItem("Texture")) {
-			BeginScrollableContent("##TextureScroll");
-			ImGui::SeparatorText("Subtextures");
-			int numX = static_cast<int>(settings.numSubtexturesX);
-			int numY = static_cast<int>(settings.numSubtexturesY);
-			if (ImGui::InputInt("Num Subtextures X", &numX)) {
-				settings.numSubtexturesX = std::max(1, numX);
-				changed = true;
-			}
-			if (ImGui::InputInt("Num Subtextures Y", &numY)) {
-				settings.numSubtexturesY = std::max(1, numY);
-				changed = true;
-			}
-
-			ImGui::SeparatorText("Texture Path");
-			if (ImGui::InputText("Particle Texture", textureBuffer, sizeof(textureBuffer))) {
-				settings.particleTexture = textureBuffer;
-				changed = true;
-			}
-
-			EndScrollableContent();
-			ImGui::EndTabItem();
-		}
-
-		ImGui::EndTabBar();
-	}
-
-	if (changed && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
-		ApplyChanges();
-	}
 	ImGui::End();
 }
 

--- a/src/WeatherEditor/Weather/PrecipitationWidget.cpp
+++ b/src/WeatherEditor/Weather/PrecipitationWidget.cpp
@@ -131,10 +131,10 @@ void PrecipitationWidget::LoadSettings()
 	settings.numSubtexturesX = std::max(1u, settings.numSubtexturesX);
 	settings.numSubtexturesY = std::max(1u, settings.numSubtexturesY);
 	settings.particleDensity = std::max(0.0f, settings.particleDensity);
-	settings.particleType    = std::min(settings.particleType, 1u);
-	settings.boxSize         = std::max(0.0f, settings.boxSize);
-	settings.particleSizeX   = std::clamp(settings.particleSizeX, 0.0f, 10.0f);
-	settings.particleSizeY   = std::clamp(settings.particleSizeY, 0.0f, 10.0f);
+	settings.particleType = std::min(settings.particleType, 1u);
+	settings.boxSize = std::max(0.0f, settings.boxSize);
+	settings.particleSizeX = std::clamp(settings.particleSizeX, 0.0f, 10.0f);
+	settings.particleSizeY = std::clamp(settings.particleSizeY, 0.0f, 10.0f);
 
 	originalSettings = settings;
 	strncpy_s(textureBuffer, sizeof(textureBuffer), settings.particleTexture.c_str(), _TRUNCATE);

--- a/src/WeatherEditor/Weather/PrecipitationWidget.cpp
+++ b/src/WeatherEditor/Weather/PrecipitationWidget.cpp
@@ -28,85 +28,85 @@ void PrecipitationWidget::DrawWidget()
 	}
 	DrawWidgetHeader("##PrecipitationSearch", true, true);
 
-		bool changed = false;
+	bool changed = false;
 
-		if (ImGui::BeginTabBar("PrecipitationTabs")) {
-			if (ImGui::BeginTabItem("Particle")) {
-				BeginScrollableContent("##ParticleScroll");
-				ImGui::SeparatorText("Particle Type");
-				static constexpr const char* kParticleTypes[] = { "Rain", "Snow" };
-				int currentType = static_cast<int>(settings.particleType);
-				if (ImGui::Combo("Type", &currentType, kParticleTypes, IM_ARRAYSIZE(kParticleTypes))) {
-					settings.particleType = static_cast<uint32_t>(currentType);
-					changed = true;
-				}
-
-				ImGui::SeparatorText("Particle Size");
-				if (WeatherUtils::DrawSliderFloat("Size X", settings.particleSizeX, 0.0f, 10.0f))
-					changed = true;
-				if (WeatherUtils::DrawSliderFloat("Size Y", settings.particleSizeY, 0.0f, 10.0f))
-					changed = true;
-
-				ImGui::SeparatorText("Velocity");
-				if (WeatherUtils::DrawSliderFloat("Gravity Velocity", settings.gravityVelocity, -100.0f, 100.0f))
-					changed = true;
-				if (WeatherUtils::DrawSliderFloat("Rotation Velocity", settings.rotationVelocity, -360.0f, 360.0f))
-					changed = true;
-
-				EndScrollableContent();
-				ImGui::EndTabItem();
+	if (ImGui::BeginTabBar("PrecipitationTabs")) {
+		if (ImGui::BeginTabItem("Particle")) {
+			BeginScrollableContent("##ParticleScroll");
+			ImGui::SeparatorText("Particle Type");
+			static constexpr const char* kParticleTypes[] = { "Rain", "Snow" };
+			int currentType = static_cast<int>(settings.particleType);
+			if (ImGui::Combo("Type", &currentType, kParticleTypes, IM_ARRAYSIZE(kParticleTypes))) {
+				settings.particleType = static_cast<uint32_t>(currentType);
+				changed = true;
 			}
 
-			if (ImGui::BeginTabItem("Position")) {
-				BeginScrollableContent("##PositionScroll");
-				ImGui::SeparatorText("Offset");
-				if (WeatherUtils::DrawSliderFloat("Center Offset Min", settings.centerOffsetMin, -1000.0f, 1000.0f))
-					changed = true;
-				if (WeatherUtils::DrawSliderFloat("Center Offset Max", settings.centerOffsetMax, -1000.0f, 1000.0f))
-					changed = true;
-				if (WeatherUtils::DrawSliderFloat("Start Rotation Range", settings.startRotationRange, 0.0f, 360.0f))
-					changed = true;
+			ImGui::SeparatorText("Particle Size");
+			if (WeatherUtils::DrawSliderFloat("Size X", settings.particleSizeX, 0.0f, 10.0f))
+				changed = true;
+			if (WeatherUtils::DrawSliderFloat("Size Y", settings.particleSizeY, 0.0f, 10.0f))
+				changed = true;
 
-				ImGui::SeparatorText("Volume");
-				if (WeatherUtils::DrawSliderFloat("Box Size", settings.boxSize, 0.0f, 10000.0f))
-					changed = true;
-				if (WeatherUtils::DrawSliderFloat("Particle Density", settings.particleDensity, 0.0f, 10.0f))
-					changed = true;
+			ImGui::SeparatorText("Velocity");
+			if (WeatherUtils::DrawSliderFloat("Gravity Velocity", settings.gravityVelocity, -100.0f, 100.0f))
+				changed = true;
+			if (WeatherUtils::DrawSliderFloat("Rotation Velocity", settings.rotationVelocity, -360.0f, 360.0f))
+				changed = true;
 
-				EndScrollableContent();
-				ImGui::EndTabItem();
-			}
-
-			if (ImGui::BeginTabItem("Texture")) {
-				BeginScrollableContent("##TextureScroll");
-				ImGui::SeparatorText("Subtextures");
-				int numX = static_cast<int>(settings.numSubtexturesX);
-				int numY = static_cast<int>(settings.numSubtexturesY);
-				if (ImGui::InputInt("Num Subtextures X", &numX)) {
-					settings.numSubtexturesX = std::max(1, numX);
-					changed = true;
-				}
-				if (ImGui::InputInt("Num Subtextures Y", &numY)) {
-					settings.numSubtexturesY = std::max(1, numY);
-					changed = true;
-				}
-
-				ImGui::SeparatorText("Texture Path");
-				if (ImGui::InputText("Particle Texture", textureBuffer, sizeof(textureBuffer))) {
-					settings.particleTexture = textureBuffer;
-					changed = true;
-				}
-
-				EndScrollableContent();
-				ImGui::EndTabItem();
-			}
-
-			ImGui::EndTabBar();
+			EndScrollableContent();
+			ImGui::EndTabItem();
 		}
 
-		if (changed && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
-			ApplyChanges();
+		if (ImGui::BeginTabItem("Position")) {
+			BeginScrollableContent("##PositionScroll");
+			ImGui::SeparatorText("Offset");
+			if (WeatherUtils::DrawSliderFloat("Center Offset Min", settings.centerOffsetMin, -1000.0f, 1000.0f))
+				changed = true;
+			if (WeatherUtils::DrawSliderFloat("Center Offset Max", settings.centerOffsetMax, -1000.0f, 1000.0f))
+				changed = true;
+			if (WeatherUtils::DrawSliderFloat("Start Rotation Range", settings.startRotationRange, 0.0f, 360.0f))
+				changed = true;
+
+			ImGui::SeparatorText("Volume");
+			if (WeatherUtils::DrawSliderFloat("Box Size", settings.boxSize, 0.0f, 10000.0f))
+				changed = true;
+			if (WeatherUtils::DrawSliderFloat("Particle Density", settings.particleDensity, 0.0f, 10.0f))
+				changed = true;
+
+			EndScrollableContent();
+			ImGui::EndTabItem();
 		}
+
+		if (ImGui::BeginTabItem("Texture")) {
+			BeginScrollableContent("##TextureScroll");
+			ImGui::SeparatorText("Subtextures");
+			int numX = static_cast<int>(settings.numSubtexturesX);
+			int numY = static_cast<int>(settings.numSubtexturesY);
+			if (ImGui::InputInt("Num Subtextures X", &numX)) {
+				settings.numSubtexturesX = std::max(1, numX);
+				changed = true;
+			}
+			if (ImGui::InputInt("Num Subtextures Y", &numY)) {
+				settings.numSubtexturesY = std::max(1, numY);
+				changed = true;
+			}
+
+			ImGui::SeparatorText("Texture Path");
+			if (ImGui::InputText("Particle Texture", textureBuffer, sizeof(textureBuffer))) {
+				settings.particleTexture = textureBuffer;
+				changed = true;
+			}
+
+			EndScrollableContent();
+			ImGui::EndTabItem();
+		}
+
+		ImGui::EndTabBar();
+	}
+
+	if (changed && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
+		ApplyChanges();
+	}
 	ImGui::End();
 }
 

--- a/src/WeatherEditor/Weather/PrecipitationWidget.cpp
+++ b/src/WeatherEditor/Weather/PrecipitationWidget.cpp
@@ -127,6 +127,15 @@ void PrecipitationWidget::LoadSettings()
 		}
 	}
 
+	// Normalize settings so originalSettings matches the clamped values applied in ApplyChanges
+	settings.numSubtexturesX = std::max(1u, settings.numSubtexturesX);
+	settings.numSubtexturesY = std::max(1u, settings.numSubtexturesY);
+	settings.particleDensity = std::max(0.0f, settings.particleDensity);
+	settings.particleType    = std::min(settings.particleType, 1u);
+	settings.boxSize         = std::max(0.0f, settings.boxSize);
+	settings.particleSizeX   = std::clamp(settings.particleSizeX, 0.0f, 10.0f);
+	settings.particleSizeY   = std::clamp(settings.particleSizeY, 0.0f, 10.0f);
+
 	originalSettings = settings;
 	strncpy_s(textureBuffer, sizeof(textureBuffer), settings.particleTexture.c_str(), _TRUNCATE);
 	ApplyChanges();

--- a/src/WeatherEditor/Weather/PrecipitationWidget.cpp
+++ b/src/WeatherEditor/Weather/PrecipitationWidget.cpp
@@ -2,6 +2,22 @@
 #include "../EditorWindow.h"
 #include "../WeatherUtils.h"
 
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
+	PrecipitationWidget::Settings,
+	gravityVelocity,
+	rotationVelocity,
+	particleSizeX,
+	particleSizeY,
+	centerOffsetMin,
+	centerOffsetMax,
+	startRotationRange,
+	numSubtexturesX,
+	numSubtexturesY,
+	particleType,
+	boxSize,
+	particleDensity,
+	particleTexture)
+
 void PrecipitationWidget::DrawWidget()
 {
 	WeatherUtils::SetCurrentWidget(this);
@@ -96,40 +112,14 @@ void PrecipitationWidget::LoadSettings()
 	if (!precipitation)
 		return;
 
-	if (!js.empty()) {
-		settings = vanillaSettings;
-		try {
-			if (js.contains("gravityVelocity"))
-				settings.gravityVelocity = js["gravityVelocity"];
-			if (js.contains("rotationVelocity"))
-				settings.rotationVelocity = js["rotationVelocity"];
-			if (js.contains("particleSizeX"))
-				settings.particleSizeX = js["particleSizeX"];
-			if (js.contains("particleSizeY"))
-				settings.particleSizeY = js["particleSizeY"];
-			if (js.contains("centerOffsetMin"))
-				settings.centerOffsetMin = js["centerOffsetMin"];
-			if (js.contains("centerOffsetMax"))
-				settings.centerOffsetMax = js["centerOffsetMax"];
-			if (js.contains("startRotationRange"))
-				settings.startRotationRange = js["startRotationRange"];
-			if (js.contains("numSubtexturesX"))
-				settings.numSubtexturesX = js["numSubtexturesX"];
-			if (js.contains("numSubtexturesY"))
-				settings.numSubtexturesY = js["numSubtexturesY"];
-			if (js.contains("particleType"))
-				settings.particleType = js["particleType"];
-			if (js.contains("boxSize"))
-				settings.boxSize = js["boxSize"];
-			if (js.contains("particleDensity"))
-				settings.particleDensity = js["particleDensity"];
-			if (js.contains("particleTexture"))
-				settings.particleTexture = js["particleTexture"].get<std::string>();
-		} catch (const std::exception& e) {
-			logger::error("Precipitation {}: Failed to load from JSON: {}", GetEditorID(), e.what());
+	try {
+		if (!js.empty()) {
+			settings = js;
+		} else {
 			settings = vanillaSettings;
 		}
-	} else {
+	} catch (const std::exception& e) {
+		logger::error("Precipitation {}: Failed to load from JSON: {}", GetEditorID(), e.what());
 		settings = vanillaSettings;
 	}
 
@@ -143,38 +133,27 @@ void PrecipitationWidget::LoadFromGameSettings()
 	if (!precipitation)
 		return;
 
+	using DataID = RE::BGSShaderParticleGeometryData::DataID;
 	auto& runtime = precipitation->GetRuntimeData();
 
-	settings.gravityVelocity = precipitation->GetSettingValue(RE::BGSShaderParticleGeometryData::DataID::kGravityVelocity).f;
-	settings.rotationVelocity = precipitation->GetSettingValue(RE::BGSShaderParticleGeometryData::DataID::kRotationVelocity).f;
-	settings.particleSizeX = precipitation->GetSettingValue(RE::BGSShaderParticleGeometryData::DataID::kParticleSizeX).f;
-	settings.particleSizeY = precipitation->GetSettingValue(RE::BGSShaderParticleGeometryData::DataID::kParticleSizeY).f;
-	settings.centerOffsetMin = precipitation->GetSettingValue(RE::BGSShaderParticleGeometryData::DataID::kCenterOffsetMin).f;
-	settings.centerOffsetMax = precipitation->GetSettingValue(RE::BGSShaderParticleGeometryData::DataID::kCenterOffsetMax).f;
-	settings.startRotationRange = precipitation->GetSettingValue(RE::BGSShaderParticleGeometryData::DataID::kStartRotationRange).f;
-	settings.numSubtexturesX = precipitation->GetSettingValue(RE::BGSShaderParticleGeometryData::DataID::kNumSubtexturesX).i;
-	settings.numSubtexturesY = precipitation->GetSettingValue(RE::BGSShaderParticleGeometryData::DataID::kNumSubtexturesY).i;
-	settings.particleType = precipitation->GetSettingValue(RE::BGSShaderParticleGeometryData::DataID::kParticleType).i;
-	settings.boxSize = precipitation->GetSettingValue(RE::BGSShaderParticleGeometryData::DataID::kBoxSize).f;
-	settings.particleDensity = precipitation->GetSettingValue(RE::BGSShaderParticleGeometryData::DataID::kParticleDensity).f;
+	settings.gravityVelocity = precipitation->GetSettingValue(DataID::kGravityVelocity).f;
+	settings.rotationVelocity = precipitation->GetSettingValue(DataID::kRotationVelocity).f;
+	settings.particleSizeX = precipitation->GetSettingValue(DataID::kParticleSizeX).f;
+	settings.particleSizeY = precipitation->GetSettingValue(DataID::kParticleSizeY).f;
+	settings.centerOffsetMin = precipitation->GetSettingValue(DataID::kCenterOffsetMin).f;
+	settings.centerOffsetMax = precipitation->GetSettingValue(DataID::kCenterOffsetMax).f;
+	settings.startRotationRange = precipitation->GetSettingValue(DataID::kStartRotationRange).f;
+	settings.numSubtexturesX = precipitation->GetSettingValue(DataID::kNumSubtexturesX).i;
+	settings.numSubtexturesY = precipitation->GetSettingValue(DataID::kNumSubtexturesY).i;
+	settings.particleType = precipitation->GetSettingValue(DataID::kParticleType).i;
+	settings.boxSize = precipitation->GetSettingValue(DataID::kBoxSize).f;
+	settings.particleDensity = precipitation->GetSettingValue(DataID::kParticleDensity).f;
 	settings.particleTexture = runtime.particleTexture.textureName.c_str();
 }
 
 void PrecipitationWidget::SaveSettings()
 {
-	js["gravityVelocity"] = settings.gravityVelocity;
-	js["rotationVelocity"] = settings.rotationVelocity;
-	js["particleSizeX"] = settings.particleSizeX;
-	js["particleSizeY"] = settings.particleSizeY;
-	js["centerOffsetMin"] = settings.centerOffsetMin;
-	js["centerOffsetMax"] = settings.centerOffsetMax;
-	js["startRotationRange"] = settings.startRotationRange;
-	js["numSubtexturesX"] = settings.numSubtexturesX;
-	js["numSubtexturesY"] = settings.numSubtexturesY;
-	js["particleType"] = settings.particleType;
-	js["boxSize"] = settings.boxSize;
-	js["particleDensity"] = settings.particleDensity;
-	js["particleTexture"] = settings.particleTexture;
+	js = settings;
 	originalSettings = settings;
 }
 
@@ -183,20 +162,21 @@ void PrecipitationWidget::ApplyChanges()
 	if (!precipitation)
 		return;
 
+	using DataID = RE::BGSShaderParticleGeometryData::DataID;
 	auto& runtime = precipitation->GetRuntimeData();
 
-	runtime.data[(uint32_t)RE::BGSShaderParticleGeometryData::DataID::kGravityVelocity].f = settings.gravityVelocity;
-	runtime.data[(uint32_t)RE::BGSShaderParticleGeometryData::DataID::kRotationVelocity].f = settings.rotationVelocity;
-	runtime.data[(uint32_t)RE::BGSShaderParticleGeometryData::DataID::kParticleSizeX].f = settings.particleSizeX;
-	runtime.data[(uint32_t)RE::BGSShaderParticleGeometryData::DataID::kParticleSizeY].f = settings.particleSizeY;
-	runtime.data[(uint32_t)RE::BGSShaderParticleGeometryData::DataID::kCenterOffsetMin].f = settings.centerOffsetMin;
-	runtime.data[(uint32_t)RE::BGSShaderParticleGeometryData::DataID::kCenterOffsetMax].f = settings.centerOffsetMax;
-	runtime.data[(uint32_t)RE::BGSShaderParticleGeometryData::DataID::kStartRotationRange].f = settings.startRotationRange;
-	runtime.data[(uint32_t)RE::BGSShaderParticleGeometryData::DataID::kNumSubtexturesX].i = settings.numSubtexturesX;
-	runtime.data[(uint32_t)RE::BGSShaderParticleGeometryData::DataID::kNumSubtexturesY].i = settings.numSubtexturesY;
-	runtime.data[(uint32_t)RE::BGSShaderParticleGeometryData::DataID::kParticleType].i = settings.particleType;
-	runtime.data[(uint32_t)RE::BGSShaderParticleGeometryData::DataID::kBoxSize].f = settings.boxSize;
-	runtime.data[(uint32_t)RE::BGSShaderParticleGeometryData::DataID::kParticleDensity].f = settings.particleDensity;
+	runtime.data[static_cast<uint32_t>(DataID::kGravityVelocity)].f = settings.gravityVelocity;
+	runtime.data[static_cast<uint32_t>(DataID::kRotationVelocity)].f = settings.rotationVelocity;
+	runtime.data[static_cast<uint32_t>(DataID::kParticleSizeX)].f = settings.particleSizeX;
+	runtime.data[static_cast<uint32_t>(DataID::kParticleSizeY)].f = settings.particleSizeY;
+	runtime.data[static_cast<uint32_t>(DataID::kCenterOffsetMin)].f = settings.centerOffsetMin;
+	runtime.data[static_cast<uint32_t>(DataID::kCenterOffsetMax)].f = settings.centerOffsetMax;
+	runtime.data[static_cast<uint32_t>(DataID::kStartRotationRange)].f = settings.startRotationRange;
+	runtime.data[static_cast<uint32_t>(DataID::kNumSubtexturesX)].i = settings.numSubtexturesX;
+	runtime.data[static_cast<uint32_t>(DataID::kNumSubtexturesY)].i = settings.numSubtexturesY;
+	runtime.data[static_cast<uint32_t>(DataID::kParticleType)].i = settings.particleType;
+	runtime.data[static_cast<uint32_t>(DataID::kBoxSize)].f = settings.boxSize;
+	runtime.data[static_cast<uint32_t>(DataID::kParticleDensity)].f = settings.particleDensity;
 	runtime.particleTexture.textureName = settings.particleTexture.c_str();
 }
 

--- a/src/WeatherEditor/Weather/PrecipitationWidget.cpp
+++ b/src/WeatherEditor/Weather/PrecipitationWidget.cpp
@@ -8,86 +8,85 @@ void PrecipitationWidget::DrawWidget()
 	ImGui::SetNextWindowSizeConstraints(ImVec2(600, 0), ImVec2(FLT_MAX, FLT_MAX));
 	if (ImGui::Begin(GetEditorID().c_str(), &open, ImGuiWindowFlags_NoSavedSettings | kStickyHeaderFlags)) {
 		DrawWidgetHeader("##PrecipitationSearch", true, true);
+	}
+	bool changed = false;
 
-		bool changed = false;
-
-		if (ImGui::BeginTabBar("PrecipitationTabs")) {
-			if (ImGui::BeginTabItem("Particle")) {
-				BeginScrollableContent("##ParticleScroll");
-				ImGui::SeparatorText("Particle Type");
-				const char* types[] = { "Rain", "Snow" };
-				int currentType = static_cast<int>(settings.particleType);
-				if (ImGui::Combo("Type", &currentType, types, IM_ARRAYSIZE(types))) {
-					settings.particleType = static_cast<uint32_t>(currentType);
-					changed = true;
-				}
-
-				ImGui::SeparatorText("Particle Size");
-				if (WeatherUtils::DrawSliderFloat("Size X", settings.particleSizeX, 0.0f, 10.0f))
-					changed = true;
-				if (WeatherUtils::DrawSliderFloat("Size Y", settings.particleSizeY, 0.0f, 10.0f))
-					changed = true;
-
-				ImGui::SeparatorText("Velocity");
-				if (WeatherUtils::DrawSliderFloat("Gravity Velocity", settings.gravityVelocity, -100.0f, 100.0f))
-					changed = true;
-				if (WeatherUtils::DrawSliderFloat("Rotation Velocity", settings.rotationVelocity, -360.0f, 360.0f))
-					changed = true;
-
-				EndScrollableContent();
-				ImGui::EndTabItem();
+	if (ImGui::BeginTabBar("PrecipitationTabs")) {
+		if (ImGui::BeginTabItem("Particle")) {
+			BeginScrollableContent("##ParticleScroll");
+			ImGui::SeparatorText("Particle Type");
+			static constexpr const char* kParticleTypes[] = { "Rain", "Snow" };
+			int currentType = static_cast<int>(settings.particleType);
+			if (ImGui::Combo("Type", &currentType, kParticleTypes, IM_ARRAYSIZE(kParticleTypes))) {
+				settings.particleType = static_cast<uint32_t>(currentType);
+				changed = true;
 			}
 
-			if (ImGui::BeginTabItem("Position")) {
-				BeginScrollableContent("##PositionScroll");
-				ImGui::SeparatorText("Offset");
-				if (WeatherUtils::DrawSliderFloat("Center Offset Min", settings.centerOffsetMin, -1000.0f, 1000.0f))
-					changed = true;
-				if (WeatherUtils::DrawSliderFloat("Center Offset Max", settings.centerOffsetMax, -1000.0f, 1000.0f))
-					changed = true;
-				if (WeatherUtils::DrawSliderFloat("Start Rotation Range", settings.startRotationRange, 0.0f, 360.0f))
-					changed = true;
+			ImGui::SeparatorText("Particle Size");
+			if (WeatherUtils::DrawSliderFloat("Size X", settings.particleSizeX, 0.0f, 10.0f))
+				changed = true;
+			if (WeatherUtils::DrawSliderFloat("Size Y", settings.particleSizeY, 0.0f, 10.0f))
+				changed = true;
 
-				ImGui::SeparatorText("Volume");
-				if (WeatherUtils::DrawSliderFloat("Box Size", settings.boxSize, 0.0f, 10000.0f))
-					changed = true;
-				if (WeatherUtils::DrawSliderFloat("Particle Density", settings.particleDensity, 0.0f, 10.0f))
-					changed = true;
+			ImGui::SeparatorText("Velocity");
+			if (WeatherUtils::DrawSliderFloat("Gravity Velocity", settings.gravityVelocity, -100.0f, 100.0f))
+				changed = true;
+			if (WeatherUtils::DrawSliderFloat("Rotation Velocity", settings.rotationVelocity, -360.0f, 360.0f))
+				changed = true;
 
-				EndScrollableContent();
-				ImGui::EndTabItem();
-			}
-
-			if (ImGui::BeginTabItem("Texture")) {
-				BeginScrollableContent("##TextureScroll");
-				ImGui::SeparatorText("Subtextures");
-				int numX = static_cast<int>(settings.numSubtexturesX);
-				int numY = static_cast<int>(settings.numSubtexturesY);
-				if (ImGui::InputInt("Num Subtextures X", &numX)) {
-					settings.numSubtexturesX = std::max(1, numX);
-					changed = true;
-				}
-				if (ImGui::InputInt("Num Subtextures Y", &numY)) {
-					settings.numSubtexturesY = std::max(1, numY);
-					changed = true;
-				}
-
-				ImGui::SeparatorText("Texture Path");
-				if (ImGui::InputText("Particle Texture", textureBuffer, sizeof(textureBuffer))) {
-					settings.particleTexture = textureBuffer;
-					changed = true;
-				}
-
-				EndScrollableContent();
-				ImGui::EndTabItem();
-			}
-
-			ImGui::EndTabBar();
+			EndScrollableContent();
+			ImGui::EndTabItem();
 		}
 
-		if (changed && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
-			ApplyChanges();
+		if (ImGui::BeginTabItem("Position")) {
+			BeginScrollableContent("##PositionScroll");
+			ImGui::SeparatorText("Offset");
+			if (WeatherUtils::DrawSliderFloat("Center Offset Min", settings.centerOffsetMin, -1000.0f, 1000.0f))
+				changed = true;
+			if (WeatherUtils::DrawSliderFloat("Center Offset Max", settings.centerOffsetMax, -1000.0f, 1000.0f))
+				changed = true;
+			if (WeatherUtils::DrawSliderFloat("Start Rotation Range", settings.startRotationRange, 0.0f, 360.0f))
+				changed = true;
+
+			ImGui::SeparatorText("Volume");
+			if (WeatherUtils::DrawSliderFloat("Box Size", settings.boxSize, 0.0f, 10000.0f))
+				changed = true;
+			if (WeatherUtils::DrawSliderFloat("Particle Density", settings.particleDensity, 0.0f, 10.0f))
+				changed = true;
+
+			EndScrollableContent();
+			ImGui::EndTabItem();
 		}
+
+		if (ImGui::BeginTabItem("Texture")) {
+			BeginScrollableContent("##TextureScroll");
+			ImGui::SeparatorText("Subtextures");
+			int numX = static_cast<int>(settings.numSubtexturesX);
+			int numY = static_cast<int>(settings.numSubtexturesY);
+			if (ImGui::InputInt("Num Subtextures X", &numX)) {
+				settings.numSubtexturesX = std::max(1, numX);
+				changed = true;
+			}
+			if (ImGui::InputInt("Num Subtextures Y", &numY)) {
+				settings.numSubtexturesY = std::max(1, numY);
+				changed = true;
+			}
+
+			ImGui::SeparatorText("Texture Path");
+			if (ImGui::InputText("Particle Texture", textureBuffer, sizeof(textureBuffer))) {
+				settings.particleTexture = textureBuffer;
+				changed = true;
+			}
+
+			EndScrollableContent();
+			ImGui::EndTabItem();
+		}
+
+		ImGui::EndTabBar();
+	}
+
+	if (changed && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
+		ApplyChanges();
 	}
 	ImGui::End();
 }

--- a/src/WeatherEditor/Weather/PrecipitationWidget.cpp
+++ b/src/WeatherEditor/Weather/PrecipitationWidget.cpp
@@ -20,12 +20,12 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 
 void PrecipitationWidget::DrawWidget()
 {
-	WeatherUtils::SetCurrentWidget(this);
 	ImGui::SetNextWindowSizeConstraints(ImVec2(600, 0), ImVec2(FLT_MAX, FLT_MAX));
 	if (!ImGui::Begin(GetEditorID().c_str(), &open, ImGuiWindowFlags_NoSavedSettings | kStickyHeaderFlags)) {
 		ImGui::End();
 		return;
 	}
+	WeatherUtils::SetCurrentWidget(this);
 	DrawWidgetHeader("##PrecipitationSearch", true, true);
 
 	bool changed = false;
@@ -115,15 +115,16 @@ void PrecipitationWidget::LoadSettings()
 	if (!precipitation)
 		return;
 
-	try {
-		if (!js.empty()) {
-			settings = js;
-		} else {
+	settings = vanillaSettings;
+	if (!js.empty()) {
+		try {
+			nlohmann::json merged = vanillaSettings;
+			merged.merge_patch(js);
+			settings = merged.get<Settings>();
+		} catch (const std::exception& e) {
+			logger::error("Precipitation {}: Failed to load from JSON: {}", GetEditorID(), e.what());
 			settings = vanillaSettings;
 		}
-	} catch (const std::exception& e) {
-		logger::error("Precipitation {}: Failed to load from JSON: {}", GetEditorID(), e.what());
-		settings = vanillaSettings;
 	}
 
 	originalSettings = settings;
@@ -164,6 +165,15 @@ void PrecipitationWidget::ApplyChanges()
 {
 	if (!precipitation)
 		return;
+
+	// Validate and clamp fields to safe ranges before applying
+	settings.numSubtexturesX = std::max(1u, settings.numSubtexturesX);
+	settings.numSubtexturesY = std::max(1u, settings.numSubtexturesY);
+	settings.particleDensity = std::max(0.0f, settings.particleDensity);
+	settings.particleType = std::min(settings.particleType, 1u);
+	settings.boxSize = std::max(0.0f, settings.boxSize);
+	settings.particleSizeX = std::clamp(settings.particleSizeX, 0.0f, 10.0f);
+	settings.particleSizeY = std::clamp(settings.particleSizeY, 0.0f, 10.0f);
 
 	using DataID = RE::BGSShaderParticleGeometryData::DataID;
 	auto& runtime = precipitation->GetRuntimeData();

--- a/src/WeatherEditor/Weather/PrecipitationWidget.h
+++ b/src/WeatherEditor/Weather/PrecipitationWidget.h
@@ -26,11 +26,7 @@ public:
 	void RevertChanges() override;
 	bool HasUnsavedChanges() const override;
 
-	RE::BGSShaderParticleGeometryData* precipitation = nullptr;
-
-private:
-	void LoadFromGameSettings();
-
+	// Public type required by NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT macro
 	struct Settings
 	{
 		float gravityVelocity = 0.0f;
@@ -48,6 +44,11 @@ private:
 		std::string particleTexture = "";
 		bool operator==(const Settings&) const = default;
 	};
+
+private:
+	void LoadFromGameSettings();
+
+	RE::BGSShaderParticleGeometryData* precipitation = nullptr;
 
 	Settings settings;
 	Settings vanillaSettings;

--- a/src/WeatherEditor/Weather/ReferenceEffectWidget.cpp
+++ b/src/WeatherEditor/Weather/ReferenceEffectWidget.cpp
@@ -4,12 +4,12 @@
 
 void ReferenceEffectWidget::DrawWidget()
 {
-	WeatherUtils::SetCurrentWidget(this);
 	ImGui::SetNextWindowSizeConstraints(ImVec2(600, 0), ImVec2(FLT_MAX, FLT_MAX));
 	if (!ImGui::Begin(GetEditorID().c_str(), &open, ImGuiWindowFlags_NoSavedSettings | kStickyHeaderFlags)) {
 		ImGui::End();
 		return;
 	}
+	WeatherUtils::SetCurrentWidget(this);
 	DrawWidgetHeader("##ReferenceEffectSearch", true, true);
 
 	BeginScrollableContent("##REScroll");

--- a/src/WeatherEditor/Weather/ReferenceEffectWidget.cpp
+++ b/src/WeatherEditor/Weather/ReferenceEffectWidget.cpp
@@ -12,40 +12,40 @@ void ReferenceEffectWidget::DrawWidget()
 	}
 	DrawWidgetHeader("##ReferenceEffectSearch", true, true);
 
-		BeginScrollableContent("##REScroll");
-		bool changed = false;
+	BeginScrollableContent("##REScroll");
+	bool changed = false;
 
-		auto editorWindow = EditorWindow::GetSingleton();
+	auto editorWindow = EditorWindow::GetSingleton();
 
-		ImGui::SeparatorText("Art Object");
-		if (editorWindow->artObjectWidgets.empty()) {
-			ImGui::TextDisabled("No Art Objects available");
-		} else {
-			if (WeatherUtils::DrawFormPickerCached("Art Object", settings.artObject, editorWindow->artObjectWidgets, false, true))
-				changed = true;
-		}
-
-		ImGui::SeparatorText("Effect Shader");
-		if (editorWindow->effectShaderWidgets.empty()) {
-			ImGui::TextDisabled("No Effect Shaders available");
-		} else {
-			if (WeatherUtils::DrawFormPickerCached("Effect Shader", settings.effectShader, editorWindow->effectShaderWidgets, false, true))
-				changed = true;
-		}
-
-		ImGui::SeparatorText("Flags");
-		if (ImGui::Checkbox("Face Target", &settings.faceTarget))
+	ImGui::SeparatorText("Art Object");
+	if (editorWindow->artObjectWidgets.empty()) {
+		ImGui::TextDisabled("No Art Objects available");
+	} else {
+		if (WeatherUtils::DrawFormPickerCached("Art Object", settings.artObject, editorWindow->artObjectWidgets, false, true))
 			changed = true;
-		if (ImGui::Checkbox("Attach To Camera", &settings.attachToCamera))
-			changed = true;
-		if (ImGui::Checkbox("Inherit Rotation", &settings.inheritRotation))
-			changed = true;
+	}
 
-		if (changed && editorWindow->settings.autoApplyChanges) {
-			editorWindow->PushUndoState(this);
-			ApplyChanges();
-		}
-		EndScrollableContent();
+	ImGui::SeparatorText("Effect Shader");
+	if (editorWindow->effectShaderWidgets.empty()) {
+		ImGui::TextDisabled("No Effect Shaders available");
+	} else {
+		if (WeatherUtils::DrawFormPickerCached("Effect Shader", settings.effectShader, editorWindow->effectShaderWidgets, false, true))
+			changed = true;
+	}
+
+	ImGui::SeparatorText("Flags");
+	if (ImGui::Checkbox("Face Target", &settings.faceTarget))
+		changed = true;
+	if (ImGui::Checkbox("Attach To Camera", &settings.attachToCamera))
+		changed = true;
+	if (ImGui::Checkbox("Inherit Rotation", &settings.inheritRotation))
+		changed = true;
+
+	if (changed && editorWindow->settings.autoApplyChanges) {
+		editorWindow->PushUndoState(this);
+		ApplyChanges();
+	}
+	EndScrollableContent();
 	ImGui::End();
 }
 

--- a/src/WeatherEditor/Weather/ReferenceEffectWidget.cpp
+++ b/src/WeatherEditor/Weather/ReferenceEffectWidget.cpp
@@ -39,6 +39,7 @@ void ReferenceEffectWidget::DrawWidget()
 		changed = true;
 
 	if (changed && editorWindow->settings.autoApplyChanges) {
+		editorWindow->PushUndoState(this);
 		ApplyChanges();
 	}
 	EndScrollableContent();

--- a/src/WeatherEditor/Weather/ReferenceEffectWidget.cpp
+++ b/src/WeatherEditor/Weather/ReferenceEffectWidget.cpp
@@ -6,43 +6,46 @@ void ReferenceEffectWidget::DrawWidget()
 {
 	WeatherUtils::SetCurrentWidget(this);
 	ImGui::SetNextWindowSizeConstraints(ImVec2(600, 0), ImVec2(FLT_MAX, FLT_MAX));
-	if (ImGui::Begin(GetEditorID().c_str(), &open, ImGuiWindowFlags_NoSavedSettings | kStickyHeaderFlags)) {
-		DrawWidgetHeader("##ReferenceEffectSearch", true, true);
+	if (!ImGui::Begin(GetEditorID().c_str(), &open, ImGuiWindowFlags_NoSavedSettings | kStickyHeaderFlags)) {
+		ImGui::End();
+		return;
 	}
-	BeginScrollableContent("##REScroll");
-	bool changed = false;
+	DrawWidgetHeader("##ReferenceEffectSearch", true, true);
 
-	auto editorWindow = EditorWindow::GetSingleton();
+		BeginScrollableContent("##REScroll");
+		bool changed = false;
 
-	ImGui::SeparatorText("Art Object");
-	if (editorWindow->artObjectWidgets.empty()) {
-		ImGui::TextDisabled("No Art Objects available");
-	} else {
-		if (WeatherUtils::DrawFormPickerCached("Art Object", settings.artObject, editorWindow->artObjectWidgets, false, true))
+		auto editorWindow = EditorWindow::GetSingleton();
+
+		ImGui::SeparatorText("Art Object");
+		if (editorWindow->artObjectWidgets.empty()) {
+			ImGui::TextDisabled("No Art Objects available");
+		} else {
+			if (WeatherUtils::DrawFormPickerCached("Art Object", settings.artObject, editorWindow->artObjectWidgets, false, true))
+				changed = true;
+		}
+
+		ImGui::SeparatorText("Effect Shader");
+		if (editorWindow->effectShaderWidgets.empty()) {
+			ImGui::TextDisabled("No Effect Shaders available");
+		} else {
+			if (WeatherUtils::DrawFormPickerCached("Effect Shader", settings.effectShader, editorWindow->effectShaderWidgets, false, true))
+				changed = true;
+		}
+
+		ImGui::SeparatorText("Flags");
+		if (ImGui::Checkbox("Face Target", &settings.faceTarget))
 			changed = true;
-	}
-
-	ImGui::SeparatorText("Effect Shader");
-	if (editorWindow->effectShaderWidgets.empty()) {
-		ImGui::TextDisabled("No Effect Shaders available");
-	} else {
-		if (WeatherUtils::DrawFormPickerCached("Effect Shader", settings.effectShader, editorWindow->effectShaderWidgets, false, true))
+		if (ImGui::Checkbox("Attach To Camera", &settings.attachToCamera))
 			changed = true;
-	}
+		if (ImGui::Checkbox("Inherit Rotation", &settings.inheritRotation))
+			changed = true;
 
-	ImGui::SeparatorText("Flags");
-	if (ImGui::Checkbox("Face Target", &settings.faceTarget))
-		changed = true;
-	if (ImGui::Checkbox("Attach To Camera", &settings.attachToCamera))
-		changed = true;
-	if (ImGui::Checkbox("Inherit Rotation", &settings.inheritRotation))
-		changed = true;
-
-	if (changed && editorWindow->settings.autoApplyChanges) {
-		editorWindow->PushUndoState(this);
-		ApplyChanges();
-	}
-	EndScrollableContent();
+		if (changed && editorWindow->settings.autoApplyChanges) {
+			editorWindow->PushUndoState(this);
+			ApplyChanges();
+		}
+		EndScrollableContent();
 	ImGui::End();
 }
 

--- a/src/WeatherEditor/Weather/ReferenceEffectWidget.cpp
+++ b/src/WeatherEditor/Weather/ReferenceEffectWidget.cpp
@@ -4,46 +4,44 @@
 
 void ReferenceEffectWidget::DrawWidget()
 {
+	WeatherUtils::SetCurrentWidget(this);
 	ImGui::SetNextWindowSizeConstraints(ImVec2(600, 0), ImVec2(FLT_MAX, FLT_MAX));
 	if (ImGui::Begin(GetEditorID().c_str(), &open, ImGuiWindowFlags_NoSavedSettings | kStickyHeaderFlags)) {
 		DrawWidgetHeader("##ReferenceEffectSearch", true, true);
-		BeginScrollableContent("##REScroll");
-		{
-			bool changed = false;
-
-			auto editorWindow = EditorWindow::GetSingleton();
-
-			ImGui::SeparatorText("Art Object");
-			if (editorWindow->artObjectWidgets.empty()) {
-				ImGui::TextDisabled("No Art Objects available");
-			} else {
-				if (WeatherUtils::DrawFormPickerCached("Art Object", settings.artObject, editorWindow->artObjectWidgets, false, true))
-					changed = true;
-			}
-
-			ImGui::SeparatorText("Effect Shader");
-			if (editorWindow->effectShaderWidgets.empty()) {
-				ImGui::TextDisabled("No Effect Shaders available");
-			} else {
-				if (WeatherUtils::DrawFormPickerCached("Effect Shader", settings.effectShader, editorWindow->effectShaderWidgets, false, true))
-					changed = true;
-			}
-
-			ImGui::SeparatorText("Flags");
-			if (ImGui::Checkbox("Face Target", &settings.faceTarget))
-				changed = true;
-			if (ImGui::Checkbox("Attach To Camera", &settings.attachToCamera))
-				changed = true;
-			if (ImGui::Checkbox("Inherit Rotation", &settings.inheritRotation))
-				changed = true;
-
-			if (changed && editorWindow->settings.autoApplyChanges) {
-				editorWindow->PushUndoState(this);
-				ApplyChanges();
-			}
-		}
-		EndScrollableContent();
 	}
+	BeginScrollableContent("##REScroll");
+	bool changed = false;
+
+	auto editorWindow = EditorWindow::GetSingleton();
+
+	ImGui::SeparatorText("Art Object");
+	if (editorWindow->artObjectWidgets.empty()) {
+		ImGui::TextDisabled("No Art Objects available");
+	} else {
+		if (WeatherUtils::DrawFormPickerCached("Art Object", settings.artObject, editorWindow->artObjectWidgets, false, true))
+			changed = true;
+	}
+
+	ImGui::SeparatorText("Effect Shader");
+	if (editorWindow->effectShaderWidgets.empty()) {
+		ImGui::TextDisabled("No Effect Shaders available");
+	} else {
+		if (WeatherUtils::DrawFormPickerCached("Effect Shader", settings.effectShader, editorWindow->effectShaderWidgets, false, true))
+			changed = true;
+	}
+
+	ImGui::SeparatorText("Flags");
+	if (ImGui::Checkbox("Face Target", &settings.faceTarget))
+		changed = true;
+	if (ImGui::Checkbox("Attach To Camera", &settings.attachToCamera))
+		changed = true;
+	if (ImGui::Checkbox("Inherit Rotation", &settings.inheritRotation))
+		changed = true;
+
+	if (changed && editorWindow->settings.autoApplyChanges) {
+		ApplyChanges();
+	}
+	EndScrollableContent();
 	ImGui::End();
 }
 

--- a/src/WeatherEditor/Weather/ReferenceEffectWidget.h
+++ b/src/WeatherEditor/Weather/ReferenceEffectWidget.h
@@ -43,7 +43,4 @@ private:
 	Settings settings;
 	Settings vanillaSettings;
 	Settings originalSettings;
-
-	std::vector<RE::BGSArtObject*> artObjectArray;
-	std::vector<RE::TESEffectShader*> effectShaderArray;
 };

--- a/src/WeatherEditor/Weather/VolumetricLightingWidget.cpp
+++ b/src/WeatherEditor/Weather/VolumetricLightingWidget.cpp
@@ -27,9 +27,9 @@ void VolumetricLightingWidget::DrawWidget()
 	}
 	DrawWidgetHeader("##VolumetricLightingSearch", true, true);
 
-		bool changed = false;
+	bool changed = false;
 
-		if (ImGui::BeginTabBar("VolumetricLightingTabs")) {
+	if (ImGui::BeginTabBar("VolumetricLightingTabs")) {
 		if (ImGui::BeginTabItem("Basic")) {
 			BeginScrollableContent("##BasicScroll");
 			ImGui::SeparatorText("Intensity");
@@ -85,12 +85,12 @@ void VolumetricLightingWidget::DrawWidget()
 			ImGui::EndTabItem();
 		}
 
-			ImGui::EndTabBar();
-		}
+		ImGui::EndTabBar();
+	}
 
-		if (changed && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
-			ApplyChanges();
-		}
+	if (changed && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
+		ApplyChanges();
+	}
 	ImGui::End();
 }
 

--- a/src/WeatherEditor/Weather/VolumetricLightingWidget.cpp
+++ b/src/WeatherEditor/Weather/VolumetricLightingWidget.cpp
@@ -2,6 +2,21 @@
 #include "../EditorWindow.h"
 #include "../WeatherUtils.h"
 
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
+	VolumetricLightingWidget::Settings,
+	intensity,
+	customColorContribution,
+	red,
+	green,
+	blue,
+	densityContribution,
+	densitySize,
+	densityWindSpeed,
+	densityFallingSpeed,
+	phaseFunctionContribution,
+	phaseFunctionScattering,
+	samplingRangeFactor)
+
 void VolumetricLightingWidget::DrawWidget()
 {
 	WeatherUtils::SetCurrentWidget(this);
@@ -81,38 +96,14 @@ void VolumetricLightingWidget::LoadSettings()
 	if (!volumetricLighting)
 		return;
 
-	if (!js.empty()) {
-		settings = vanillaSettings;
-		try {
-			if (js.contains("intensity"))
-				settings.intensity = js["intensity"];
-			if (js.contains("customColorContribution"))
-				settings.customColorContribution = js["customColorContribution"];
-			if (js.contains("red"))
-				settings.red = js["red"];
-			if (js.contains("green"))
-				settings.green = js["green"];
-			if (js.contains("blue"))
-				settings.blue = js["blue"];
-			if (js.contains("densityContribution"))
-				settings.densityContribution = js["densityContribution"];
-			if (js.contains("densitySize"))
-				settings.densitySize = js["densitySize"];
-			if (js.contains("densityWindSpeed"))
-				settings.densityWindSpeed = js["densityWindSpeed"];
-			if (js.contains("densityFallingSpeed"))
-				settings.densityFallingSpeed = js["densityFallingSpeed"];
-			if (js.contains("phaseFunctionContribution"))
-				settings.phaseFunctionContribution = js["phaseFunctionContribution"];
-			if (js.contains("phaseFunctionScattering"))
-				settings.phaseFunctionScattering = js["phaseFunctionScattering"];
-			if (js.contains("samplingRangeFactor"))
-				settings.samplingRangeFactor = js["samplingRangeFactor"];
-		} catch (const std::exception& e) {
-			logger::error("VolumetricLighting {}: Failed to load from JSON: {}", GetEditorID(), e.what());
+	try {
+		if (!js.empty()) {
+			settings = js;
+		} else {
 			settings = vanillaSettings;
 		}
-	} else {
+	} catch (const std::exception& e) {
+		logger::error("VolumetricLighting {}: Failed to load from JSON: {}", GetEditorID(), e.what());
 		settings = vanillaSettings;
 	}
 
@@ -140,18 +131,7 @@ void VolumetricLightingWidget::LoadFromGameSettings()
 
 void VolumetricLightingWidget::SaveSettings()
 {
-	js["intensity"] = settings.intensity;
-	js["customColorContribution"] = settings.customColorContribution;
-	js["red"] = settings.red;
-	js["green"] = settings.green;
-	js["blue"] = settings.blue;
-	js["densityContribution"] = settings.densityContribution;
-	js["densitySize"] = settings.densitySize;
-	js["densityWindSpeed"] = settings.densityWindSpeed;
-	js["densityFallingSpeed"] = settings.densityFallingSpeed;
-	js["phaseFunctionContribution"] = settings.phaseFunctionContribution;
-	js["phaseFunctionScattering"] = settings.phaseFunctionScattering;
-	js["samplingRangeFactor"] = settings.samplingRangeFactor;
+	js = settings;
 	originalSettings = settings;
 }
 

--- a/src/WeatherEditor/Weather/VolumetricLightingWidget.cpp
+++ b/src/WeatherEditor/Weather/VolumetricLightingWidget.cpp
@@ -19,12 +19,12 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 
 void VolumetricLightingWidget::DrawWidget()
 {
-	WeatherUtils::SetCurrentWidget(this);
 	ImGui::SetNextWindowSizeConstraints(ImVec2(600, 0), ImVec2(FLT_MAX, FLT_MAX));
 	if (!ImGui::Begin(GetEditorID().c_str(), &open, ImGuiWindowFlags_NoSavedSettings | kStickyHeaderFlags)) {
 		ImGui::End();
 		return;
 	}
+	WeatherUtils::SetCurrentWidget(this);
 	DrawWidgetHeader("##VolumetricLightingSearch", true, true);
 
 	bool changed = false;
@@ -99,15 +99,16 @@ void VolumetricLightingWidget::LoadSettings()
 	if (!volumetricLighting)
 		return;
 
-	try {
-		if (!js.empty()) {
-			settings = js;
-		} else {
+	settings = vanillaSettings;
+	if (!js.empty()) {
+		try {
+			nlohmann::json merged = vanillaSettings;
+			merged.merge_patch(js);
+			settings = merged.get<Settings>();
+		} catch (const std::exception& e) {
+			logger::error("VolumetricLighting {}: Failed to load from JSON: {}", GetEditorID(), e.what());
 			settings = vanillaSettings;
 		}
-	} catch (const std::exception& e) {
-		logger::error("VolumetricLighting {}: Failed to load from JSON: {}", GetEditorID(), e.what());
-		settings = vanillaSettings;
 	}
 
 	originalSettings = settings;

--- a/src/WeatherEditor/Weather/VolumetricLightingWidget.cpp
+++ b/src/WeatherEditor/Weather/VolumetricLightingWidget.cpp
@@ -21,12 +21,15 @@ void VolumetricLightingWidget::DrawWidget()
 {
 	WeatherUtils::SetCurrentWidget(this);
 	ImGui::SetNextWindowSizeConstraints(ImVec2(600, 0), ImVec2(FLT_MAX, FLT_MAX));
-	if (ImGui::Begin(GetEditorID().c_str(), &open, ImGuiWindowFlags_NoSavedSettings | kStickyHeaderFlags)) {
-		DrawWidgetHeader("##VolumetricLightingSearch", true, true);
+	if (!ImGui::Begin(GetEditorID().c_str(), &open, ImGuiWindowFlags_NoSavedSettings | kStickyHeaderFlags)) {
+		ImGui::End();
+		return;
 	}
-	bool changed = false;
+	DrawWidgetHeader("##VolumetricLightingSearch", true, true);
 
-	if (ImGui::BeginTabBar("VolumetricLightingTabs")) {
+		bool changed = false;
+
+		if (ImGui::BeginTabBar("VolumetricLightingTabs")) {
 		if (ImGui::BeginTabItem("Basic")) {
 			BeginScrollableContent("##BasicScroll");
 			ImGui::SeparatorText("Intensity");
@@ -82,12 +85,12 @@ void VolumetricLightingWidget::DrawWidget()
 			ImGui::EndTabItem();
 		}
 
-		ImGui::EndTabBar();
-	}
+			ImGui::EndTabBar();
+		}
 
-	if (changed && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
-		ApplyChanges();
-	}
+		if (changed && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
+			ApplyChanges();
+		}
 	ImGui::End();
 }
 

--- a/src/WeatherEditor/Weather/VolumetricLightingWidget.cpp
+++ b/src/WeatherEditor/Weather/VolumetricLightingWidget.cpp
@@ -110,18 +110,18 @@ void VolumetricLightingWidget::LoadSettings()
 			auto safeClamp = [](float v, float lo, float hi, float fallback) {
 				return std::isfinite(v) ? std::clamp(v, lo, hi) : fallback;
 			};
-			settings.intensity                 = safeClamp(settings.intensity,                  0.0f,     50.0f, vanillaSettings.intensity);
-			settings.customColorContribution   = safeClamp(settings.customColorContribution,    0.0f,      1.0f, vanillaSettings.customColorContribution);
-			settings.red                       = safeClamp(settings.red,                        0.0f,      1.0f, vanillaSettings.red);
-			settings.green                     = safeClamp(settings.green,                      0.0f,      1.0f, vanillaSettings.green);
-			settings.blue                      = safeClamp(settings.blue,                       0.0f,      1.0f, vanillaSettings.blue);
-			settings.densityContribution       = safeClamp(settings.densityContribution,        0.0f,      1.0f, vanillaSettings.densityContribution);
-			settings.densitySize               = safeClamp(settings.densitySize,                0.1f,  10000.0f, vanillaSettings.densitySize);
-			settings.densityWindSpeed          = safeClamp(settings.densityWindSpeed,           0.0f,    100.0f, vanillaSettings.densityWindSpeed);
-			settings.densityFallingSpeed       = safeClamp(settings.densityFallingSpeed,        0.0f,    100.0f, vanillaSettings.densityFallingSpeed);
-			settings.phaseFunctionContribution = safeClamp(settings.phaseFunctionContribution,  0.0f,      1.0f, vanillaSettings.phaseFunctionContribution);
-			settings.phaseFunctionScattering   = safeClamp(settings.phaseFunctionScattering,    0.0f,      1.0f, vanillaSettings.phaseFunctionScattering);
-			settings.samplingRangeFactor       = safeClamp(settings.samplingRangeFactor,        0.0f,    160.0f, vanillaSettings.samplingRangeFactor);
+			settings.intensity = safeClamp(settings.intensity, 0.0f, 50.0f, vanillaSettings.intensity);
+			settings.customColorContribution = safeClamp(settings.customColorContribution, 0.0f, 1.0f, vanillaSettings.customColorContribution);
+			settings.red = safeClamp(settings.red, 0.0f, 1.0f, vanillaSettings.red);
+			settings.green = safeClamp(settings.green, 0.0f, 1.0f, vanillaSettings.green);
+			settings.blue = safeClamp(settings.blue, 0.0f, 1.0f, vanillaSettings.blue);
+			settings.densityContribution = safeClamp(settings.densityContribution, 0.0f, 1.0f, vanillaSettings.densityContribution);
+			settings.densitySize = safeClamp(settings.densitySize, 0.1f, 10000.0f, vanillaSettings.densitySize);
+			settings.densityWindSpeed = safeClamp(settings.densityWindSpeed, 0.0f, 100.0f, vanillaSettings.densityWindSpeed);
+			settings.densityFallingSpeed = safeClamp(settings.densityFallingSpeed, 0.0f, 100.0f, vanillaSettings.densityFallingSpeed);
+			settings.phaseFunctionContribution = safeClamp(settings.phaseFunctionContribution, 0.0f, 1.0f, vanillaSettings.phaseFunctionContribution);
+			settings.phaseFunctionScattering = safeClamp(settings.phaseFunctionScattering, 0.0f, 1.0f, vanillaSettings.phaseFunctionScattering);
+			settings.samplingRangeFactor = safeClamp(settings.samplingRangeFactor, 0.0f, 160.0f, vanillaSettings.samplingRangeFactor);
 		} catch (const std::exception& e) {
 			logger::error("VolumetricLighting {}: Failed to load from JSON: {}", GetEditorID(), e.what());
 			settings = vanillaSettings;

--- a/src/WeatherEditor/Weather/VolumetricLightingWidget.cpp
+++ b/src/WeatherEditor/Weather/VolumetricLightingWidget.cpp
@@ -105,6 +105,23 @@ void VolumetricLightingWidget::LoadSettings()
 			nlohmann::json merged = vanillaSettings;
 			merged.merge_patch(js);
 			settings = merged.get<Settings>();
+
+			// Clamp/validate all numeric fields; replace non-finite values with vanilla fallbacks
+			auto safeClamp = [](float v, float lo, float hi, float fallback) {
+				return std::isfinite(v) ? std::clamp(v, lo, hi) : fallback;
+			};
+			settings.intensity                 = safeClamp(settings.intensity,                  0.0f,     50.0f, vanillaSettings.intensity);
+			settings.customColorContribution   = safeClamp(settings.customColorContribution,    0.0f,      1.0f, vanillaSettings.customColorContribution);
+			settings.red                       = safeClamp(settings.red,                        0.0f,      1.0f, vanillaSettings.red);
+			settings.green                     = safeClamp(settings.green,                      0.0f,      1.0f, vanillaSettings.green);
+			settings.blue                      = safeClamp(settings.blue,                       0.0f,      1.0f, vanillaSettings.blue);
+			settings.densityContribution       = safeClamp(settings.densityContribution,        0.0f,      1.0f, vanillaSettings.densityContribution);
+			settings.densitySize               = safeClamp(settings.densitySize,                0.1f,  10000.0f, vanillaSettings.densitySize);
+			settings.densityWindSpeed          = safeClamp(settings.densityWindSpeed,           0.0f,    100.0f, vanillaSettings.densityWindSpeed);
+			settings.densityFallingSpeed       = safeClamp(settings.densityFallingSpeed,        0.0f,    100.0f, vanillaSettings.densityFallingSpeed);
+			settings.phaseFunctionContribution = safeClamp(settings.phaseFunctionContribution,  0.0f,      1.0f, vanillaSettings.phaseFunctionContribution);
+			settings.phaseFunctionScattering   = safeClamp(settings.phaseFunctionScattering,    0.0f,      1.0f, vanillaSettings.phaseFunctionScattering);
+			settings.samplingRangeFactor       = safeClamp(settings.samplingRangeFactor,        0.0f,    160.0f, vanillaSettings.samplingRangeFactor);
 		} catch (const std::exception& e) {
 			logger::error("VolumetricLighting {}: Failed to load from JSON: {}", GetEditorID(), e.what());
 			settings = vanillaSettings;

--- a/src/WeatherEditor/Weather/VolumetricLightingWidget.h
+++ b/src/WeatherEditor/Weather/VolumetricLightingWidget.h
@@ -25,11 +25,7 @@ public:
 	void RevertChanges() override;
 	bool HasUnsavedChanges() const override;
 
-	RE::BGSVolumetricLighting* volumetricLighting = nullptr;
-
-private:
-	void LoadFromGameSettings();
-
+	// Public type required by NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT macro
 	struct Settings
 	{
 		float intensity = 1.0f;
@@ -46,6 +42,11 @@ private:
 		float samplingRangeFactor = 1.0f;
 		bool operator==(const Settings&) const = default;
 	};
+
+private:
+	void LoadFromGameSettings();
+
+	RE::BGSVolumetricLighting* volumetricLighting = nullptr;
 
 	Settings settings;
 	Settings vanillaSettings;

--- a/src/WeatherEditor/Weather/WeatherWidget.cpp
+++ b/src/WeatherEditor/Weather/WeatherWidget.cpp
@@ -54,12 +54,12 @@ WeatherWidget::~WeatherWidget()
 
 void WeatherWidget::DrawWidget()
 {
-	WeatherUtils::SetCurrentWidget(this);
 	ImGui::SetNextWindowSizeConstraints(ImVec2(600, 0), ImVec2(FLT_MAX, FLT_MAX));
 	if (!ImGui::Begin(GetEditorID().c_str(), &open, ImGuiWindowFlags_NoSavedSettings | kStickyHeaderFlags)) {
 		ImGui::End();
 		return;
 	}
+	WeatherUtils::SetCurrentWidget(this);
 	// Draw header with search and all buttons
 	DrawWidgetHeader("##WeatherSearch", false, true, true, weather);
 
@@ -76,7 +76,7 @@ void WeatherWidget::DrawWidget()
 		ImGui::SetNextWindowFocus();
 		ImGui::PushStyleVar(ImGuiStyleVar_Alpha, 1.0f);
 		ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4(0.16f, 0.16f, 0.16f, 1.0f));
-		if (ImGui::Begin("##SearchDropdown", nullptr,
+		if (ImGui::Begin(std::format("##SearchDropdown_{}", GetEditorID()).c_str(), nullptr,
 				ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize |
 					ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoSavedSettings)) {
 			for (size_t i = 0; i < std::min(size_t(5), searchResults.size()); ++i) {
@@ -239,7 +239,6 @@ void WeatherWidget::DrawWidget()
 			ImGui::Spacing();
 			ImGui::Separator();
 			ImGui::Spacing();
-			auto* editorWindow = EditorWindow::GetSingleton();
 
 			bool recordChanged = false;
 			bool hasParent = editorWindow->settings.enableInheritFromParent && HasParent();
@@ -420,6 +419,7 @@ void WeatherWidget::DrawWidget()
 			}
 
 			if (recordChanged && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
+				EditorWindow::GetSingleton()->PushUndoState(this);
 				ApplyChanges();
 			}
 
@@ -427,8 +427,8 @@ void WeatherWidget::DrawWidget()
 			ImGui::EndTabItem();
 		}
 		ImGui::EndTabBar();
-		ImGui::End();
 	}
+	ImGui::End();
 }
 
 void WeatherWidget::LoadSettings()

--- a/src/WeatherEditor/Weather/WeatherWidget.cpp
+++ b/src/WeatherEditor/Weather/WeatherWidget.cpp
@@ -125,7 +125,6 @@ void WeatherWidget::DrawWidget()
 			}
 
 			for (auto& widget : widgets) {
-
 				// Skip self-selection
 				if (widget.get() == this)
 					continue;

--- a/src/WeatherEditor/Weather/WeatherWidget.cpp
+++ b/src/WeatherEditor/Weather/WeatherWidget.cpp
@@ -172,92 +172,181 @@ void WeatherWidget::DrawWidget()
 	}
 
 	// Tab bar for organizing settings
-if (ImGui::BeginTabBar("WeatherSettingsTabs", ImGuiTabBarFlags_None)) {
-	// Use activeTabOverride to auto-navigate to specific tab
-	ImGuiTabItemFlags basicFlags = (activeTabOverride == "Basic") ? ImGuiTabItemFlags_SetSelected : 0;
-	ImGuiTabItemFlags dalcFlags = (activeTabOverride == "Lighting (DALC)") ? ImGuiTabItemFlags_SetSelected : 0;
-	ImGuiTabItemFlags atmosphereFlags = (activeTabOverride == "Atmosphere Colors") ? ImGuiTabItemFlags_SetSelected : 0;
-	ImGuiTabItemFlags cloudsFlags = (activeTabOverride == "Clouds") ? ImGuiTabItemFlags_SetSelected : 0;
-	ImGuiTabItemFlags fogFlags = (activeTabOverride == "Fog") ? ImGuiTabItemFlags_SetSelected : 0;
-	ImGuiTabItemFlags featuresFlags = (activeTabOverride == "Features") ? ImGuiTabItemFlags_SetSelected : 0;
-	ImGuiTabItemFlags recordsFlags = (activeTabOverride == "Records") ? ImGuiTabItemFlags_SetSelected : 0;
-	if (!activeTabOverride.empty()) {
-		activeTabOverride = "";  // Clear after use
-	}
+	if (ImGui::BeginTabBar("WeatherSettingsTabs", ImGuiTabBarFlags_None)) {
+		// Use activeTabOverride to auto-navigate to specific tab
+		ImGuiTabItemFlags basicFlags = (activeTabOverride == "Basic") ? ImGuiTabItemFlags_SetSelected : 0;
+		ImGuiTabItemFlags dalcFlags = (activeTabOverride == "Lighting (DALC)") ? ImGuiTabItemFlags_SetSelected : 0;
+		ImGuiTabItemFlags atmosphereFlags = (activeTabOverride == "Atmosphere Colors") ? ImGuiTabItemFlags_SetSelected : 0;
+		ImGuiTabItemFlags cloudsFlags = (activeTabOverride == "Clouds") ? ImGuiTabItemFlags_SetSelected : 0;
+		ImGuiTabItemFlags fogFlags = (activeTabOverride == "Fog") ? ImGuiTabItemFlags_SetSelected : 0;
+		ImGuiTabItemFlags featuresFlags = (activeTabOverride == "Features") ? ImGuiTabItemFlags_SetSelected : 0;
+		ImGuiTabItemFlags recordsFlags = (activeTabOverride == "Records") ? ImGuiTabItemFlags_SetSelected : 0;
+		if (!activeTabOverride.empty()) {
+			activeTabOverride = "";  // Clear after use
+		}
 
-	if (ImGui::BeginTabItem("Basic", nullptr, basicFlags)) {
-		BeginScrollableContent("##BasicScroll");
-		DrawProperties("Sun", { { "Sun Damage", INT8_SLIDER } });
-		DrawProperties("Wind", { { "Wind Speed", UINT8_SLIDER }, { "Wind Direction", INT8_SLIDER }, { "Wind Direction Range", INT8_SLIDER } });
-		DrawProperties("Precipitation", { { "Precipitation Begin Fade In", INT8_SLIDER }, { "Precipitation End Fade Out", INT8_SLIDER } });
-		DrawProperties("Lightning", { { "Thunder Lightning Begin Fade In", INT8_SLIDER }, { "Thunder Lightning End Fade Out", INT8_SLIDER },
-										{ "Thunder Lightning Frequency", INT8_SLIDER }, { "Lightning Color", COLOR3_PICKER } });
-		DrawProperties("Visual Effects", { { "Visual Effect Begin", INT8_SLIDER }, { "Visual Effect End", INT8_SLIDER } });
-		DrawProperties("Weather Transition", { { "Trans Delta", INT8_SLIDER } });
-		EndScrollableContent();
-		ImGui::EndTabItem();
-	}
-	if (ImGui::BeginTabItem("Lighting (DALC)", nullptr, dalcFlags)) {
-		BeginScrollableContent("##DALCScroll");
-		DrawDALCSettings();
-		EndScrollableContent();
-		ImGui::EndTabItem();
-	}
+		if (ImGui::BeginTabItem("Basic", nullptr, basicFlags)) {
+			BeginScrollableContent("##BasicScroll");
+			DrawProperties("Sun", { { "Sun Damage", INT8_SLIDER } });
+			DrawProperties("Wind", { { "Wind Speed", UINT8_SLIDER }, { "Wind Direction", INT8_SLIDER }, { "Wind Direction Range", INT8_SLIDER } });
+			DrawProperties("Precipitation", { { "Precipitation Begin Fade In", INT8_SLIDER }, { "Precipitation End Fade Out", INT8_SLIDER } });
+			DrawProperties("Lightning", { { "Thunder Lightning Begin Fade In", INT8_SLIDER }, { "Thunder Lightning End Fade Out", INT8_SLIDER },
+											{ "Thunder Lightning Frequency", INT8_SLIDER }, { "Lightning Color", COLOR3_PICKER } });
+			DrawProperties("Visual Effects", { { "Visual Effect Begin", INT8_SLIDER }, { "Visual Effect End", INT8_SLIDER } });
+			DrawProperties("Weather Transition", { { "Trans Delta", INT8_SLIDER } });
+			EndScrollableContent();
+			ImGui::EndTabItem();
+		}
+		if (ImGui::BeginTabItem("Lighting (DALC)", nullptr, dalcFlags)) {
+			BeginScrollableContent("##DALCScroll");
+			DrawDALCSettings();
+			EndScrollableContent();
+			ImGui::EndTabItem();
+		}
 
-	if (ImGui::BeginTabItem("Atmosphere Colors", nullptr, atmosphereFlags)) {
-		BeginScrollableContent("##AtmosphereScroll");
-		DrawWeatherColorSettings();
-		EndScrollableContent();
-		ImGui::EndTabItem();
-	}
+		if (ImGui::BeginTabItem("Atmosphere Colors", nullptr, atmosphereFlags)) {
+			BeginScrollableContent("##AtmosphereScroll");
+			DrawWeatherColorSettings();
+			EndScrollableContent();
+			ImGui::EndTabItem();
+		}
 
-	if (ImGui::BeginTabItem("Clouds", nullptr, cloudsFlags)) {
-		BeginScrollableContent("##CloudsScroll");
-		DrawCloudSettings();
-		EndScrollableContent();
-		ImGui::EndTabItem();
-	}
+		if (ImGui::BeginTabItem("Clouds", nullptr, cloudsFlags)) {
+			BeginScrollableContent("##CloudsScroll");
+			DrawCloudSettings();
+			EndScrollableContent();
+			ImGui::EndTabItem();
+		}
 
-	if (ImGui::BeginTabItem("Fog", nullptr, fogFlags)) {
-		BeginScrollableContent("##FogScroll");
-		DrawFogSettings();
-		EndScrollableContent();
-		ImGui::EndTabItem();
-	}
+		if (ImGui::BeginTabItem("Fog", nullptr, fogFlags)) {
+			BeginScrollableContent("##FogScroll");
+			DrawFogSettings();
+			EndScrollableContent();
+			ImGui::EndTabItem();
+		}
 
-	if (ImGui::BeginTabItem("Features", nullptr, featuresFlags)) {
-		BeginScrollableContent("##FeaturesScroll");
-		DrawFeatureSettings();
-		EndScrollableContent();
-		ImGui::EndTabItem();
-	}
+		if (ImGui::BeginTabItem("Features", nullptr, featuresFlags)) {
+			BeginScrollableContent("##FeaturesScroll");
+			DrawFeatureSettings();
+			EndScrollableContent();
+			ImGui::EndTabItem();
+		}
 
-	if (ImGui::BeginTabItem("Records", nullptr, recordsFlags)) {
-		BeginScrollableContent("##RecordsScroll");
-		ImGui::Spacing();
-		ImGui::TextWrapped("Form record references used by this weather.");
-		ImGui::Spacing();
-		ImGui::Separator();
-		ImGui::Spacing();
-		auto* editorWindow = EditorWindow::GetSingleton();
+		if (ImGui::BeginTabItem("Records", nullptr, recordsFlags)) {
+			BeginScrollableContent("##RecordsScroll");
+			ImGui::Spacing();
+			ImGui::TextWrapped("Form record references used by this weather.");
+			ImGui::Spacing();
+			ImGui::Separator();
+			ImGui::Spacing();
+			auto* editorWindow = EditorWindow::GetSingleton();
 
-		bool recordChanged = false;
-		bool hasParent = editorWindow->settings.enableInheritFromParent && HasParent();
-		WeatherWidget* parentWidget = hasParent ? GetParent() : nullptr;
+			bool recordChanged = false;
+			bool hasParent = editorWindow->settings.enableInheritFromParent && HasParent();
+			WeatherWidget* parentWidget = hasParent ? GetParent() : nullptr;
 
-		// ImageSpace Records (per time of day)
-		if (ImGui::CollapsingHeader("ImageSpace", ImGuiTreeNodeFlags_DefaultOpen)) {
-			for (int i = 0; i < ColorTimes::kTotal; i++) {
-				ImGui::PushID(i);
-				std::string label = ColorTimeLabel(i);
-				std::string inheritKey = "ImageSpace_" + std::to_string(i);
+			// ImageSpace Records (per time of day)
+			if (ImGui::CollapsingHeader("ImageSpace", ImGuiTreeNodeFlags_DefaultOpen)) {
+				for (int i = 0; i < ColorTimes::kTotal; i++) {
+					ImGui::PushID(i);
+					std::string label = ColorTimeLabel(i);
+					std::string inheritKey = "ImageSpace_" + std::to_string(i);
 
+					// Inherit checkbox
+					if (hasParent) {
+						bool& inheritFlag = settings.inheritFlags[inheritKey];
+						if (ImGui::Checkbox(("##inherit_" + inheritKey).c_str(), &inheritFlag)) {
+							if (inheritFlag && parentWidget) {
+								weather->imageSpaces[i] = parentWidget->weather->imageSpaces[i];
+								recordChanged = true;
+							}
+						}
+						if (ImGui::IsItemHovered()) {
+							ImGui::SetTooltip(inheritFlag ? "Inheriting from parent" : "Inherit from parent");
+						}
+						ImGui::SameLine();
+					}
+
+					ImGui::Text("%s:", label.c_str());
+					ImGui::SameLine(hasParent ? 120.0f : 100.0f);
+					if (WeatherUtils::DrawFormPickerCached("##ImageSpace", weather->imageSpaces[i], editorWindow->imageSpaceWidgets, false, true)) {
+						recordChanged = true;
+					}  // Add "Open" button
+					if (weather->imageSpaces[i]) {
+						ImGui::SameLine();
+						if (ImGui::SmallButton(std::format("Open##{}", i).c_str())) {
+							for (auto& widget : editorWindow->imageSpaceWidgets) {
+								if (widget->form == weather->imageSpaces[i]) {
+									widget->SetOpen(true);
+									break;
+								}
+							}
+						}
+						if (ImGui::IsItemHovered()) {
+							ImGui::SetTooltip("Open this ImageSpace for editing");
+						}
+					}
+
+					ImGui::PopID();
+				}
+				ImGui::Spacing();
+			}
+
+			// Volumetric Lighting Records (per time of day)
+			if (ImGui::CollapsingHeader("Volumetric Lighting", ImGuiTreeNodeFlags_DefaultOpen)) {
+				for (int i = 0; i < ColorTimes::kTotal; i++) {
+					ImGui::PushID(100 + i);
+					std::string label = ColorTimeLabel(i);
+					std::string inheritKey = "VolumetricLighting_" + std::to_string(i);
+
+					// Inherit checkbox
+					if (hasParent) {
+						bool& inheritFlag = settings.inheritFlags[inheritKey];
+						if (ImGui::Checkbox(("##inherit_" + inheritKey).c_str(), &inheritFlag)) {
+							if (inheritFlag && parentWidget) {
+								weather->volumetricLighting[i] = parentWidget->weather->volumetricLighting[i];
+								recordChanged = true;
+							}
+						}
+						if (ImGui::IsItemHovered()) {
+							ImGui::SetTooltip(inheritFlag ? "Inheriting from parent" : "Inherit from parent");
+						}
+						ImGui::SameLine();
+					}
+
+					ImGui::Text("%s:", label.c_str());
+					ImGui::SameLine(hasParent ? 120.0f : 100.0f);
+					if (WeatherUtils::DrawFormPickerCached("##VolumetricLighting", weather->volumetricLighting[i], editorWindow->volumetricLightingWidgets, false, true)) {
+						recordChanged = true;
+					}  // Add "Open" button
+					if (weather->volumetricLighting[i]) {
+						ImGui::SameLine();
+						if (ImGui::SmallButton(std::format("Open##{}", i).c_str())) {
+							for (auto& widget : editorWindow->volumetricLightingWidgets) {
+								if (widget->form == weather->volumetricLighting[i]) {
+									widget->SetOpen(true);
+									break;
+								}
+							}
+						}
+						if (ImGui::IsItemHovered()) {
+							ImGui::SetTooltip("Open this Volumetric Lighting for editing");
+						}
+					}
+
+					ImGui::PopID();
+				}
+				ImGui::Spacing();
+			}
+
+			// Precipitation Data
+			if (ImGui::CollapsingHeader("Precipitation", ImGuiTreeNodeFlags_DefaultOpen)) {
 				// Inherit checkbox
 				if (hasParent) {
-					bool& inheritFlag = settings.inheritFlags[inheritKey];
-					if (ImGui::Checkbox(("##inherit_" + inheritKey).c_str(), &inheritFlag)) {
+					bool& inheritFlag = settings.inheritFlags["Precipitation"];
+					if (ImGui::Checkbox("##inherit_Precipitation", &inheritFlag)) {
 						if (inheritFlag && parentWidget) {
-							weather->imageSpaces[i] = parentWidget->weather->imageSpaces[i];
+							weather->precipitationData = parentWidget->weather->precipitationData;
 							recordChanged = true;
 						}
 					}
@@ -267,44 +356,37 @@ if (ImGui::BeginTabBar("WeatherSettingsTabs", ImGuiTabBarFlags_None)) {
 					ImGui::SameLine();
 				}
 
-				ImGui::Text("%s:", label.c_str());
-				ImGui::SameLine(hasParent ? 120.0f : 100.0f);
-				if (WeatherUtils::DrawFormPickerCached("##ImageSpace", weather->imageSpaces[i], editorWindow->imageSpaceWidgets, false, true)) {
+				ImGui::Text("Particle Shader:");
+				ImGui::SameLine(hasParent ? 170.0f : 150.0f);
+				if (WeatherUtils::DrawFormPickerCached("##Precipitation", weather->precipitationData, editorWindow->precipitationWidgets, false, true)) {
 					recordChanged = true;
 				}  // Add "Open" button
-				if (weather->imageSpaces[i]) {
+				if (weather->precipitationData) {
 					ImGui::SameLine();
-					if (ImGui::SmallButton(std::format("Open##{}", i).c_str())) {
-						for (auto& widget : editorWindow->imageSpaceWidgets) {
-							if (widget->form == weather->imageSpaces[i]) {
+					if (ImGui::SmallButton("Open##Precip")) {
+						for (auto& widget : editorWindow->precipitationWidgets) {
+							if (widget->form == weather->precipitationData) {
 								widget->SetOpen(true);
 								break;
 							}
 						}
 					}
 					if (ImGui::IsItemHovered()) {
-						ImGui::SetTooltip("Open this ImageSpace for editing");
+						ImGui::SetTooltip("Open this Precipitation for editing");
 					}
 				}
 
-				ImGui::PopID();
+				ImGui::Spacing();
 			}
-			ImGui::Spacing();
-		}
 
-		// Volumetric Lighting Records (per time of day)
-		if (ImGui::CollapsingHeader("Volumetric Lighting", ImGuiTreeNodeFlags_DefaultOpen)) {
-			for (int i = 0; i < ColorTimes::kTotal; i++) {
-				ImGui::PushID(100 + i);
-				std::string label = ColorTimeLabel(i);
-				std::string inheritKey = "VolumetricLighting_" + std::to_string(i);
-
+			// Visual Effect (Reference Effect)
+			if (ImGui::CollapsingHeader("Visual Effect", ImGuiTreeNodeFlags_DefaultOpen)) {
 				// Inherit checkbox
 				if (hasParent) {
-					bool& inheritFlag = settings.inheritFlags[inheritKey];
-					if (ImGui::Checkbox(("##inherit_" + inheritKey).c_str(), &inheritFlag)) {
+					bool& inheritFlag = settings.inheritFlags["ReferenceEffect"];
+					if (ImGui::Checkbox("##inherit_ReferenceEffect", &inheritFlag)) {
 						if (inheritFlag && parentWidget) {
-							weather->volumetricLighting[i] = parentWidget->weather->volumetricLighting[i];
+							weather->referenceEffect = parentWidget->weather->referenceEffect;
 							recordChanged = true;
 						}
 					}
@@ -314,120 +396,39 @@ if (ImGui::BeginTabBar("WeatherSettingsTabs", ImGuiTabBarFlags_None)) {
 					ImGui::SameLine();
 				}
 
-				ImGui::Text("%s:", label.c_str());
-				ImGui::SameLine(hasParent ? 120.0f : 100.0f);
-				if (WeatherUtils::DrawFormPickerCached("##VolumetricLighting", weather->volumetricLighting[i], editorWindow->volumetricLightingWidgets, false, true)) {
+				ImGui::Text("Reference Effect:");
+				ImGui::SameLine(hasParent ? 170.0f : 150.0f);
+				if (WeatherUtils::DrawFormPickerCached("##ReferenceEffect", weather->referenceEffect, editorWindow->referenceEffectWidgets, false, true)) {
 					recordChanged = true;
 				}  // Add "Open" button
-				if (weather->volumetricLighting[i]) {
+				if (weather->referenceEffect) {
 					ImGui::SameLine();
-					if (ImGui::SmallButton(std::format("Open##{}", i).c_str())) {
-						for (auto& widget : editorWindow->volumetricLightingWidgets) {
-							if (widget->form == weather->volumetricLighting[i]) {
+					if (ImGui::SmallButton("Open##RefEffect")) {
+						for (auto& widget : editorWindow->referenceEffectWidgets) {
+							if (widget->form == weather->referenceEffect) {
 								widget->SetOpen(true);
 								break;
 							}
 						}
 					}
 					if (ImGui::IsItemHovered()) {
-						ImGui::SetTooltip("Open this Volumetric Lighting for editing");
+						ImGui::SetTooltip("Open this Visual Effect for editing");
 					}
 				}
 
-				ImGui::PopID();
+				ImGui::Spacing();
 			}
-			ImGui::Spacing();
+
+			if (recordChanged && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
+				ApplyChanges();
+			}
+
+			EndScrollableContent();
+			ImGui::EndTabItem();
 		}
-
-		// Precipitation Data
-		if (ImGui::CollapsingHeader("Precipitation", ImGuiTreeNodeFlags_DefaultOpen)) {
-			// Inherit checkbox
-			if (hasParent) {
-				bool& inheritFlag = settings.inheritFlags["Precipitation"];
-				if (ImGui::Checkbox("##inherit_Precipitation", &inheritFlag)) {
-					if (inheritFlag && parentWidget) {
-						weather->precipitationData = parentWidget->weather->precipitationData;
-						recordChanged = true;
-					}
-				}
-				if (ImGui::IsItemHovered()) {
-					ImGui::SetTooltip(inheritFlag ? "Inheriting from parent" : "Inherit from parent");
-				}
-				ImGui::SameLine();
-			}
-
-			ImGui::Text("Particle Shader:");
-			ImGui::SameLine(hasParent ? 170.0f : 150.0f);
-			if (WeatherUtils::DrawFormPickerCached("##Precipitation", weather->precipitationData, editorWindow->precipitationWidgets, false, true)) {
-				recordChanged = true;
-			}  // Add "Open" button
-			if (weather->precipitationData) {
-				ImGui::SameLine();
-				if (ImGui::SmallButton("Open##Precip")) {
-					for (auto& widget : editorWindow->precipitationWidgets) {
-						if (widget->form == weather->precipitationData) {
-							widget->SetOpen(true);
-							break;
-						}
-					}
-				}
-				if (ImGui::IsItemHovered()) {
-					ImGui::SetTooltip("Open this Precipitation for editing");
-				}
-			}
-
-			ImGui::Spacing();
-		}
-
-		// Visual Effect (Reference Effect)
-		if (ImGui::CollapsingHeader("Visual Effect", ImGuiTreeNodeFlags_DefaultOpen)) {
-			// Inherit checkbox
-			if (hasParent) {
-				bool& inheritFlag = settings.inheritFlags["ReferenceEffect"];
-				if (ImGui::Checkbox("##inherit_ReferenceEffect", &inheritFlag)) {
-					if (inheritFlag && parentWidget) {
-						weather->referenceEffect = parentWidget->weather->referenceEffect;
-						recordChanged = true;
-					}
-				}
-				if (ImGui::IsItemHovered()) {
-					ImGui::SetTooltip(inheritFlag ? "Inheriting from parent" : "Inherit from parent");
-				}
-				ImGui::SameLine();
-			}
-
-			ImGui::Text("Reference Effect:");
-			ImGui::SameLine(hasParent ? 170.0f : 150.0f);
-			if (WeatherUtils::DrawFormPickerCached("##ReferenceEffect", weather->referenceEffect, editorWindow->referenceEffectWidgets, false, true)) {
-				recordChanged = true;
-			}  // Add "Open" button
-			if (weather->referenceEffect) {
-				ImGui::SameLine();
-				if (ImGui::SmallButton("Open##RefEffect")) {
-					for (auto& widget : editorWindow->referenceEffectWidgets) {
-						if (widget->form == weather->referenceEffect) {
-							widget->SetOpen(true);
-							break;
-						}
-					}
-				}
-				if (ImGui::IsItemHovered()) {
-					ImGui::SetTooltip("Open this Visual Effect for editing");
-				}
-			}
-
-			ImGui::Spacing();
-		}
-
-		if (recordChanged && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
-			ApplyChanges();
-		}
-
-		EndScrollableContent();
-		ImGui::EndTabItem();
+		ImGui::EndTabBar();
+		ImGui::End();
 	}
-	ImGui::EndTabBar();
-	ImGui::End();
 }
 
 void WeatherWidget::LoadSettings()

--- a/src/WeatherEditor/Weather/WeatherWidget.cpp
+++ b/src/WeatherEditor/Weather/WeatherWidget.cpp
@@ -172,1175 +172,182 @@ void WeatherWidget::DrawWidget()
 	}
 
 	// Tab bar for organizing settings
-	if (ImGui::BeginTabBar("WeatherSettingsTabs", ImGuiTabBarFlags_None)) {
-		// Use activeTabOverride to auto-navigate to specific tab
-		ImGuiTabItemFlags basicFlags = (activeTabOverride == "Basic") ? ImGuiTabItemFlags_SetSelected : 0;
-		ImGuiTabItemFlags dalcFlags = (activeTabOverride == "Lighting (DALC)") ? ImGuiTabItemFlags_SetSelected : 0;
-		ImGuiTabItemFlags atmosphereFlags = (activeTabOverride == "Atmosphere Colors") ? ImGuiTabItemFlags_SetSelected : 0;
-		ImGuiTabItemFlags cloudsFlags = (activeTabOverride == "Clouds") ? ImGuiTabItemFlags_SetSelected : 0;
-		ImGuiTabItemFlags fogFlags = (activeTabOverride == "Fog") ? ImGuiTabItemFlags_SetSelected : 0;
-		ImGuiTabItemFlags featuresFlags = (activeTabOverride == "Features") ? ImGuiTabItemFlags_SetSelected : 0;
-		ImGuiTabItemFlags recordsFlags = (activeTabOverride == "Records") ? ImGuiTabItemFlags_SetSelected : 0;
-		if (!activeTabOverride.empty()) {
-			activeTabOverride = "";  // Clear after use
-		}
-
-		if (ImGui::BeginTabItem("Basic", nullptr, basicFlags)) {
-			BeginScrollableContent("##BasicScroll");
-			DrawProperties("Sun", { { "Sun Damage", INT8_SLIDER } });
-			DrawProperties("Wind", { { "Wind Speed", UINT8_SLIDER }, { "Wind Direction", INT8_SLIDER }, { "Wind Direction Range", INT8_SLIDER } });
-			DrawProperties("Precipitation", { { "Precipitation Begin Fade In", INT8_SLIDER }, { "Precipitation End Fade Out", INT8_SLIDER } });
-			DrawProperties("Lightning", { { "Thunder Lightning Begin Fade In", INT8_SLIDER }, { "Thunder Lightning End Fade Out", INT8_SLIDER },
-											{ "Thunder Lightning Frequency", INT8_SLIDER }, { "Lightning Color", COLOR3_PICKER } });
-			DrawProperties("Visual Effects", { { "Visual Effect Begin", INT8_SLIDER }, { "Visual Effect End", INT8_SLIDER } });
-			DrawProperties("Weather Transition", { { "Trans Delta", INT8_SLIDER } });
-			EndScrollableContent();
-			ImGui::EndTabItem();
-		}
-		if (ImGui::BeginTabItem("Lighting (DALC)", nullptr, dalcFlags)) {
-			BeginScrollableContent("##DALCScroll");
-			DrawDALCSettings();
-			EndScrollableContent();
-			ImGui::EndTabItem();
-		}
-
-		if (ImGui::BeginTabItem("Atmosphere Colors", nullptr, atmosphereFlags)) {
-			BeginScrollableContent("##AtmosphereScroll");
-			DrawWeatherColorSettings();
-			EndScrollableContent();
-			ImGui::EndTabItem();
-		}
-
-		if (ImGui::BeginTabItem("Clouds", nullptr, cloudsFlags)) {
-			BeginScrollableContent("##CloudsScroll");
-			DrawCloudSettings();
-			EndScrollableContent();
-			ImGui::EndTabItem();
-		}
-
-		if (ImGui::BeginTabItem("Fog", nullptr, fogFlags)) {
-			BeginScrollableContent("##FogScroll");
-			DrawFogSettings();
-			EndScrollableContent();
-			ImGui::EndTabItem();
-		}
-
-		if (ImGui::BeginTabItem("Features", nullptr, featuresFlags)) {
-			BeginScrollableContent("##FeaturesScroll");
-			DrawFeatureSettings();
-			EndScrollableContent();
-			ImGui::EndTabItem();
-		}
-
-		if (ImGui::BeginTabItem("Records", nullptr, recordsFlags)) {
-			BeginScrollableContent("##RecordsScroll");
-			ImGui::Spacing();
-			ImGui::TextWrapped("Form record references used by this weather.");
-			ImGui::Spacing();
-			ImGui::Separator();
-			ImGui::Spacing();
-			auto* editorWindow = EditorWindow::GetSingleton();
-
-			bool recordChanged = false;
-			bool hasParent = editorWindow->settings.enableInheritFromParent && HasParent();
-			WeatherWidget* parentWidget = hasParent ? GetParent() : nullptr;
-
-			// ImageSpace Records (per time of day)
-			if (ImGui::CollapsingHeader("ImageSpace", ImGuiTreeNodeFlags_DefaultOpen)) {
-				for (int i = 0; i < ColorTimes::kTotal; i++) {
-					ImGui::PushID(i);
-					std::string label = ColorTimeLabel(i);
-					std::string inheritKey = "ImageSpace_" + std::to_string(i);
-
-					// Inherit checkbox
-					if (hasParent) {
-						bool& inheritFlag = settings.inheritFlags[inheritKey];
-						if (ImGui::Checkbox(("##inherit_" + inheritKey).c_str(), &inheritFlag)) {
-							if (inheritFlag && parentWidget) {
-								weather->imageSpaces[i] = parentWidget->weather->imageSpaces[i];
-								recordChanged = true;
-							}
-						}
-						if (ImGui::IsItemHovered()) {
-							ImGui::SetTooltip(inheritFlag ? "Inheriting from parent" : "Inherit from parent");
-						}
-						ImGui::SameLine();
-					}
-
-					ImGui::Text("%s:", label.c_str());
-					ImGui::SameLine(hasParent ? 120.0f : 100.0f);
-					if (WeatherUtils::DrawFormPickerCached("##ImageSpace", weather->imageSpaces[i], editorWindow->imageSpaceWidgets, false, true)) {
-						recordChanged = true;
-					}  // Add "Open" button
-					if (weather->imageSpaces[i]) {
-						ImGui::SameLine();
-						if (ImGui::SmallButton(std::format("Open##{}", i).c_str())) {
-							for (auto& widget : editorWindow->imageSpaceWidgets) {
-								if (widget->form == weather->imageSpaces[i]) {
-									widget->SetOpen(true);
-									break;
-								}
-							}
-						}
-						if (ImGui::IsItemHovered()) {
-							ImGui::SetTooltip("Open this ImageSpace for editing");
-						}
-					}
-
-					ImGui::PopID();
-				}
-				ImGui::Spacing();
-			}
-
-			// Volumetric Lighting Records (per time of day)
-			if (ImGui::CollapsingHeader("Volumetric Lighting", ImGuiTreeNodeFlags_DefaultOpen)) {
-				for (int i = 0; i < ColorTimes::kTotal; i++) {
-					ImGui::PushID(100 + i);
-					std::string label = ColorTimeLabel(i);
-					std::string inheritKey = "VolumetricLighting_" + std::to_string(i);
-
-					// Inherit checkbox
-					if (hasParent) {
-						bool& inheritFlag = settings.inheritFlags[inheritKey];
-						if (ImGui::Checkbox(("##inherit_" + inheritKey).c_str(), &inheritFlag)) {
-							if (inheritFlag && parentWidget) {
-								weather->volumetricLighting[i] = parentWidget->weather->volumetricLighting[i];
-								recordChanged = true;
-							}
-						}
-						if (ImGui::IsItemHovered()) {
-							ImGui::SetTooltip(inheritFlag ? "Inheriting from parent" : "Inherit from parent");
-						}
-						ImGui::SameLine();
-					}
-
-					ImGui::Text("%s:", label.c_str());
-					ImGui::SameLine(hasParent ? 120.0f : 100.0f);
-					if (WeatherUtils::DrawFormPickerCached("##VolumetricLighting", weather->volumetricLighting[i], editorWindow->volumetricLightingWidgets, false, true)) {
-						recordChanged = true;
-					}  // Add "Open" button
-					if (weather->volumetricLighting[i]) {
-						ImGui::SameLine();
-						if (ImGui::SmallButton(std::format("Open##{}", i).c_str())) {
-							for (auto& widget : editorWindow->volumetricLightingWidgets) {
-								if (widget->form == weather->volumetricLighting[i]) {
-									widget->SetOpen(true);
-									break;
-								}
-							}
-						}
-						if (ImGui::IsItemHovered()) {
-							ImGui::SetTooltip("Open this Volumetric Lighting for editing");
-						}
-					}
-
-					ImGui::PopID();
-				}
-				ImGui::Spacing();
-			}
-
-			// Precipitation Data
-			if (ImGui::CollapsingHeader("Precipitation", ImGuiTreeNodeFlags_DefaultOpen)) {
-				// Inherit checkbox
-				if (hasParent) {
-					bool& inheritFlag = settings.inheritFlags["Precipitation"];
-					if (ImGui::Checkbox("##inherit_Precipitation", &inheritFlag)) {
-						if (inheritFlag && parentWidget) {
-							weather->precipitationData = parentWidget->weather->precipitationData;
-							recordChanged = true;
-						}
-					}
-					if (ImGui::IsItemHovered()) {
-						ImGui::SetTooltip(inheritFlag ? "Inheriting from parent" : "Inherit from parent");
-					}
-					ImGui::SameLine();
-				}
-
-				ImGui::Text("Particle Shader:");
-				ImGui::SameLine(hasParent ? 170.0f : 150.0f);
-				if (WeatherUtils::DrawFormPickerCached("##Precipitation", weather->precipitationData, editorWindow->precipitationWidgets, false, true)) {
-					recordChanged = true;
-				}  // Add "Open" button
-				if (weather->precipitationData) {
-					ImGui::SameLine();
-					if (ImGui::SmallButton("Open##Precip")) {
-						for (auto& widget : editorWindow->precipitationWidgets) {
-							if (widget->form == weather->precipitationData) {
-								widget->SetOpen(true);
-								break;
-							}
-						}
-					}
-					if (ImGui::IsItemHovered()) {
-						ImGui::SetTooltip("Open this Precipitation for editing");
-					}
-				}
-
-				ImGui::Spacing();
-			}
-
-			// Visual Effect (Reference Effect)
-			if (ImGui::CollapsingHeader("Visual Effect", ImGuiTreeNodeFlags_DefaultOpen)) {
-				// Inherit checkbox
-				if (hasParent) {
-					bool& inheritFlag = settings.inheritFlags["ReferenceEffect"];
-					if (ImGui::Checkbox("##inherit_ReferenceEffect", &inheritFlag)) {
-						if (inheritFlag && parentWidget) {
-							weather->referenceEffect = parentWidget->weather->referenceEffect;
-							recordChanged = true;
-						}
-					}
-					if (ImGui::IsItemHovered()) {
-						ImGui::SetTooltip(inheritFlag ? "Inheriting from parent" : "Inherit from parent");
-					}
-					ImGui::SameLine();
-				}
-
-				ImGui::Text("Reference Effect:");
-				ImGui::SameLine(hasParent ? 170.0f : 150.0f);
-				if (WeatherUtils::DrawFormPickerCached("##ReferenceEffect", weather->referenceEffect, editorWindow->referenceEffectWidgets, false, true)) {
-					recordChanged = true;
-				}  // Add "Open" button
-				if (weather->referenceEffect) {
-					ImGui::SameLine();
-					if (ImGui::SmallButton("Open##RefEffect")) {
-						for (auto& widget : editorWindow->referenceEffectWidgets) {
-							if (widget->form == weather->referenceEffect) {
-								widget->SetOpen(true);
-								break;
-							}
-						}
-					}
-					if (ImGui::IsItemHovered()) {
-						ImGui::SetTooltip("Open this Visual Effect for editing");
-					}
-				}
-
-				ImGui::Spacing();
-			}
-
-			if (recordChanged && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
-				ApplyChanges();
-			}
-
-			EndScrollableContent();
-			ImGui::EndTabItem();
-		}
-		ImGui::EndTabBar();
-		ImGui::End();
+if (ImGui::BeginTabBar("WeatherSettingsTabs", ImGuiTabBarFlags_None)) {
+	// Use activeTabOverride to auto-navigate to specific tab
+	ImGuiTabItemFlags basicFlags = (activeTabOverride == "Basic") ? ImGuiTabItemFlags_SetSelected : 0;
+	ImGuiTabItemFlags dalcFlags = (activeTabOverride == "Lighting (DALC)") ? ImGuiTabItemFlags_SetSelected : 0;
+	ImGuiTabItemFlags atmosphereFlags = (activeTabOverride == "Atmosphere Colors") ? ImGuiTabItemFlags_SetSelected : 0;
+	ImGuiTabItemFlags cloudsFlags = (activeTabOverride == "Clouds") ? ImGuiTabItemFlags_SetSelected : 0;
+	ImGuiTabItemFlags fogFlags = (activeTabOverride == "Fog") ? ImGuiTabItemFlags_SetSelected : 0;
+	ImGuiTabItemFlags featuresFlags = (activeTabOverride == "Features") ? ImGuiTabItemFlags_SetSelected : 0;
+	ImGuiTabItemFlags recordsFlags = (activeTabOverride == "Records") ? ImGuiTabItemFlags_SetSelected : 0;
+	if (!activeTabOverride.empty()) {
+		activeTabOverride = "";  // Clear after use
 	}
 
-	void WeatherWidget::LoadSettings()
-	{
-		bool hadErrors = false;
-		if (!js.empty()) {
-			try {
-				// Attempt to load settings from JSON
-				settings = js;
-
-				// Validate that critical fields were loaded correctly
-				if (js.contains("weatherProperties") && settings.weatherProperties.empty() && !js["weatherProperties"].empty()) {
-					logger::warn("Weather {}: weatherProperties loaded but appears empty, reverting to vanilla values", GetEditorID());
-					hadErrors = true;
-				}
-				if (js.contains("weatherColors") && settings.weatherColors.empty() && !js["weatherColors"].empty()) {
-					logger::warn("Weather {}: weatherColors loaded but appears empty, reverting to vanilla values", GetEditorID());
-					hadErrors = true;
-				}
-				if (js.contains("fogProperties") && settings.fogProperties.empty() && !js["fogProperties"].empty()) {
-					logger::warn("Weather {}: fogProperties loaded but appears empty, reverting to vanilla values", GetEditorID());
-					hadErrors = true;
-				}
-
-				if (hadErrors) {
-					// Fallback to vanilla/game values
-					settings = vanillaSettings;
-					EditorWindow::GetSingleton()->ShowNotification(
-						std::format("Some values failed to load for {}", GetEditorID()),
-						ImVec4(1.0f, 0.0f, 0.0f, 1.0f),
-						3.0f);
-				} else {
-					logger::info("Weather {}: Loaded settings - {} weather properties, {} colors, {} fog properties",
-						GetEditorID(),
-						settings.weatherProperties.size(),
-						settings.weatherColors.size(),
-						settings.fogProperties.size());
-				}
-
-			} catch (const nlohmann::json::exception& e) {
-				logger::error("Weather {}: Failed to deserialize settings from JSON: {}", GetEditorID(), e.what());
-				// Fallback to vanilla/game values on exception
-				settings = vanillaSettings;
-				EditorWindow::GetSingleton()->ShowNotification(
-					std::format("Some values failed to load for {}", GetEditorID()),
-					ImVec4(1.0f, 0.0f, 0.0f, 1.0f),
-					3.0f);
-				return;
-			}
-		} else {
-			settings = vanillaSettings;
-		}
-		InitializeInheritFlags();
-		if (!js.empty()) {
-			LoadFeatureSettings();
-		}
-		originalSettings = settings;
-		ApplyChanges();
+	if (ImGui::BeginTabItem("Basic", nullptr, basicFlags)) {
+		BeginScrollableContent("##BasicScroll");
+		DrawProperties("Sun", { { "Sun Damage", INT8_SLIDER } });
+		DrawProperties("Wind", { { "Wind Speed", UINT8_SLIDER }, { "Wind Direction", INT8_SLIDER }, { "Wind Direction Range", INT8_SLIDER } });
+		DrawProperties("Precipitation", { { "Precipitation Begin Fade In", INT8_SLIDER }, { "Precipitation End Fade Out", INT8_SLIDER } });
+		DrawProperties("Lightning", { { "Thunder Lightning Begin Fade In", INT8_SLIDER }, { "Thunder Lightning End Fade Out", INT8_SLIDER },
+										{ "Thunder Lightning Frequency", INT8_SLIDER }, { "Lightning Color", COLOR3_PICKER } });
+		DrawProperties("Visual Effects", { { "Visual Effect Begin", INT8_SLIDER }, { "Visual Effect End", INT8_SLIDER } });
+		DrawProperties("Weather Transition", { { "Trans Delta", INT8_SLIDER } });
+		EndScrollableContent();
+		ImGui::EndTabItem();
+	}
+	if (ImGui::BeginTabItem("Lighting (DALC)", nullptr, dalcFlags)) {
+		BeginScrollableContent("##DALCScroll");
+		DrawDALCSettings();
+		EndScrollableContent();
+		ImGui::EndTabItem();
 	}
 
-	void WeatherWidget::SaveSettings()
-	{
-		SaveFeatureSettings();
-
-		try {
-			js = settings;
-
-			if (js.is_null()) {
-				logger::error("Weather {}: Serialization produced null JSON!", GetEditorID());
-			} else if (!js.contains("weatherProperties")) {
-				logger::error("Weather {}: Serialized JSON missing weatherProperties field!", GetEditorID());
-			} else if (!js.contains("atmosphereColors")) {
-				logger::error("Weather {}: Serialized JSON missing atmosphereColors field!", GetEditorID());
-			} else if (!js.contains("clouds")) {
-				logger::error("Weather {}: Serialized JSON missing clouds field!", GetEditorID());
-			} else {
-				originalSettings = settings;
-			}
-
-		} catch (const nlohmann::json::exception& e) {
-			logger::error("Weather {}: Failed to serialize settings to JSON: {}", GetEditorID(), e.what());
-		}
+	if (ImGui::BeginTabItem("Atmosphere Colors", nullptr, atmosphereFlags)) {
+		BeginScrollableContent("##AtmosphereScroll");
+		DrawWeatherColorSettings();
+		EndScrollableContent();
+		ImGui::EndTabItem();
 	}
 
-	WeatherWidget* WeatherWidget::GetParent()
-	{
-		auto editorWindow = EditorWindow::GetSingleton();
-		auto& widgets = editorWindow->weatherWidgets;
-
-		auto temp = std::find_if(widgets.begin(), widgets.end(), [&](const auto& w) { return w->GetEditorID() == settings.parent; });
-		if (temp != widgets.end())
-			return (WeatherWidget*)temp->get();
-
-		return nullptr;
+	if (ImGui::BeginTabItem("Clouds", nullptr, cloudsFlags)) {
+		BeginScrollableContent("##CloudsScroll");
+		DrawCloudSettings();
+		EndScrollableContent();
+		ImGui::EndTabItem();
 	}
 
-	bool WeatherWidget::HasParent() const
-	{
-		return settings.parent != "None";
+	if (ImGui::BeginTabItem("Fog", nullptr, fogFlags)) {
+		BeginScrollableContent("##FogScroll");
+		DrawFogSettings();
+		EndScrollableContent();
+		ImGui::EndTabItem();
 	}
 
-	void WeatherWidget::SetWeatherValues()
-	{
-		std::map<std::string, int>& weatherProps = settings.weatherProperties;
-		std::map<std::string, float3>& weatherColors = settings.weatherColors;
-		std::map<std::string, float>& fogProperties = settings.fogProperties;
-
-		auto& data = weather->data;
-		auto& colorData = weather->colorData;
-		auto& fogData = weather->fogData;
-
-		weather->data.transDelta = (int8_t)weatherProps["Trans Delta"];
-
-		// Sun
-		data.sunGlare = (int8_t)weatherProps["Sun Glare"];
-		data.sunDamage = (int8_t)weatherProps["Sun Damage"];
-
-		// Precipitation
-		data.precipitationBeginFadeIn = (int8_t)weatherProps["Precipitation Begin Fade In"];
-		data.precipitationEndFadeOut = (int8_t)weatherProps["Precipitation End Fade Out"];
-
-		// Lightning
-		data.thunderLightningBeginFadeIn = (int8_t)weatherProps["Thunder Lightning Begin Fade In"];
-		data.thunderLightningEndFadeOut = (int8_t)weatherProps["Thunder Lightning End Fade Out"];
-		data.thunderLightningFrequency = (int8_t)weatherProps["Thunder Lightning Frequency"];
-		Float3ToColor(weatherColors["Lightning Color"], weather->data.lightningColor);
-
-		// Visual Effects
-		data.visualEffectBegin = (int8_t)weatherProps["Visual Effect Begin"];
-		data.visualEffectEnd = (int8_t)weatherProps["Visual Effect End"];
-
-		// Wind
-		data.windSpeed = (uint8_t)weatherProps["Wind Speed"];
-		data.windDirection = (int8_t)weatherProps["Wind Direction"];
-		data.windDirectionRange = (int8_t)weatherProps["Wind Direction Range"];
-
-		// Fog
-		fogData.dayNear = fogProperties["Day Near"];
-		fogData.dayFar = fogProperties["Day Far"];
-		fogData.dayPower = fogProperties["Day Power"];
-		fogData.dayMax = fogProperties["Day Max"];
-		fogData.nightNear = fogProperties["Night Near"];
-		fogData.nightFar = fogProperties["Night Far"];
-		fogData.nightPower = fogProperties["Night Power"];
-		fogData.nightMax = fogProperties["Night Max"];
-
-		// Atmosphere colors
-		for (size_t i = 0; i < ColorTypes::kTotal; i++) {
-			for (size_t j = 0; j < ColorTimes::kTotal; j++) {
-				auto& color = colorData[i][j];
-				Float3ToColor(settings.atmosphereColors[i].colorTimes[j], color);
-			}
-		}
-
-		//DALC
-		for (size_t i = 0; i < ColorTimes::kTotal; i++) {
-			auto& dalc = weather->directionalAmbientLightingColors[i];
-			auto& settingsDalc = settings.dalc[i];
-			dalc.fresnelPower = settingsDalc.fresnelPower;
-
-			Float3ToColor(settingsDalc.specular, dalc.specular);
-
-			Float3ToColor(settingsDalc.directional[0].max, dalc.directional.x.max);
-			Float3ToColor(settingsDalc.directional[0].min, dalc.directional.x.min);
-
-			Float3ToColor(settingsDalc.directional[1].max, dalc.directional.y.max);
-			Float3ToColor(settingsDalc.directional[1].min, dalc.directional.y.min);
-
-			Float3ToColor(settingsDalc.directional[2].max, dalc.directional.z.max);
-			Float3ToColor(settingsDalc.directional[2].min, dalc.directional.z.min);
-		}
-
-		// Clouds
-		uint32_t disabledBits = 0;
-		for (size_t i = 0; i < TESWeather::kTotalLayers; i++) {
-			auto& settingsCloud = settings.clouds[i];
-
-			weather->cloudLayerSpeedX[i] = (int8_t)settingsCloud.cloudLayerSpeedX;
-			weather->cloudLayerSpeedY[i] = (int8_t)settingsCloud.cloudLayerSpeedY;
-
-			if (!settingsCloud.enabled) {
-				disabledBits |= (1 << i);
-			}
-
-			auto& cloudColors = weather->cloudColorData[i];
-			auto& cloudAlphas = weather->cloudAlpha[i];
-
-			for (int j = 0; j < ColorTimes::kTotal; j++) {
-				cloudAlphas[j] = settingsCloud.cloudAlpha[j];
-				Float3ToColor(settingsCloud.color[j], cloudColors[j]);
-			}
-		}
-		weather->cloudLayerDisabledBits = disabledBits;
-
-		// If this weather is currently active, immediately apply feature settings to game memory
-		auto* weatherManager = WeatherManager::GetSingleton();
-		if (weatherManager->GetCurrentWeathers().currentWeather == weather) {
-			auto* globalRegistry = WeatherVariables::GlobalWeatherRegistry::GetSingleton();
-			json emptyWeather;
-
-			for (const auto& [featureName, featureSettings] : settings.featureSettings) {
-				if (!featureSettings.value("__enabled", false) || !globalRegistry->HasWeatherSupport(featureName)) {
-					continue;
-				}
-
-				// Filter out __enabled flag and apply settings
-				json filteredSettings = featureSettings;
-				filteredSettings.erase("__enabled");
-				globalRegistry->UpdateFeatureFromWeathers(featureName, emptyWeather, filteredSettings, 1.0f);
-			}
-		}
+	if (ImGui::BeginTabItem("Features", nullptr, featuresFlags)) {
+		BeginScrollableContent("##FeaturesScroll");
+		DrawFeatureSettings();
+		EndScrollableContent();
+		ImGui::EndTabItem();
 	}
 
-	void WeatherWidget::InitializeInheritFlags()
-	{
-		auto& flags = settings.inheritFlags;
-		auto ensureFlag = [&](const std::string& key) {
-			flags.try_emplace(key, false);
-		};
-
-		static const char* kFixedKeys[] = {
-			"Precipitation",
-			"ReferenceEffect",
-			"DALC_Specular",
-			"DALC_Fresnel",
-			"DALC_DirXMax",
-			"DALC_DirXMin",
-			"DALC_DirYMax",
-			"DALC_DirYMin",
-			"DALC_DirZMax",
-			"DALC_DirZMin",
-			"Fog_Near",
-			"Fog_Far",
-			"Fog_Power",
-			"Fog_Max",
-			"Sun Damage",
-			"Wind Speed",
-			"Wind Direction",
-			"Wind Direction Range",
-			"Precipitation Begin Fade In",
-			"Precipitation End Fade Out",
-			"Thunder Lightning Begin Fade In",
-			"Thunder Lightning End Fade Out",
-			"Thunder Lightning Frequency",
-			"Lightning Color",
-			"Visual Effect Begin",
-			"Visual Effect End",
-			"Trans Delta",
-		};
-		for (const char* key : kFixedKeys) {
-			ensureFlag(key);
-		}
-
-		for (int i = 0; i < ColorTimes::kTotal; i++) {
-			ensureFlag(std::format("ImageSpace_{}", i));
-			ensureFlag(std::format("VolumetricLighting_{}", i));
-		}
-
-		for (int i = 0; i < ColorTypes::kTotal; i++) {
-			ensureFlag(std::format("Atmosphere_{}", ColorTypeLabel(i)));
-		}
-
-		for (int i = 0; i < TESWeather::kTotalLayers; i++) {
-			ensureFlag(std::format("Cloud{}_Color", i));
-			ensureFlag(std::format("Cloud{}_Alpha", i));
-		}
-	}
-
-	void WeatherWidget::LoadWeatherValues()
-	{
-		std::map<std::string, int>& weatherProps = settings.weatherProperties;
-		std::map<std::string, float3>& weatherColors = settings.weatherColors;
-		std::map<std::string, float>& fogProperties = settings.fogProperties;
-
-		const auto& data = weather->data;
-		const auto& colorData = weather->colorData;
-		const auto& fogData = weather->fogData;
-
-		weatherProps["Trans Delta"] = data.transDelta;
-
-		// Sun
-		weatherProps["Sun Glare"] = data.sunGlare;
-		weatherProps["Sun Damage"] = data.sunDamage;
-
-		// Precipitation
-		weatherProps["Precipitation Begin Fade In"] = data.precipitationBeginFadeIn;
-		weatherProps["Precipitation End Fade Out"] = data.precipitationEndFadeOut;
-
-		// Lightning
-		weatherProps["Thunder Lightning Begin Fade In"] = data.thunderLightningBeginFadeIn;
-		weatherProps["Thunder Lightning End Fade Out"] = data.thunderLightningEndFadeOut;
-		weatherProps["Thunder Lightning Frequency"] = data.thunderLightningFrequency;
-		ColorToFloat3(data.lightningColor, weatherColors["Lightning Color"]);
-
-		// Visual Effects
-		weatherProps["Visual Effect Begin"] = data.visualEffectBegin;
-		weatherProps["Visual Effect End"] = data.visualEffectEnd;
-
-		// Wind
-		weatherProps["Wind Speed"] = data.windSpeed;
-		weatherProps["Wind Direction"] = data.windDirection;
-		weatherProps["Wind Direction Range"] = data.windDirectionRange;
-
-		// Fog
-		fogProperties["Day Near"] = fogData.dayNear;
-		fogProperties["Day Far"] = fogData.dayFar;
-		fogProperties["Night Near"] = fogData.nightNear;
-		fogProperties["Night Far"] = fogData.nightFar;
-		fogProperties["Day Power"] = fogData.dayPower;
-		fogProperties["Night Power"] = fogData.nightPower;
-		fogProperties["Day Max"] = fogData.dayMax;
-		fogProperties["Night Max"] = fogData.nightMax;
-
-		// Atmosphere color
-		for (size_t i = 0; i < ColorTypes::kTotal; i++) {
-			for (size_t j = 0; j < ColorTimes::kTotal; j++) {
-				auto& color = colorData[i][j];
-				ColorToFloat3(color, settings.atmosphereColors[i].colorTimes[j]);
-			}
-		}
-
-		// DALC
-		for (size_t i = 0; i < ColorTimes::kTotal; i++) {
-			auto& dalc = weather->directionalAmbientLightingColors[i];
-			auto& settingsDalc = settings.dalc[i];
-			settingsDalc.fresnelPower = dalc.fresnelPower;
-
-			ColorToFloat3(dalc.specular, settingsDalc.specular);
-
-			ColorToFloat3(dalc.directional.x.max, settingsDalc.directional[0].max);
-			ColorToFloat3(dalc.directional.x.min, settingsDalc.directional[0].min);
-
-			ColorToFloat3(dalc.directional.y.max, settingsDalc.directional[1].max);
-			ColorToFloat3(dalc.directional.y.min, settingsDalc.directional[1].min);
-
-			ColorToFloat3(dalc.directional.z.max, settingsDalc.directional[2].max);
-			ColorToFloat3(dalc.directional.z.min, settingsDalc.directional[2].min);
-		}
-
-		// Clouds
-		for (size_t i = 0; i < TESWeather::kTotalLayers; i++) {
-			auto& settingsCloud = settings.clouds[i];
-
-			settingsCloud.cloudLayerSpeedX = weather->cloudLayerSpeedX[i];
-			settingsCloud.cloudLayerSpeedY = weather->cloudLayerSpeedY[i];
-			settingsCloud.enabled = !(weather->cloudLayerDisabledBits & (1 << i));
-			settingsCloud.texturePath = weather->cloudTextures[i].textureName.c_str();
-
-			auto& cloudColors = weather->cloudColorData[i];
-			auto& cloudAlphas = weather->cloudAlpha[i];
-
-			for (int j = 0; j < ColorTimes::kTotal; j++) {
-				settingsCloud.cloudAlpha[j] = cloudAlphas[j];
-				ColorToFloat3(cloudColors[j], settingsCloud.color[j]);
-			}
-		}
-	}
-
-	void WeatherWidget::DrawDALCSettings()
-	{
-		auto editorWindow = EditorWindow::GetSingleton();
-		bool hasParent = editorWindow->settings.enableInheritFromParent && HasParent();
-		WeatherWidget* parentWidget = hasParent ? GetParent() : nullptr;
-
-		bool changed = false;
-
-		if (TOD::BeginTODTable("DALC_TOD_Table")) {
-			TOD::RenderTODHeader();
-			TOD::DrawTODSeparator();
-
-			// Prepare arrays for TOD rendering
-			float3 specularColors[4];
-			float fresnelPowers[4];
-			float3 directionalXMax[4], directionalXMin[4];
-			float3 directionalYMax[4], directionalYMin[4];
-			float3 directionalZMax[4], directionalZMin[4];
-
-			// Parent values
-			float3 parentSpecular[4] = {};
-			float parentFresnel[4] = {};
-			float3 parentDirXMax[4] = {}, parentDirXMin[4] = {};
-			float3 parentDirYMax[4] = {}, parentDirYMin[4] = {};
-			float3 parentDirZMax[4] = {}, parentDirZMin[4] = {};
-
-			for (int i = 0; i < ColorTimes::kTotal; i++) {
-				specularColors[i] = settings.dalc[i].specular;
-				fresnelPowers[i] = settings.dalc[i].fresnelPower;
-				directionalXMax[i] = settings.dalc[i].directional[0].max;
-				directionalXMin[i] = settings.dalc[i].directional[0].min;
-				directionalYMax[i] = settings.dalc[i].directional[1].max;
-				directionalYMin[i] = settings.dalc[i].directional[1].min;
-				directionalZMax[i] = settings.dalc[i].directional[2].max;
-				directionalZMin[i] = settings.dalc[i].directional[2].min;
-
-				if (parentWidget) {
-					parentSpecular[i] = parentWidget->settings.dalc[i].specular;
-					parentFresnel[i] = parentWidget->settings.dalc[i].fresnelPower;
-					parentDirXMax[i] = parentWidget->settings.dalc[i].directional[0].max;
-					parentDirXMin[i] = parentWidget->settings.dalc[i].directional[0].min;
-					parentDirYMax[i] = parentWidget->settings.dalc[i].directional[1].max;
-					parentDirYMin[i] = parentWidget->settings.dalc[i].directional[1].min;
-					parentDirZMax[i] = parentWidget->settings.dalc[i].directional[2].max;
-					parentDirZMin[i] = parentWidget->settings.dalc[i].directional[2].min;
-				}
-			}
-
-			// Draw with per-parameter inheritance
-			if (hasParent) {
-				if (TOD::DrawTODColorRow("Specular", specularColors, settings.inheritFlags["DALC_Specular"], parentSpecular)) {
-					for (int i = 0; i < ColorTimes::kTotal; i++)
-						settings.dalc[i].specular = specularColors[i];
-					changed = true;
-				}
-
-				if (TOD::DrawTODFloatRow("Fresnel Power", fresnelPowers, settings.inheritFlags["DALC_Fresnel"], parentFresnel, 0.0f, 10.0f)) {
-					for (int i = 0; i < ColorTimes::kTotal; i++)
-						settings.dalc[i].fresnelPower = fresnelPowers[i];
-					changed = true;
-				}
-			} else {
-				if (TOD::DrawTODColorRow("Specular", specularColors)) {
-					for (int i = 0; i < ColorTimes::kTotal; i++)
-						settings.dalc[i].specular = specularColors[i];
-					changed = true;
-				}
-
-				if (TOD::DrawTODFloatRow("Fresnel Power", fresnelPowers, 0.0f, 10.0f)) {
-					for (int i = 0; i < ColorTimes::kTotal; i++)
-						settings.dalc[i].fresnelPower = fresnelPowers[i];
-					changed = true;
-				}
-			}
-
-			TOD::DrawTODSeparator();
-
-			// Directional colors with per-parameter inheritance
-			if (hasParent) {
-				if (TOD::DrawTODColorRow("Directional +X", directionalXMax, settings.inheritFlags["DALC_DirXMax"], parentDirXMax)) {
-					for (int i = 0; i < ColorTimes::kTotal; i++)
-						settings.dalc[i].directional[0].max = directionalXMax[i];
-					changed = true;
-				}
-
-				if (TOD::DrawTODColorRow("Directional -X", directionalXMin, settings.inheritFlags["DALC_DirXMin"], parentDirXMin)) {
-					for (int i = 0; i < ColorTimes::kTotal; i++)
-						settings.dalc[i].directional[0].min = directionalXMin[i];
-					changed = true;
-				}
-
-				if (TOD::DrawTODColorRow("Directional +Y", directionalYMax, settings.inheritFlags["DALC_DirYMax"], parentDirYMax)) {
-					for (int i = 0; i < ColorTimes::kTotal; i++)
-						settings.dalc[i].directional[1].max = directionalYMax[i];
-					changed = true;
-				}
-
-				if (TOD::DrawTODColorRow("Directional -Y", directionalYMin, settings.inheritFlags["DALC_DirYMin"], parentDirYMin)) {
-					for (int i = 0; i < ColorTimes::kTotal; i++)
-						settings.dalc[i].directional[1].min = directionalYMin[i];
-					changed = true;
-				}
-
-				if (TOD::DrawTODColorRow("Directional +Z", directionalZMax, settings.inheritFlags["DALC_DirZMax"], parentDirZMax)) {
-					for (int i = 0; i < ColorTimes::kTotal; i++)
-						settings.dalc[i].directional[2].max = directionalZMax[i];
-					changed = true;
-				}
-
-				if (TOD::DrawTODColorRow("Directional -Z", directionalZMin, settings.inheritFlags["DALC_DirZMin"], parentDirZMin)) {
-					for (int i = 0; i < ColorTimes::kTotal; i++)
-						settings.dalc[i].directional[2].min = directionalZMin[i];
-					changed = true;
-				}
-			} else {
-				if (TOD::DrawTODColorRow("Directional +X", directionalXMax)) {
-					for (int i = 0; i < ColorTimes::kTotal; i++)
-						settings.dalc[i].directional[0].max = directionalXMax[i];
-					changed = true;
-				}
-
-				if (TOD::DrawTODColorRow("Directional -X", directionalXMin)) {
-					for (int i = 0; i < ColorTimes::kTotal; i++)
-						settings.dalc[i].directional[0].min = directionalXMin[i];
-					changed = true;
-				}
-
-				if (TOD::DrawTODColorRow("Directional +Y", directionalYMax)) {
-					for (int i = 0; i < ColorTimes::kTotal; i++)
-						settings.dalc[i].directional[1].max = directionalYMax[i];
-					changed = true;
-				}
-
-				if (TOD::DrawTODColorRow("Directional -Y", directionalYMin)) {
-					for (int i = 0; i < ColorTimes::kTotal; i++)
-						settings.dalc[i].directional[1].min = directionalYMin[i];
-					changed = true;
-				}
-
-				if (TOD::DrawTODColorRow("Directional +Z", directionalZMax)) {
-					for (int i = 0; i < ColorTimes::kTotal; i++)
-						settings.dalc[i].directional[2].max = directionalZMax[i];
-					changed = true;
-				}
-
-				if (TOD::DrawTODColorRow("Directional -Z", directionalZMin)) {
-					for (int i = 0; i < ColorTimes::kTotal; i++)
-						settings.dalc[i].directional[2].min = directionalZMin[i];
-					changed = true;
-				}
-			}
-
-			TOD::EndTODTable();
-		}
-		if (changed && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
-			ApplyChanges();
-		}
-	}
-
-	void WeatherWidget::DrawWeatherColorSettings()
-	{
-		auto editorWindow = EditorWindow::GetSingleton();
-		bool hasParent = editorWindow->settings.enableInheritFromParent && HasParent();
-		WeatherWidget* parentWidget = hasParent ? GetParent() : nullptr;
-
-		bool changed = false;
-
-		if (TOD::BeginTODTable("AtmosphereColors_Table")) {
-			TOD::RenderTODHeader();
-			TOD::DrawTODSeparator();
-
-			// Organized display order: group related sky/fog/lighting properties
-			static const int displayOrder[] = {
-				0,   // Sky Upper
-				7,   // Sky Lower
-				8,   // Horizon
-				1,   // Fog Near
-				12,  // Fog Far
-				3,   // Ambient
-				4,   // Sunlight
-				15,  // Sun Glare
-				5,   // Sun
-				6,   // Stars
-				16,  // Moon Glare
-				9,   // Effect Lighting
-				10,  // Cloud LOD Diffuse
-				11,  // Cloud LOD Ambient
-				13,  // Sky Statics
-				14,  // Water Multiplier
-				2,   // Unknown
-			};
-
-			for (int idx = 0; idx < ColorTypes::kTotal; idx++) {
-				int i = displayOrder[idx];
-				std::string colorTypeLabel = ColorTypeLabel(i);
-
-				if (hasParent) {
-					float3 parentColors[4];
-					for (int j = 0; j < 4; j++)
-						parentColors[j] = parentWidget->settings.atmosphereColors[i].colorTimes[j];
-
-					std::string inheritKey = "Atmosphere_" + colorTypeLabel;
-					if (TOD::DrawTODColorRow(colorTypeLabel.c_str(), settings.atmosphereColors[i].colorTimes, settings.inheritFlags[inheritKey], parentColors)) {
-						changed = true;
-					}
-				} else {
-					if (TOD::DrawTODColorRow(colorTypeLabel.c_str(), settings.atmosphereColors[i].colorTimes)) {
-						changed = true;
-					}
-				}
-			}
-
-			TOD::EndTODTable();
-		}
-
-		if (changed && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
-			ApplyChanges();
-		}
-	}
-
-	void WeatherWidget::DrawCloudSettings()
-	{
-		auto editorWindow = EditorWindow::GetSingleton();
-		bool hasParent = editorWindow->settings.enableInheritFromParent && HasParent();
-		WeatherWidget* parentWidget = hasParent ? GetParent() : nullptr;
-
-		bool changed = false;
-		bool enableChanged = false;
-
-		// OpenOnArrow|OpenOnDoubleClick prevents accidental collapse when clicking
-		// the [Enabled] badge area that overlaps the right side of the header.
-		constexpr ImGuiTreeNodeFlags flags = ImGuiTreeNodeFlags_OpenOnArrow | ImGuiTreeNodeFlags_OpenOnDoubleClick;
-		constexpr char kEnabledBadge[] = "[Enabled]";
-
-		for (int i = 0; i < TESWeather::kTotalLayers; i++) {
-			std::string layer = std::format("Layer {}", i);
-			bool layerEnabled = settings.clouds[i].enabled;
-
-			if (!layerEnabled) {
-				ImGui::PushStyleColor(ImGuiCol_Header, ImGui::GetStyleColorVec4(ImGuiCol_FrameBg));
-				ImGui::PushStyleColor(ImGuiCol_HeaderHovered, ImGui::GetStyleColorVec4(ImGuiCol_FrameBgHovered));
-				ImGui::PushStyleColor(ImGuiCol_HeaderActive, ImGui::GetStyleColorVec4(ImGuiCol_FrameBgActive));
-			}
-
-			// Label is constant so the storage ID never changes — open/closed state always persists.
-			// [Enabled] badge is overlaid on the header via the draw list instead of altering the label.
-			float headerScreenY = ImGui::GetCursorScreenPos().y;
-			bool layerOpen = ImGui::CollapsingHeader(layer.c_str(), flags);
-
-			if (!layerEnabled)
-				ImGui::PopStyleColor(3);
-
-			if (layerEnabled) {
-				const ImVec2 badgeSize = ImGui::CalcTextSize(kEnabledBadge);
-				const float headerHeight = ImGui::GetFrameHeight();
-				const ImVec2 badgePos = {
-					ImGui::GetWindowPos().x + ImGui::GetContentRegionMax().x - badgeSize.x,
-					headerScreenY + (headerHeight - badgeSize.y) * 0.5f
-				};
-				ImGui::GetWindowDrawList()->AddText(badgePos, ImGui::GetColorU32(ImGuiCol_CheckMark), kEnabledBadge);
-			}
-
-			if (layerOpen) {
-				ImGui::Indent(10.0f);
-				ImGui::Spacing();
-
-				// Begin horizontal layout for enable checkbox and sliders on left, texture on right
-				ImGui::BeginGroup();
-
-				if (ImGui::Checkbox(std::format("Enable##{}", layer).c_str(), &layerEnabled)) {
-					settings.clouds[i].enabled = layerEnabled;
-					enableChanged = true;
-					changed = true;
-				}
-
-				ImGui::Spacing();
-				ImGui::Spacing();
-
-				// Make sliders 1/3 width
-				ImGui::PushItemWidth(ImGui::GetContentRegionAvail().x * 0.4f);
-				if (WeatherUtils::DrawSliderInt8(std::format("Cloud Layer Speed Y##{}", layer), settings.clouds[i].cloudLayerSpeedY))
-					changed = true;
-				ImGui::Spacing();
-				if (WeatherUtils::DrawSliderInt8(std::format("Cloud Layer Speed X##{}", layer), settings.clouds[i].cloudLayerSpeedX))
-					changed = true;
-				ImGui::PopItemWidth();
-
-				ImGui::EndGroup();
-
-				// Draw texture in upper right if available
-				if (!settings.clouds[i].texturePath.empty()) {
-					auto* texture = GetCloudTexture(i);
-					if (texture) {
-						ImGui::SameLine(0.0f, 20.0f);
-						ImGui::BeginGroup();
-						float textureSize = 128.0f;
-						ImGui::Image((void*)texture, ImVec2(textureSize, textureSize));
-						// Small grey subtext below image, clamped to texture width
-						ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
-						ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + textureSize);
-						ImGui::TextWrapped("%s", settings.clouds[i].texturePath.c_str());
-						ImGui::PopTextWrapPos();
-						ImGui::PopStyleColor();
-						ImGui::EndGroup();
-					}
-				}
-
-				ImGui::Spacing();
-				ImGui::Spacing();
-				if (TOD::BeginTODTable((layer + "_TOD_Table").c_str())) {
-					TOD::RenderTODHeader();
-					TOD::DrawTODSeparator();
-
-					if (hasParent) {
-						float3 parentColors[4];
-						float parentAlphas[4];
-						for (int j = 0; j < 4; j++) {
-							parentColors[j] = parentWidget->settings.clouds[i].color[j];
-							parentAlphas[j] = parentWidget->settings.clouds[i].cloudAlpha[j];
-						}
-
-						std::string colorKey = std::format("Cloud{}_Color", i);
-						std::string alphaKey = std::format("Cloud{}_Alpha", i);
-
-						if (TOD::DrawTODColorRow("Cloud Color", settings.clouds[i].color, settings.inheritFlags[colorKey], parentColors)) {
-							changed = true;
-						}
-
-						if (TOD::DrawTODFloatRow("Cloud Alpha", settings.clouds[i].cloudAlpha, settings.inheritFlags[alphaKey], parentAlphas, 0.0f, 1.0f)) {
-							changed = true;
-						}
-					} else {
-						if (TOD::DrawTODColorRow("Cloud Color", settings.clouds[i].color)) {
-							changed = true;
-						}
-
-						if (TOD::DrawTODFloatRow("Cloud Alpha", settings.clouds[i].cloudAlpha, 0.0f, 1.0f)) {
-							changed = true;
-						}
-					}
-
-					TOD::EndTODTable();
-				}
-
-				ImGui::Spacing();
-				ImGui::Unindent(10.0f);
-			}
-		}
-		if (enableChanged) {
-			// Apply enable/disable immediately for instant feedback, regardless of autoApplyChanges.
-			editorWindow->PushUndoState(this);
-			ApplyChanges();
-			if (editorWindow->IsWeatherLocked() && editorWindow->GetLockedWeather() == weather) {
-				if (auto sky = RE::Sky::GetSingleton()) {
-					sky->ForceWeather(weather, true);  // override=true for immediate application; matches "instant feedback" intent above
-				}
-			}
-		} else if (changed && editorWindow->settings.autoApplyChanges) {
-			editorWindow->PushUndoState(this);
-			ApplyChanges();
-		}
-	}
-
-	void WeatherWidget::DrawFogSettings()
-	{
-		auto editorWindow = EditorWindow::GetSingleton();
-		bool hasParent = editorWindow->settings.enableInheritFromParent && HasParent();
-		WeatherWidget* parentWidget = hasParent ? GetParent() : nullptr;
-
-		bool changed = false;
-
-		if (ImGui::BeginTable("FogTable", 3, ImGuiTableFlags_BordersInnerV | ImGuiTableFlags_SizingFixedFit)) {
-			ImGui::TableSetupColumn("Parameter", ImGuiTableColumnFlags_WidthFixed, 200.0f);
-			ImGui::TableSetupColumn("Day", ImGuiTableColumnFlags_WidthFixed, 250.0f);
-			ImGui::TableSetupColumn("Night", ImGuiTableColumnFlags_WidthFixed, 250.0f);
-
-			// Header row
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0);
-			ImGui::TableSetColumnIndex(1);
-			ImGui::Text("Day");
-			ImGui::TableSetColumnIndex(2);
-			ImGui::Text("Night");
-
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0);
-			ImGui::Separator();
-			ImGui::TableSetColumnIndex(1);
-			ImGui::Separator();
-			ImGui::TableSetColumnIndex(2);
-			ImGui::Separator();
-
-			// Near
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0);
-			if (hasParent) {
-				ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(0.15f, 0.15f, 0.15f, 1.0f));
-				ImGui::PushStyleColor(ImGuiCol_CheckMark, ImVec4(0.5f, 0.5f, 0.5f, 1.0f));
-				ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(2, 2));
-				ImGui::Checkbox("##FogNear", &settings.inheritFlags["Fog_Near"]);
-				if (settings.inheritFlags["Fog_Near"]) {
-					settings.fogProperties["Day Near"] = parentWidget->settings.fogProperties["Day Near"];
-					settings.fogProperties["Night Near"] = parentWidget->settings.fogProperties["Night Near"];
-					changed = true;
-				}
-				ImGui::PopStyleVar();
-				ImGui::PopStyleColor(2);
-				ImGui::SameLine();
-			}
-			ImGui::Text("Near");
-			ImGui::TableSetColumnIndex(1);
-			ImGui::SetNextItemWidth(-1);
-			if (ImGui::SliderFloat("##FogDayNear", &settings.fogProperties["Day Near"], 0.0f, 1000000.0f, "%.0f"))
-				changed = true;
-			ImGui::TableSetColumnIndex(2);
-			ImGui::SetNextItemWidth(-1);
-			if (ImGui::SliderFloat("##FogNightNear", &settings.fogProperties["Night Near"], 0.0f, 1000000.0f, "%.0f"))
-				changed = true;
-
-			// Far
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0);
-			if (hasParent) {
-				ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(0.15f, 0.15f, 0.15f, 1.0f));
-				ImGui::PushStyleColor(ImGuiCol_CheckMark, ImVec4(0.5f, 0.5f, 0.5f, 1.0f));
-				ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(2, 2));
-				ImGui::Checkbox("##FogFar", &settings.inheritFlags["Fog_Far"]);
-				if (settings.inheritFlags["Fog_Far"]) {
-					settings.fogProperties["Day Far"] = parentWidget->settings.fogProperties["Day Far"];
-					settings.fogProperties["Night Far"] = parentWidget->settings.fogProperties["Night Far"];
-					changed = true;
-				}
-				ImGui::PopStyleVar();
-				ImGui::PopStyleColor(2);
-				ImGui::SameLine();
-			}
-			ImGui::Text("Far");
-			ImGui::TableSetColumnIndex(1);
-			ImGui::SetNextItemWidth(-1);
-			if (ImGui::SliderFloat("##FogDayFar", &settings.fogProperties["Day Far"], 0.0f, 1000000.0f, "%.0f"))
-				changed = true;
-			ImGui::TableSetColumnIndex(2);
-			ImGui::SetNextItemWidth(-1);
-			if (ImGui::SliderFloat("##FogNightFar", &settings.fogProperties["Night Far"], 0.0f, 1000000.0f, "%.0f"))
-				changed = true;
-
-			// Power
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0);
-			if (hasParent) {
-				ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(0.15f, 0.15f, 0.15f, 1.0f));
-				ImGui::PushStyleColor(ImGuiCol_CheckMark, ImVec4(0.5f, 0.5f, 0.5f, 1.0f));
-				ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(2, 2));
-				ImGui::Checkbox("##FogPower", &settings.inheritFlags["Fog_Power"]);
-				if (settings.inheritFlags["Fog_Power"]) {
-					settings.fogProperties["Day Power"] = parentWidget->settings.fogProperties["Day Power"];
-					settings.fogProperties["Night Power"] = parentWidget->settings.fogProperties["Night Power"];
-					changed = true;
-				}
-				ImGui::PopStyleVar();
-				ImGui::PopStyleColor(2);
-				ImGui::SameLine();
-			}
-			ImGui::Text("Power");
-			ImGui::TableSetColumnIndex(1);
-			ImGui::SetNextItemWidth(-1);
-			if (ImGui::SliderFloat("##FogDayPower", &settings.fogProperties["Day Power"], 0.0f, 10.0f, "%.3f"))
-				changed = true;
-			ImGui::TableSetColumnIndex(2);
-			ImGui::SetNextItemWidth(-1);
-			if (ImGui::SliderFloat("##FogNightPower", &settings.fogProperties["Night Power"], 0.0f, 10.0f, "%.3f"))
-				changed = true;
-
-			// Max
-			ImGui::TableNextRow();
-			ImGui::TableSetColumnIndex(0);
-			if (hasParent) {
-				ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(0.15f, 0.15f, 0.15f, 1.0f));
-				ImGui::PushStyleColor(ImGuiCol_CheckMark, ImVec4(0.5f, 0.5f, 0.5f, 1.0f));
-				ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(2, 2));
-				ImGui::Checkbox("##FogMax", &settings.inheritFlags["Fog_Max"]);
-				if (settings.inheritFlags["Fog_Max"]) {
-					settings.fogProperties["Day Max"] = parentWidget->settings.fogProperties["Day Max"];
-					settings.fogProperties["Night Max"] = parentWidget->settings.fogProperties["Night Max"];
-					changed = true;
-				}
-				ImGui::PopStyleVar();
-				ImGui::PopStyleColor(2);
-				ImGui::SameLine();
-			}
-			ImGui::Text("Max");
-			ImGui::TableSetColumnIndex(1);
-			ImGui::SetNextItemWidth(-1);
-			if (ImGui::SliderFloat("##FogDayMax", &settings.fogProperties["Day Max"], 0.0f, 1.0f, "%.3f"))
-				changed = true;
-			ImGui::TableSetColumnIndex(2);
-			ImGui::SetNextItemWidth(-1);
-			if (ImGui::SliderFloat("##FogNightMax", &settings.fogProperties["Night Max"], 0.0f, 1.0f, "%.3f"))
-				changed = true;
-
-			ImGui::EndTable();
-		}
-
-		if (changed && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
-			ApplyChanges();
-		}
-	}
-
-	void WeatherWidget::DrawProperties(std::string category, std::map<std::string, int> properties)
-	{
-		// Check if any property matches search (only check if search is active)
-		bool hasMatchingProperty = false;
-		if (searchBuffer[0] != '\0') {
-			hasMatchingProperty = MatchesSearch(category);
-			if (!hasMatchingProperty) {
-				for (auto& p : properties) {
-					if (MatchesSearch(p.first)) {
-						hasMatchingProperty = true;
-						break;
-					}
-				}
-			}
-			// Skip this entire category if nothing matches
-			if (!hasMatchingProperty) {
-				return;
-			}
-		}
-
-		ImGui::TextColored(ImVec4(0.7f, 0.9f, 1.0f, 1.0f), "%s", category.c_str());
-
-		bool changed = false;
+	if (ImGui::BeginTabItem("Records", nullptr, recordsFlags)) {
+		BeginScrollableContent("##RecordsScroll");
+		ImGui::Spacing();
+		ImGui::TextWrapped("Form record references used by this weather.");
+		ImGui::Spacing();
+		ImGui::Separator();
+		ImGui::Spacing();
 		auto* editorWindow = EditorWindow::GetSingleton();
+
+		bool recordChanged = false;
 		bool hasParent = editorWindow->settings.enableInheritFromParent && HasParent();
+		WeatherWidget* parentWidget = hasParent ? GetParent() : nullptr;
 
-		for (auto& p : properties) {
-			// Filter individual properties based on search
-			if (searchBuffer[0] != '\0' && !MatchesSearch(p.first)) {
-				continue;
+		// ImageSpace Records (per time of day)
+		if (ImGui::CollapsingHeader("ImageSpace", ImGuiTreeNodeFlags_DefaultOpen)) {
+			for (int i = 0; i < ColorTimes::kTotal; i++) {
+				ImGui::PushID(i);
+				std::string label = ColorTimeLabel(i);
+				std::string inheritKey = "ImageSpace_" + std::to_string(i);
+
+				// Inherit checkbox
+				if (hasParent) {
+					bool& inheritFlag = settings.inheritFlags[inheritKey];
+					if (ImGui::Checkbox(("##inherit_" + inheritKey).c_str(), &inheritFlag)) {
+						if (inheritFlag && parentWidget) {
+							weather->imageSpaces[i] = parentWidget->weather->imageSpaces[i];
+							recordChanged = true;
+						}
+					}
+					if (ImGui::IsItemHovered()) {
+						ImGui::SetTooltip(inheritFlag ? "Inheriting from parent" : "Inherit from parent");
+					}
+					ImGui::SameLine();
+				}
+
+				ImGui::Text("%s:", label.c_str());
+				ImGui::SameLine(hasParent ? 120.0f : 100.0f);
+				if (WeatherUtils::DrawFormPickerCached("##ImageSpace", weather->imageSpaces[i], editorWindow->imageSpaceWidgets, false, true)) {
+					recordChanged = true;
+				}  // Add "Open" button
+				if (weather->imageSpaces[i]) {
+					ImGui::SameLine();
+					if (ImGui::SmallButton(std::format("Open##{}", i).c_str())) {
+						for (auto& widget : editorWindow->imageSpaceWidgets) {
+							if (widget->form == weather->imageSpaces[i]) {
+								widget->SetOpen(true);
+								break;
+							}
+						}
+					}
+					if (ImGui::IsItemHovered()) {
+						ImGui::SetTooltip("Open this ImageSpace for editing");
+					}
+				}
+
+				ImGui::PopID();
 			}
+			ImGui::Spacing();
+		}
 
-			// Apply highlight effect if this setting should be highlighted
-			if (ShouldHighlight(p.first)) {
-				float elapsed = static_cast<float>(ImGui::GetTime()) - highlightStartTime;
-				float alpha = 0.3f * (1.0f - std::abs(elapsed - 0.5f) * 2.0f);
-				ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(0.3f, 0.6f, 1.0f, alpha));
-				ImGui::PushStyleColor(ImGuiCol_FrameBgHovered, ImVec4(0.4f, 0.7f, 1.0f, alpha));
+		// Volumetric Lighting Records (per time of day)
+		if (ImGui::CollapsingHeader("Volumetric Lighting", ImGuiTreeNodeFlags_DefaultOpen)) {
+			for (int i = 0; i < ColorTimes::kTotal; i++) {
+				ImGui::PushID(100 + i);
+				std::string label = ColorTimeLabel(i);
+				std::string inheritKey = "VolumetricLighting_" + std::to_string(i);
+
+				// Inherit checkbox
+				if (hasParent) {
+					bool& inheritFlag = settings.inheritFlags[inheritKey];
+					if (ImGui::Checkbox(("##inherit_" + inheritKey).c_str(), &inheritFlag)) {
+						if (inheritFlag && parentWidget) {
+							weather->volumetricLighting[i] = parentWidget->weather->volumetricLighting[i];
+							recordChanged = true;
+						}
+					}
+					if (ImGui::IsItemHovered()) {
+						ImGui::SetTooltip(inheritFlag ? "Inheriting from parent" : "Inherit from parent");
+					}
+					ImGui::SameLine();
+				}
+
+				ImGui::Text("%s:", label.c_str());
+				ImGui::SameLine(hasParent ? 120.0f : 100.0f);
+				if (WeatherUtils::DrawFormPickerCached("##VolumetricLighting", weather->volumetricLighting[i], editorWindow->volumetricLightingWidgets, false, true)) {
+					recordChanged = true;
+				}  // Add "Open" button
+				if (weather->volumetricLighting[i]) {
+					ImGui::SameLine();
+					if (ImGui::SmallButton(std::format("Open##{}", i).c_str())) {
+						for (auto& widget : editorWindow->volumetricLightingWidgets) {
+							if (widget->form == weather->volumetricLighting[i]) {
+								widget->SetOpen(true);
+								break;
+							}
+						}
+					}
+					if (ImGui::IsItemHovered()) {
+						ImGui::SetTooltip("Open this Volumetric Lighting for editing");
+					}
+				}
+
+				ImGui::PopID();
 			}
+			ImGui::Spacing();
+		}
 
+		// Precipitation Data
+		if (ImGui::CollapsingHeader("Precipitation", ImGuiTreeNodeFlags_DefaultOpen)) {
 			// Inherit checkbox
 			if (hasParent) {
-				bool& inheritFlag = settings.inheritFlags[p.first];
-				if (ImGui::Checkbox(("##inherit_" + p.first).c_str(), &inheritFlag)) {
-					if (inheritFlag) {
-						InheritFromParent(p.first);
-						changed = true;
+				bool& inheritFlag = settings.inheritFlags["Precipitation"];
+				if (ImGui::Checkbox("##inherit_Precipitation", &inheritFlag)) {
+					if (inheritFlag && parentWidget) {
+						weather->precipitationData = parentWidget->weather->precipitationData;
+						recordChanged = true;
 					}
 				}
 				if (ImGui::IsItemHovered()) {
@@ -1349,685 +356,1678 @@ void WeatherWidget::DrawWidget()
 				ImGui::SameLine();
 			}
 
-			switch (p.second) {
-			case 0:
-				if (WeatherUtils::DrawSliderInt8(p.first, settings.weatherProperties[p.first]))
-					changed = true;
-				break;
-			case 1:
-				if (WeatherUtils::DrawColorEdit(p.first, settings.weatherColors[p.first]))
-					changed = true;
-				break;
-			case 2:
-				if (WeatherUtils::DrawSliderUint8(p.first, settings.weatherProperties[p.first]))
-					changed = true;
-				break;
-			case 3:
-				if (WeatherUtils::DrawSliderFloat(p.first, settings.fogProperties[p.first]))
-					changed = true;
-				break;
-			default:
-				break;
+			ImGui::Text("Particle Shader:");
+			ImGui::SameLine(hasParent ? 170.0f : 150.0f);
+			if (WeatherUtils::DrawFormPickerCached("##Precipitation", weather->precipitationData, editorWindow->precipitationWidgets, false, true)) {
+				recordChanged = true;
+			}  // Add "Open" button
+			if (weather->precipitationData) {
+				ImGui::SameLine();
+				if (ImGui::SmallButton("Open##Precip")) {
+					for (auto& widget : editorWindow->precipitationWidgets) {
+						if (widget->form == weather->precipitationData) {
+							widget->SetOpen(true);
+							break;
+						}
+					}
+				}
+				if (ImGui::IsItemHovered()) {
+					ImGui::SetTooltip("Open this Precipitation for editing");
+				}
 			}
 
-			if (ShouldHighlight(p.first)) {
-				ImGui::PopStyleColor(2);
-			}
+			ImGui::Spacing();
 		}
 
-		if (changed && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
+		// Visual Effect (Reference Effect)
+		if (ImGui::CollapsingHeader("Visual Effect", ImGuiTreeNodeFlags_DefaultOpen)) {
+			// Inherit checkbox
+			if (hasParent) {
+				bool& inheritFlag = settings.inheritFlags["ReferenceEffect"];
+				if (ImGui::Checkbox("##inherit_ReferenceEffect", &inheritFlag)) {
+					if (inheritFlag && parentWidget) {
+						weather->referenceEffect = parentWidget->weather->referenceEffect;
+						recordChanged = true;
+					}
+				}
+				if (ImGui::IsItemHovered()) {
+					ImGui::SetTooltip(inheritFlag ? "Inheriting from parent" : "Inherit from parent");
+				}
+				ImGui::SameLine();
+			}
+
+			ImGui::Text("Reference Effect:");
+			ImGui::SameLine(hasParent ? 170.0f : 150.0f);
+			if (WeatherUtils::DrawFormPickerCached("##ReferenceEffect", weather->referenceEffect, editorWindow->referenceEffectWidgets, false, true)) {
+				recordChanged = true;
+			}  // Add "Open" button
+			if (weather->referenceEffect) {
+				ImGui::SameLine();
+				if (ImGui::SmallButton("Open##RefEffect")) {
+					for (auto& widget : editorWindow->referenceEffectWidgets) {
+						if (widget->form == weather->referenceEffect) {
+							widget->SetOpen(true);
+							break;
+						}
+					}
+				}
+				if (ImGui::IsItemHovered()) {
+					ImGui::SetTooltip("Open this Visual Effect for editing");
+				}
+			}
+
+			ImGui::Spacing();
+		}
+
+		if (recordChanged && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
 			ApplyChanges();
 		}
 
-		ImGui::Spacing();
-		ImGui::Separator();
-		ImGui::Spacing();
+		EndScrollableContent();
+		ImGui::EndTabItem();
+	}
+	ImGui::EndTabBar();
+	ImGui::End();
+}
+
+void WeatherWidget::LoadSettings()
+{
+	bool hadErrors = false;
+	if (!js.empty()) {
+		try {
+			// Attempt to load settings from JSON
+			settings = js;
+
+			// Validate that critical fields were loaded correctly
+			if (js.contains("weatherProperties") && settings.weatherProperties.empty() && !js["weatherProperties"].empty()) {
+				logger::warn("Weather {}: weatherProperties loaded but appears empty, reverting to vanilla values", GetEditorID());
+				hadErrors = true;
+			}
+			if (js.contains("weatherColors") && settings.weatherColors.empty() && !js["weatherColors"].empty()) {
+				logger::warn("Weather {}: weatherColors loaded but appears empty, reverting to vanilla values", GetEditorID());
+				hadErrors = true;
+			}
+			if (js.contains("fogProperties") && settings.fogProperties.empty() && !js["fogProperties"].empty()) {
+				logger::warn("Weather {}: fogProperties loaded but appears empty, reverting to vanilla values", GetEditorID());
+				hadErrors = true;
+			}
+
+			if (hadErrors) {
+				// Fallback to vanilla/game values
+				settings = vanillaSettings;
+				EditorWindow::GetSingleton()->ShowNotification(
+					std::format("Some values failed to load for {}", GetEditorID()),
+					ImVec4(1.0f, 0.0f, 0.0f, 1.0f),
+					3.0f);
+			} else {
+				logger::info("Weather {}: Loaded settings - {} weather properties, {} colors, {} fog properties",
+					GetEditorID(),
+					settings.weatherProperties.size(),
+					settings.weatherColors.size(),
+					settings.fogProperties.size());
+			}
+
+		} catch (const nlohmann::json::exception& e) {
+			logger::error("Weather {}: Failed to deserialize settings from JSON: {}", GetEditorID(), e.what());
+			// Fallback to vanilla/game values on exception
+			settings = vanillaSettings;
+			EditorWindow::GetSingleton()->ShowNotification(
+				std::format("Some values failed to load for {}", GetEditorID()),
+				ImVec4(1.0f, 0.0f, 0.0f, 1.0f),
+				3.0f);
+			return;
+		}
+	} else {
+		settings = vanillaSettings;
+	}
+	InitializeInheritFlags();
+	if (!js.empty()) {
+		LoadFeatureSettings();
+	}
+	originalSettings = settings;
+	ApplyChanges();
+}
+
+void WeatherWidget::SaveSettings()
+{
+	SaveFeatureSettings();
+
+	try {
+		js = settings;
+
+		if (js.is_null()) {
+			logger::error("Weather {}: Serialization produced null JSON!", GetEditorID());
+		} else if (!js.contains("weatherProperties")) {
+			logger::error("Weather {}: Serialized JSON missing weatherProperties field!", GetEditorID());
+		} else if (!js.contains("atmosphereColors")) {
+			logger::error("Weather {}: Serialized JSON missing atmosphereColors field!", GetEditorID());
+		} else if (!js.contains("clouds")) {
+			logger::error("Weather {}: Serialized JSON missing clouds field!", GetEditorID());
+		} else {
+			originalSettings = settings;
+		}
+
+	} catch (const nlohmann::json::exception& e) {
+		logger::error("Weather {}: Failed to serialize settings to JSON: {}", GetEditorID(), e.what());
+	}
+}
+
+WeatherWidget* WeatherWidget::GetParent()
+{
+	auto editorWindow = EditorWindow::GetSingleton();
+	auto& widgets = editorWindow->weatherWidgets;
+
+	auto temp = std::find_if(widgets.begin(), widgets.end(), [&](const auto& w) { return w->GetEditorID() == settings.parent; });
+	if (temp != widgets.end())
+		return (WeatherWidget*)temp->get();
+
+	return nullptr;
+}
+
+bool WeatherWidget::HasParent() const
+{
+	return settings.parent != "None";
+}
+
+void WeatherWidget::SetWeatherValues()
+{
+	std::map<std::string, int>& weatherProps = settings.weatherProperties;
+	std::map<std::string, float3>& weatherColors = settings.weatherColors;
+	std::map<std::string, float>& fogProperties = settings.fogProperties;
+
+	auto& data = weather->data;
+	auto& colorData = weather->colorData;
+	auto& fogData = weather->fogData;
+
+	weather->data.transDelta = (int8_t)weatherProps["Trans Delta"];
+
+	// Sun
+	data.sunGlare = (int8_t)weatherProps["Sun Glare"];
+	data.sunDamage = (int8_t)weatherProps["Sun Damage"];
+
+	// Precipitation
+	data.precipitationBeginFadeIn = (int8_t)weatherProps["Precipitation Begin Fade In"];
+	data.precipitationEndFadeOut = (int8_t)weatherProps["Precipitation End Fade Out"];
+
+	// Lightning
+	data.thunderLightningBeginFadeIn = (int8_t)weatherProps["Thunder Lightning Begin Fade In"];
+	data.thunderLightningEndFadeOut = (int8_t)weatherProps["Thunder Lightning End Fade Out"];
+	data.thunderLightningFrequency = (int8_t)weatherProps["Thunder Lightning Frequency"];
+	Float3ToColor(weatherColors["Lightning Color"], weather->data.lightningColor);
+
+	// Visual Effects
+	data.visualEffectBegin = (int8_t)weatherProps["Visual Effect Begin"];
+	data.visualEffectEnd = (int8_t)weatherProps["Visual Effect End"];
+
+	// Wind
+	data.windSpeed = (uint8_t)weatherProps["Wind Speed"];
+	data.windDirection = (int8_t)weatherProps["Wind Direction"];
+	data.windDirectionRange = (int8_t)weatherProps["Wind Direction Range"];
+
+	// Fog
+	fogData.dayNear = fogProperties["Day Near"];
+	fogData.dayFar = fogProperties["Day Far"];
+	fogData.dayPower = fogProperties["Day Power"];
+	fogData.dayMax = fogProperties["Day Max"];
+	fogData.nightNear = fogProperties["Night Near"];
+	fogData.nightFar = fogProperties["Night Far"];
+	fogData.nightPower = fogProperties["Night Power"];
+	fogData.nightMax = fogProperties["Night Max"];
+
+	// Atmosphere colors
+	for (size_t i = 0; i < ColorTypes::kTotal; i++) {
+		for (size_t j = 0; j < ColorTimes::kTotal; j++) {
+			auto& color = colorData[i][j];
+			Float3ToColor(settings.atmosphereColors[i].colorTimes[j], color);
+		}
 	}
 
-	void WeatherWidget::InheritFromParent(const std::string& property)
-	{
-		if (!HasParent())
-			return;
+	//DALC
+	for (size_t i = 0; i < ColorTimes::kTotal; i++) {
+		auto& dalc = weather->directionalAmbientLightingColors[i];
+		auto& settingsDalc = settings.dalc[i];
+		dalc.fresnelPower = settingsDalc.fresnelPower;
 
-		WeatherWidget* parentWidget = GetParent();
-		if (!parentWidget)
-			return;
+		Float3ToColor(settingsDalc.specular, dalc.specular);
 
-		if (settings.weatherProperties.find(property) != settings.weatherProperties.end()) {
-			settings.weatherProperties[property] = parentWidget->settings.weatherProperties[property];
-		} else if (settings.weatherColors.find(property) != settings.weatherColors.end()) {
-			settings.weatherColors[property] = parentWidget->settings.weatherColors[property];
-		} else if (settings.fogProperties.find(property) != settings.fogProperties.end()) {
-			settings.fogProperties[property] = parentWidget->settings.fogProperties[property];
+		Float3ToColor(settingsDalc.directional[0].max, dalc.directional.x.max);
+		Float3ToColor(settingsDalc.directional[0].min, dalc.directional.x.min);
+
+		Float3ToColor(settingsDalc.directional[1].max, dalc.directional.y.max);
+		Float3ToColor(settingsDalc.directional[1].min, dalc.directional.y.min);
+
+		Float3ToColor(settingsDalc.directional[2].max, dalc.directional.z.max);
+		Float3ToColor(settingsDalc.directional[2].min, dalc.directional.z.min);
+	}
+
+	// Clouds
+	uint32_t disabledBits = 0;
+	for (size_t i = 0; i < TESWeather::kTotalLayers; i++) {
+		auto& settingsCloud = settings.clouds[i];
+
+		weather->cloudLayerSpeedX[i] = (int8_t)settingsCloud.cloudLayerSpeedX;
+		weather->cloudLayerSpeedY[i] = (int8_t)settingsCloud.cloudLayerSpeedY;
+
+		if (!settingsCloud.enabled) {
+			disabledBits |= (1 << i);
+		}
+
+		auto& cloudColors = weather->cloudColorData[i];
+		auto& cloudAlphas = weather->cloudAlpha[i];
+
+		for (int j = 0; j < ColorTimes::kTotal; j++) {
+			cloudAlphas[j] = settingsCloud.cloudAlpha[j];
+			Float3ToColor(settingsCloud.color[j], cloudColors[j]);
+		}
+	}
+	weather->cloudLayerDisabledBits = disabledBits;
+
+	// If this weather is currently active, immediately apply feature settings to game memory
+	auto* weatherManager = WeatherManager::GetSingleton();
+	if (weatherManager->GetCurrentWeathers().currentWeather == weather) {
+		auto* globalRegistry = WeatherVariables::GlobalWeatherRegistry::GetSingleton();
+		json emptyWeather;
+
+		for (const auto& [featureName, featureSettings] : settings.featureSettings) {
+			if (!featureSettings.value("__enabled", false) || !globalRegistry->HasWeatherSupport(featureName)) {
+				continue;
+			}
+
+			// Filter out __enabled flag and apply settings
+			json filteredSettings = featureSettings;
+			filteredSettings.erase("__enabled");
+			globalRegistry->UpdateFeatureFromWeathers(featureName, emptyWeather, filteredSettings, 1.0f);
+		}
+	}
+}
+
+void WeatherWidget::InitializeInheritFlags()
+{
+	auto& flags = settings.inheritFlags;
+	auto ensureFlag = [&](const std::string& key) {
+		flags.try_emplace(key, false);
+	};
+
+	static const char* kFixedKeys[] = {
+		"Precipitation",
+		"ReferenceEffect",
+		"DALC_Specular",
+		"DALC_Fresnel",
+		"DALC_DirXMax",
+		"DALC_DirXMin",
+		"DALC_DirYMax",
+		"DALC_DirYMin",
+		"DALC_DirZMax",
+		"DALC_DirZMin",
+		"Fog_Near",
+		"Fog_Far",
+		"Fog_Power",
+		"Fog_Max",
+		"Sun Damage",
+		"Wind Speed",
+		"Wind Direction",
+		"Wind Direction Range",
+		"Precipitation Begin Fade In",
+		"Precipitation End Fade Out",
+		"Thunder Lightning Begin Fade In",
+		"Thunder Lightning End Fade Out",
+		"Thunder Lightning Frequency",
+		"Lightning Color",
+		"Visual Effect Begin",
+		"Visual Effect End",
+		"Trans Delta",
+	};
+	for (const char* key : kFixedKeys) {
+		ensureFlag(key);
+	}
+
+	for (int i = 0; i < ColorTimes::kTotal; i++) {
+		ensureFlag(std::format("ImageSpace_{}", i));
+		ensureFlag(std::format("VolumetricLighting_{}", i));
+	}
+
+	for (int i = 0; i < ColorTypes::kTotal; i++) {
+		ensureFlag(std::format("Atmosphere_{}", ColorTypeLabel(i)));
+	}
+
+	for (int i = 0; i < TESWeather::kTotalLayers; i++) {
+		ensureFlag(std::format("Cloud{}_Color", i));
+		ensureFlag(std::format("Cloud{}_Alpha", i));
+	}
+}
+
+void WeatherWidget::LoadWeatherValues()
+{
+	std::map<std::string, int>& weatherProps = settings.weatherProperties;
+	std::map<std::string, float3>& weatherColors = settings.weatherColors;
+	std::map<std::string, float>& fogProperties = settings.fogProperties;
+
+	const auto& data = weather->data;
+	const auto& colorData = weather->colorData;
+	const auto& fogData = weather->fogData;
+
+	weatherProps["Trans Delta"] = data.transDelta;
+
+	// Sun
+	weatherProps["Sun Glare"] = data.sunGlare;
+	weatherProps["Sun Damage"] = data.sunDamage;
+
+	// Precipitation
+	weatherProps["Precipitation Begin Fade In"] = data.precipitationBeginFadeIn;
+	weatherProps["Precipitation End Fade Out"] = data.precipitationEndFadeOut;
+
+	// Lightning
+	weatherProps["Thunder Lightning Begin Fade In"] = data.thunderLightningBeginFadeIn;
+	weatherProps["Thunder Lightning End Fade Out"] = data.thunderLightningEndFadeOut;
+	weatherProps["Thunder Lightning Frequency"] = data.thunderLightningFrequency;
+	ColorToFloat3(data.lightningColor, weatherColors["Lightning Color"]);
+
+	// Visual Effects
+	weatherProps["Visual Effect Begin"] = data.visualEffectBegin;
+	weatherProps["Visual Effect End"] = data.visualEffectEnd;
+
+	// Wind
+	weatherProps["Wind Speed"] = data.windSpeed;
+	weatherProps["Wind Direction"] = data.windDirection;
+	weatherProps["Wind Direction Range"] = data.windDirectionRange;
+
+	// Fog
+	fogProperties["Day Near"] = fogData.dayNear;
+	fogProperties["Day Far"] = fogData.dayFar;
+	fogProperties["Night Near"] = fogData.nightNear;
+	fogProperties["Night Far"] = fogData.nightFar;
+	fogProperties["Day Power"] = fogData.dayPower;
+	fogProperties["Night Power"] = fogData.nightPower;
+	fogProperties["Day Max"] = fogData.dayMax;
+	fogProperties["Night Max"] = fogData.nightMax;
+
+	// Atmosphere color
+	for (size_t i = 0; i < ColorTypes::kTotal; i++) {
+		for (size_t j = 0; j < ColorTimes::kTotal; j++) {
+			auto& color = colorData[i][j];
+			ColorToFloat3(color, settings.atmosphereColors[i].colorTimes[j]);
 		}
 	}
 
-	void WeatherWidget::InheritAllFromParent()
-	{
-		if (!HasParent())
-			return;
+	// DALC
+	for (size_t i = 0; i < ColorTimes::kTotal; i++) {
+		auto& dalc = weather->directionalAmbientLightingColors[i];
+		auto& settingsDalc = settings.dalc[i];
+		settingsDalc.fresnelPower = dalc.fresnelPower;
 
-		WeatherWidget* parentWidget = GetParent();
-		if (!parentWidget)
-			return;
+		ColorToFloat3(dalc.specular, settingsDalc.specular);
 
-		// Copy all weather properties
-		for (const auto& [key, value] : parentWidget->settings.weatherProperties) {
-			settings.weatherProperties[key] = value;
+		ColorToFloat3(dalc.directional.x.max, settingsDalc.directional[0].max);
+		ColorToFloat3(dalc.directional.x.min, settingsDalc.directional[0].min);
+
+		ColorToFloat3(dalc.directional.y.max, settingsDalc.directional[1].max);
+		ColorToFloat3(dalc.directional.y.min, settingsDalc.directional[1].min);
+
+		ColorToFloat3(dalc.directional.z.max, settingsDalc.directional[2].max);
+		ColorToFloat3(dalc.directional.z.min, settingsDalc.directional[2].min);
+	}
+
+	// Clouds
+	for (size_t i = 0; i < TESWeather::kTotalLayers; i++) {
+		auto& settingsCloud = settings.clouds[i];
+
+		settingsCloud.cloudLayerSpeedX = weather->cloudLayerSpeedX[i];
+		settingsCloud.cloudLayerSpeedY = weather->cloudLayerSpeedY[i];
+		settingsCloud.enabled = !(weather->cloudLayerDisabledBits & (1 << i));
+		settingsCloud.texturePath = weather->cloudTextures[i].textureName.c_str();
+
+		auto& cloudColors = weather->cloudColorData[i];
+		auto& cloudAlphas = weather->cloudAlpha[i];
+
+		for (int j = 0; j < ColorTimes::kTotal; j++) {
+			settingsCloud.cloudAlpha[j] = cloudAlphas[j];
+			ColorToFloat3(cloudColors[j], settingsCloud.color[j]);
 		}
+	}
+}
 
-		// Copy all weather colors
-		for (const auto& [key, value] : parentWidget->settings.weatherColors) {
-			settings.weatherColors[key] = value;
-		}
+void WeatherWidget::DrawDALCSettings()
+{
+	auto editorWindow = EditorWindow::GetSingleton();
+	bool hasParent = editorWindow->settings.enableInheritFromParent && HasParent();
+	WeatherWidget* parentWidget = hasParent ? GetParent() : nullptr;
 
-		// Copy all fog properties
-		for (const auto& [key, value] : parentWidget->settings.fogProperties) {
-			settings.fogProperties[key] = value;
-		}
+	bool changed = false;
 
-		// Copy atmosphere colors
-		for (int i = 0; i < ColorTypes::kTotal; i++) {
-			settings.atmosphereColors[i] = parentWidget->settings.atmosphereColors[i];
-		}
+	if (TOD::BeginTODTable("DALC_TOD_Table")) {
+		TOD::RenderTODHeader();
+		TOD::DrawTODSeparator();
 
-		// Copy DALC settings
+		// Prepare arrays for TOD rendering
+		float3 specularColors[4];
+		float fresnelPowers[4];
+		float3 directionalXMax[4], directionalXMin[4];
+		float3 directionalYMax[4], directionalYMin[4];
+		float3 directionalZMax[4], directionalZMin[4];
+
+		// Parent values
+		float3 parentSpecular[4] = {};
+		float parentFresnel[4] = {};
+		float3 parentDirXMax[4] = {}, parentDirXMin[4] = {};
+		float3 parentDirYMax[4] = {}, parentDirYMin[4] = {};
+		float3 parentDirZMax[4] = {}, parentDirZMin[4] = {};
+
 		for (int i = 0; i < ColorTimes::kTotal; i++) {
-			settings.dalc[i] = parentWidget->settings.dalc[i];
+			specularColors[i] = settings.dalc[i].specular;
+			fresnelPowers[i] = settings.dalc[i].fresnelPower;
+			directionalXMax[i] = settings.dalc[i].directional[0].max;
+			directionalXMin[i] = settings.dalc[i].directional[0].min;
+			directionalYMax[i] = settings.dalc[i].directional[1].max;
+			directionalYMin[i] = settings.dalc[i].directional[1].min;
+			directionalZMax[i] = settings.dalc[i].directional[2].max;
+			directionalZMin[i] = settings.dalc[i].directional[2].min;
+
+			if (parentWidget) {
+				parentSpecular[i] = parentWidget->settings.dalc[i].specular;
+				parentFresnel[i] = parentWidget->settings.dalc[i].fresnelPower;
+				parentDirXMax[i] = parentWidget->settings.dalc[i].directional[0].max;
+				parentDirXMin[i] = parentWidget->settings.dalc[i].directional[0].min;
+				parentDirYMax[i] = parentWidget->settings.dalc[i].directional[1].max;
+				parentDirYMin[i] = parentWidget->settings.dalc[i].directional[1].min;
+				parentDirZMax[i] = parentWidget->settings.dalc[i].directional[2].max;
+				parentDirZMin[i] = parentWidget->settings.dalc[i].directional[2].min;
+			}
 		}
 
-		// Copy cloud settings
-		for (int i = 0; i < TESWeather::kTotalLayers; i++) {
-			settings.clouds[i] = parentWidget->settings.clouds[i];
+		// Draw with per-parameter inheritance
+		if (hasParent) {
+			if (TOD::DrawTODColorRow("Specular", specularColors, settings.inheritFlags["DALC_Specular"], parentSpecular)) {
+				for (int i = 0; i < ColorTimes::kTotal; i++)
+					settings.dalc[i].specular = specularColors[i];
+				changed = true;
+			}
+
+			if (TOD::DrawTODFloatRow("Fresnel Power", fresnelPowers, settings.inheritFlags["DALC_Fresnel"], parentFresnel, 0.0f, 10.0f)) {
+				for (int i = 0; i < ColorTimes::kTotal; i++)
+					settings.dalc[i].fresnelPower = fresnelPowers[i];
+				changed = true;
+			}
+		} else {
+			if (TOD::DrawTODColorRow("Specular", specularColors)) {
+				for (int i = 0; i < ColorTimes::kTotal; i++)
+					settings.dalc[i].specular = specularColors[i];
+				changed = true;
+			}
+
+			if (TOD::DrawTODFloatRow("Fresnel Power", fresnelPowers, 0.0f, 10.0f)) {
+				for (int i = 0; i < ColorTimes::kTotal; i++)
+					settings.dalc[i].fresnelPower = fresnelPowers[i];
+				changed = true;
+			}
 		}
 
-		// Set all inherit flags to true
-		settings.inheritFlags["DALC_Specular"] = true;
-		settings.inheritFlags["DALC_Fresnel"] = true;
-		settings.inheritFlags["DALC_DirXMax"] = true;
-		settings.inheritFlags["DALC_DirXMin"] = true;
-		settings.inheritFlags["DALC_DirYMax"] = true;
-		settings.inheritFlags["DALC_DirYMin"] = true;
-		settings.inheritFlags["DALC_DirZMax"] = true;
-		settings.inheritFlags["DALC_DirZMin"] = true;
+		TOD::DrawTODSeparator();
 
-		settings.inheritFlags["Fog_Near"] = true;
-		settings.inheritFlags["Fog_Far"] = true;
-		settings.inheritFlags["Fog_Power"] = true;
-		settings.inheritFlags["Fog_Max"] = true;
+		// Directional colors with per-parameter inheritance
+		if (hasParent) {
+			if (TOD::DrawTODColorRow("Directional +X", directionalXMax, settings.inheritFlags["DALC_DirXMax"], parentDirXMax)) {
+				for (int i = 0; i < ColorTimes::kTotal; i++)
+					settings.dalc[i].directional[0].max = directionalXMax[i];
+				changed = true;
+			}
 
-		// Atmosphere colors
-		static const int displayOrder[] = { 0, 7, 8, 1, 12, 3, 4, 5, 6, 9, 10, 11, 13, 14, 15, 16, 2 };
+			if (TOD::DrawTODColorRow("Directional -X", directionalXMin, settings.inheritFlags["DALC_DirXMin"], parentDirXMin)) {
+				for (int i = 0; i < ColorTimes::kTotal; i++)
+					settings.dalc[i].directional[0].min = directionalXMin[i];
+				changed = true;
+			}
+
+			if (TOD::DrawTODColorRow("Directional +Y", directionalYMax, settings.inheritFlags["DALC_DirYMax"], parentDirYMax)) {
+				for (int i = 0; i < ColorTimes::kTotal; i++)
+					settings.dalc[i].directional[1].max = directionalYMax[i];
+				changed = true;
+			}
+
+			if (TOD::DrawTODColorRow("Directional -Y", directionalYMin, settings.inheritFlags["DALC_DirYMin"], parentDirYMin)) {
+				for (int i = 0; i < ColorTimes::kTotal; i++)
+					settings.dalc[i].directional[1].min = directionalYMin[i];
+				changed = true;
+			}
+
+			if (TOD::DrawTODColorRow("Directional +Z", directionalZMax, settings.inheritFlags["DALC_DirZMax"], parentDirZMax)) {
+				for (int i = 0; i < ColorTimes::kTotal; i++)
+					settings.dalc[i].directional[2].max = directionalZMax[i];
+				changed = true;
+			}
+
+			if (TOD::DrawTODColorRow("Directional -Z", directionalZMin, settings.inheritFlags["DALC_DirZMin"], parentDirZMin)) {
+				for (int i = 0; i < ColorTimes::kTotal; i++)
+					settings.dalc[i].directional[2].min = directionalZMin[i];
+				changed = true;
+			}
+		} else {
+			if (TOD::DrawTODColorRow("Directional +X", directionalXMax)) {
+				for (int i = 0; i < ColorTimes::kTotal; i++)
+					settings.dalc[i].directional[0].max = directionalXMax[i];
+				changed = true;
+			}
+
+			if (TOD::DrawTODColorRow("Directional -X", directionalXMin)) {
+				for (int i = 0; i < ColorTimes::kTotal; i++)
+					settings.dalc[i].directional[0].min = directionalXMin[i];
+				changed = true;
+			}
+
+			if (TOD::DrawTODColorRow("Directional +Y", directionalYMax)) {
+				for (int i = 0; i < ColorTimes::kTotal; i++)
+					settings.dalc[i].directional[1].max = directionalYMax[i];
+				changed = true;
+			}
+
+			if (TOD::DrawTODColorRow("Directional -Y", directionalYMin)) {
+				for (int i = 0; i < ColorTimes::kTotal; i++)
+					settings.dalc[i].directional[1].min = directionalYMin[i];
+				changed = true;
+			}
+
+			if (TOD::DrawTODColorRow("Directional +Z", directionalZMax)) {
+				for (int i = 0; i < ColorTimes::kTotal; i++)
+					settings.dalc[i].directional[2].max = directionalZMax[i];
+				changed = true;
+			}
+
+			if (TOD::DrawTODColorRow("Directional -Z", directionalZMin)) {
+				for (int i = 0; i < ColorTimes::kTotal; i++)
+					settings.dalc[i].directional[2].min = directionalZMin[i];
+				changed = true;
+			}
+		}
+
+		TOD::EndTODTable();
+	}
+	if (changed && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
+		ApplyChanges();
+	}
+}
+
+void WeatherWidget::DrawWeatherColorSettings()
+{
+	auto editorWindow = EditorWindow::GetSingleton();
+	bool hasParent = editorWindow->settings.enableInheritFromParent && HasParent();
+	WeatherWidget* parentWidget = hasParent ? GetParent() : nullptr;
+
+	bool changed = false;
+
+	if (TOD::BeginTODTable("AtmosphereColors_Table")) {
+		TOD::RenderTODHeader();
+		TOD::DrawTODSeparator();
+
+		// Organized display order: group related sky/fog/lighting properties
+		static const int displayOrder[] = {
+			0,   // Sky Upper
+			7,   // Sky Lower
+			8,   // Horizon
+			1,   // Fog Near
+			12,  // Fog Far
+			3,   // Ambient
+			4,   // Sunlight
+			15,  // Sun Glare
+			5,   // Sun
+			6,   // Stars
+			16,  // Moon Glare
+			9,   // Effect Lighting
+			10,  // Cloud LOD Diffuse
+			11,  // Cloud LOD Ambient
+			13,  // Sky Statics
+			14,  // Water Multiplier
+			2,   // Unknown
+		};
+
 		for (int idx = 0; idx < ColorTypes::kTotal; idx++) {
 			int i = displayOrder[idx];
 			std::string colorTypeLabel = ColorTypeLabel(i);
-			settings.inheritFlags["Atmosphere_" + colorTypeLabel] = true;
-		}
 
-		// Cloud settings
-		for (int i = 0; i < TESWeather::kTotalLayers; i++) {
-			settings.inheritFlags[std::format("Cloud{}_Color", i)] = true;
-			settings.inheritFlags[std::format("Cloud{}_Alpha", i)] = true;
-		}
+			if (hasParent) {
+				float3 parentColors[4];
+				for (int j = 0; j < 4; j++)
+					parentColors[j] = parentWidget->settings.atmosphereColors[i].colorTimes[j];
 
-		// Apply the changes
-		if (EditorWindow::GetSingleton()->settings.autoApplyChanges) {
-			ApplyChanges();
-		}
-
-		EditorWindow::GetSingleton()->ShowNotification(
-			std::format("Inherited all settings from {}", parentWidget->GetEditorID()),
-			ImVec4(0.0f, 1.0f, 0.5f, 1.0f),
-			3.0f);
-	}
-
-	void WeatherWidget::SaveFeatureSettings()
-	{
-		auto* weatherManager = WeatherManager::GetSingleton();
-
-		// Collect all feature names from both current and original settings to detect deletions
-		std::set<std::string> allFeatureNames;
-		for (const auto& [featureName, _] : settings.featureSettings) {
-			allFeatureNames.insert(featureName);
-		}
-		for (const auto& [featureName, _] : originalSettings.featureSettings) {
-			allFeatureNames.insert(featureName);
-		}
-
-		// Save current settings or clear deleted features
-		for (const auto& featureName : allFeatureNames) {
-			auto it = settings.featureSettings.find(featureName);
-			weatherManager->SaveSettingsToWeather(
-				weather,
-				featureName,
-				it != settings.featureSettings.end() ? it->second : json::object());
-		}
-	}
-
-	void WeatherWidget::LoadFeatureSettings()
-	{
-		auto* weatherManager = WeatherManager::GetSingleton();
-		auto* globalRegistry = WeatherVariables::GlobalWeatherRegistry::GetSingleton();
-
-		// First, validate that all feature settings in the JSON exist as loaded features.
-		// Prevents loading a .json that references features that aren't installed. (Will load only settings for installed features.)
-		// Should make it very obvious to users when they have not followed the correct installation instructions.
-		if (js.contains("featureSettings") && js["featureSettings"].is_object()) {
-			std::vector<std::string> missingFeatures;
-
-			for (const auto& [featureName, featureJson] : js["featureSettings"].items()) {
-				if (featureJson.empty()) {
-					continue;
+				std::string inheritKey = "Atmosphere_" + colorTypeLabel;
+				if (TOD::DrawTODColorRow(colorTypeLabel.c_str(), settings.atmosphereColors[i].colorTimes, settings.inheritFlags[inheritKey], parentColors)) {
+					changed = true;
 				}
+			} else {
+				if (TOD::DrawTODColorRow(colorTypeLabel.c_str(), settings.atmosphereColors[i].colorTimes)) {
+					changed = true;
+				}
+			}
+		}
 
-				// Check if this feature exists and is loaded
-				bool featureExists = false;
-				for (auto* feature : Feature::GetFeatureList()) {
-					if (feature && feature->loaded && feature->GetShortName() == featureName) {
-						featureExists = true;
-						break;
+		TOD::EndTODTable();
+	}
+
+	if (changed && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
+		ApplyChanges();
+	}
+}
+
+void WeatherWidget::DrawCloudSettings()
+{
+	auto editorWindow = EditorWindow::GetSingleton();
+	bool hasParent = editorWindow->settings.enableInheritFromParent && HasParent();
+	WeatherWidget* parentWidget = hasParent ? GetParent() : nullptr;
+
+	bool changed = false;
+	bool enableChanged = false;
+
+	// OpenOnArrow|OpenOnDoubleClick prevents accidental collapse when clicking
+	// the [Enabled] badge area that overlaps the right side of the header.
+	constexpr ImGuiTreeNodeFlags flags = ImGuiTreeNodeFlags_OpenOnArrow | ImGuiTreeNodeFlags_OpenOnDoubleClick;
+	constexpr char kEnabledBadge[] = "[Enabled]";
+
+	for (int i = 0; i < TESWeather::kTotalLayers; i++) {
+		std::string layer = std::format("Layer {}", i);
+		bool layerEnabled = settings.clouds[i].enabled;
+
+		if (!layerEnabled) {
+			ImGui::PushStyleColor(ImGuiCol_Header, ImGui::GetStyleColorVec4(ImGuiCol_FrameBg));
+			ImGui::PushStyleColor(ImGuiCol_HeaderHovered, ImGui::GetStyleColorVec4(ImGuiCol_FrameBgHovered));
+			ImGui::PushStyleColor(ImGuiCol_HeaderActive, ImGui::GetStyleColorVec4(ImGuiCol_FrameBgActive));
+		}
+
+		// Label is constant so the storage ID never changes — open/closed state always persists.
+		// [Enabled] badge is overlaid on the header via the draw list instead of altering the label.
+		float headerScreenY = ImGui::GetCursorScreenPos().y;
+		bool layerOpen = ImGui::CollapsingHeader(layer.c_str(), flags);
+
+		if (!layerEnabled)
+			ImGui::PopStyleColor(3);
+
+		if (layerEnabled) {
+			const ImVec2 badgeSize = ImGui::CalcTextSize(kEnabledBadge);
+			const float headerHeight = ImGui::GetFrameHeight();
+			const ImVec2 badgePos = {
+				ImGui::GetWindowPos().x + ImGui::GetContentRegionMax().x - badgeSize.x,
+				headerScreenY + (headerHeight - badgeSize.y) * 0.5f
+			};
+			ImGui::GetWindowDrawList()->AddText(badgePos, ImGui::GetColorU32(ImGuiCol_CheckMark), kEnabledBadge);
+		}
+
+		if (layerOpen) {
+			ImGui::Indent(10.0f);
+			ImGui::Spacing();
+
+			// Begin horizontal layout for enable checkbox and sliders on left, texture on right
+			ImGui::BeginGroup();
+
+			if (ImGui::Checkbox(std::format("Enable##{}", layer).c_str(), &layerEnabled)) {
+				settings.clouds[i].enabled = layerEnabled;
+				enableChanged = true;
+				changed = true;
+			}
+
+			ImGui::Spacing();
+			ImGui::Spacing();
+
+			// Make sliders 1/3 width
+			ImGui::PushItemWidth(ImGui::GetContentRegionAvail().x * 0.4f);
+			if (WeatherUtils::DrawSliderInt8(std::format("Cloud Layer Speed Y##{}", layer), settings.clouds[i].cloudLayerSpeedY))
+				changed = true;
+			ImGui::Spacing();
+			if (WeatherUtils::DrawSliderInt8(std::format("Cloud Layer Speed X##{}", layer), settings.clouds[i].cloudLayerSpeedX))
+				changed = true;
+			ImGui::PopItemWidth();
+
+			ImGui::EndGroup();
+
+			// Draw texture in upper right if available
+			if (!settings.clouds[i].texturePath.empty()) {
+				auto* texture = GetCloudTexture(i);
+				if (texture) {
+					ImGui::SameLine(0.0f, 20.0f);
+					ImGui::BeginGroup();
+					float textureSize = 128.0f;
+					ImGui::Image((void*)texture, ImVec2(textureSize, textureSize));
+					// Small grey subtext below image, clamped to texture width
+					ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
+					ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + textureSize);
+					ImGui::TextWrapped("%s", settings.clouds[i].texturePath.c_str());
+					ImGui::PopTextWrapPos();
+					ImGui::PopStyleColor();
+					ImGui::EndGroup();
+				}
+			}
+
+			ImGui::Spacing();
+			ImGui::Spacing();
+			if (TOD::BeginTODTable((layer + "_TOD_Table").c_str())) {
+				TOD::RenderTODHeader();
+				TOD::DrawTODSeparator();
+
+				if (hasParent) {
+					float3 parentColors[4];
+					float parentAlphas[4];
+					for (int j = 0; j < 4; j++) {
+						parentColors[j] = parentWidget->settings.clouds[i].color[j];
+						parentAlphas[j] = parentWidget->settings.clouds[i].cloudAlpha[j];
+					}
+
+					std::string colorKey = std::format("Cloud{}_Color", i);
+					std::string alphaKey = std::format("Cloud{}_Alpha", i);
+
+					if (TOD::DrawTODColorRow("Cloud Color", settings.clouds[i].color, settings.inheritFlags[colorKey], parentColors)) {
+						changed = true;
+					}
+
+					if (TOD::DrawTODFloatRow("Cloud Alpha", settings.clouds[i].cloudAlpha, settings.inheritFlags[alphaKey], parentAlphas, 0.0f, 1.0f)) {
+						changed = true;
+					}
+				} else {
+					if (TOD::DrawTODColorRow("Cloud Color", settings.clouds[i].color)) {
+						changed = true;
+					}
+
+					if (TOD::DrawTODFloatRow("Cloud Alpha", settings.clouds[i].cloudAlpha, 0.0f, 1.0f)) {
+						changed = true;
 					}
 				}
 
-				if (!featureExists) {
-					missingFeatures.push_back(featureName);
-				}
+				TOD::EndTODTable();
 			}
 
-			// If we found missing features, warn the user
-			if (!missingFeatures.empty()) {
-				std::string missingList;
-				for (size_t i = 0; i < missingFeatures.size(); ++i) {
-					if (i > 0)
-						missingList += ", ";
-					missingList += missingFeatures[i];
-				}
-
-				// Show notification
-				EditorWindow::GetSingleton()->ShowNotification(
-					std::format("Warning: {} references missing feature(s): {}", GetEditorID(), missingList),
-					ImVec4(1.0f, 0.6f, 0.0f, 1.0f),
-					5.0f);
-
-				// Add to Feature Issues system for each missing feature
-				for (const auto& featureName : missingFeatures) {
-					FeatureIssues::FeatureFileInfo fileInfo;
-					fileInfo.featureName = featureName;
-
-					FeatureIssues::AddFeatureIssue(
-						featureName,
-						"",
-						std::format("Weather '{}' contains settings for this feature, but the feature is not loaded. "
-									"The weather-specific parameters will be ignored until the feature is installed and loaded.",
-							GetEditorID()),
-						FeatureIssues::FeatureIssueInfo::IssueType::UNKNOWN,
-						fileInfo,
-						"");
-				}
-
-				logger::warn("{}: JSON contains feature settings for features that are not loaded: {}", GetEditorID(), missingList);
+			ImGui::Spacing();
+			ImGui::Unindent(10.0f);
+		}
+	}
+	if (enableChanged) {
+		// Apply enable/disable immediately for instant feedback, regardless of autoApplyChanges.
+		editorWindow->PushUndoState(this);
+		ApplyChanges();
+		if (editorWindow->IsWeatherLocked() && editorWindow->GetLockedWeather() == weather) {
+			if (auto sky = RE::Sky::GetSingleton()) {
+				sky->ForceWeather(weather, true);  // override=true for immediate application; matches "instant feedback" intent above
 			}
 		}
+	} else if (changed && editorWindow->settings.autoApplyChanges) {
+		editorWindow->PushUndoState(this);
+		ApplyChanges();
+	}
+}
 
-		// Now load settings for features that ARE loaded
-		for (auto* feature : Feature::GetFeatureList()) {
-			if (!feature || !feature->loaded) {
-				continue;
+void WeatherWidget::DrawFogSettings()
+{
+	auto editorWindow = EditorWindow::GetSingleton();
+	bool hasParent = editorWindow->settings.enableInheritFromParent && HasParent();
+	WeatherWidget* parentWidget = hasParent ? GetParent() : nullptr;
+
+	bool changed = false;
+
+	if (ImGui::BeginTable("FogTable", 3, ImGuiTableFlags_BordersInnerV | ImGuiTableFlags_SizingFixedFit)) {
+		ImGui::TableSetupColumn("Parameter", ImGuiTableColumnFlags_WidthFixed, 200.0f);
+		ImGui::TableSetupColumn("Day", ImGuiTableColumnFlags_WidthFixed, 250.0f);
+		ImGui::TableSetupColumn("Night", ImGuiTableColumnFlags_WidthFixed, 250.0f);
+
+		// Header row
+		ImGui::TableNextRow();
+		ImGui::TableSetColumnIndex(0);
+		ImGui::TableSetColumnIndex(1);
+		ImGui::Text("Day");
+		ImGui::TableSetColumnIndex(2);
+		ImGui::Text("Night");
+
+		ImGui::TableNextRow();
+		ImGui::TableSetColumnIndex(0);
+		ImGui::Separator();
+		ImGui::TableSetColumnIndex(1);
+		ImGui::Separator();
+		ImGui::TableSetColumnIndex(2);
+		ImGui::Separator();
+
+		// Near
+		ImGui::TableNextRow();
+		ImGui::TableSetColumnIndex(0);
+		if (hasParent) {
+			ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(0.15f, 0.15f, 0.15f, 1.0f));
+			ImGui::PushStyleColor(ImGuiCol_CheckMark, ImVec4(0.5f, 0.5f, 0.5f, 1.0f));
+			ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(2, 2));
+			ImGui::Checkbox("##FogNear", &settings.inheritFlags["Fog_Near"]);
+			if (settings.inheritFlags["Fog_Near"]) {
+				settings.fogProperties["Day Near"] = parentWidget->settings.fogProperties["Day Near"];
+				settings.fogProperties["Night Near"] = parentWidget->settings.fogProperties["Night Near"];
+				changed = true;
 			}
+			ImGui::PopStyleVar();
+			ImGui::PopStyleColor(2);
+			ImGui::SameLine();
+		}
+		ImGui::Text("Near");
+		ImGui::TableSetColumnIndex(1);
+		ImGui::SetNextItemWidth(-1);
+		if (ImGui::SliderFloat("##FogDayNear", &settings.fogProperties["Day Near"], 0.0f, 1000000.0f, "%.0f"))
+			changed = true;
+		ImGui::TableSetColumnIndex(2);
+		ImGui::SetNextItemWidth(-1);
+		if (ImGui::SliderFloat("##FogNightNear", &settings.fogProperties["Night Near"], 0.0f, 1000000.0f, "%.0f"))
+			changed = true;
 
-			std::string featureName = feature->GetShortName();
-
-			// Check if feature has registered weather variables
-			if (!globalRegistry->HasWeatherSupport(featureName)) {
-				continue;
+		// Far
+		ImGui::TableNextRow();
+		ImGui::TableSetColumnIndex(0);
+		if (hasParent) {
+			ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(0.15f, 0.15f, 0.15f, 1.0f));
+			ImGui::PushStyleColor(ImGuiCol_CheckMark, ImVec4(0.5f, 0.5f, 0.5f, 1.0f));
+			ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(2, 2));
+			ImGui::Checkbox("##FogFar", &settings.inheritFlags["Fog_Far"]);
+			if (settings.inheritFlags["Fog_Far"]) {
+				settings.fogProperties["Day Far"] = parentWidget->settings.fogProperties["Day Far"];
+				settings.fogProperties["Night Far"] = parentWidget->settings.fogProperties["Night Far"];
+				changed = true;
 			}
+			ImGui::PopStyleVar();
+			ImGui::PopStyleColor(2);
+			ImGui::SameLine();
+		}
+		ImGui::Text("Far");
+		ImGui::TableSetColumnIndex(1);
+		ImGui::SetNextItemWidth(-1);
+		if (ImGui::SliderFloat("##FogDayFar", &settings.fogProperties["Day Far"], 0.0f, 1000000.0f, "%.0f"))
+			changed = true;
+		ImGui::TableSetColumnIndex(2);
+		ImGui::SetNextItemWidth(-1);
+		if (ImGui::SliderFloat("##FogNightFar", &settings.fogProperties["Night Far"], 0.0f, 1000000.0f, "%.0f"))
+			changed = true;
 
-			json featureJson;
-			if (weatherManager->LoadSettingsFromWeather(weather, featureName, featureJson)) {
-				settings.featureSettings[featureName] = featureJson;
+		// Power
+		ImGui::TableNextRow();
+		ImGui::TableSetColumnIndex(0);
+		if (hasParent) {
+			ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(0.15f, 0.15f, 0.15f, 1.0f));
+			ImGui::PushStyleColor(ImGuiCol_CheckMark, ImVec4(0.5f, 0.5f, 0.5f, 1.0f));
+			ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(2, 2));
+			ImGui::Checkbox("##FogPower", &settings.inheritFlags["Fog_Power"]);
+			if (settings.inheritFlags["Fog_Power"]) {
+				settings.fogProperties["Day Power"] = parentWidget->settings.fogProperties["Day Power"];
+				settings.fogProperties["Night Power"] = parentWidget->settings.fogProperties["Night Power"];
+				changed = true;
 			}
+			ImGui::PopStyleVar();
+			ImGui::PopStyleColor(2);
+			ImGui::SameLine();
+		}
+		ImGui::Text("Power");
+		ImGui::TableSetColumnIndex(1);
+		ImGui::SetNextItemWidth(-1);
+		if (ImGui::SliderFloat("##FogDayPower", &settings.fogProperties["Day Power"], 0.0f, 10.0f, "%.3f"))
+			changed = true;
+		ImGui::TableSetColumnIndex(2);
+		ImGui::SetNextItemWidth(-1);
+		if (ImGui::SliderFloat("##FogNightPower", &settings.fogProperties["Night Power"], 0.0f, 10.0f, "%.3f"))
+			changed = true;
+
+		// Max
+		ImGui::TableNextRow();
+		ImGui::TableSetColumnIndex(0);
+		if (hasParent) {
+			ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(0.15f, 0.15f, 0.15f, 1.0f));
+			ImGui::PushStyleColor(ImGuiCol_CheckMark, ImVec4(0.5f, 0.5f, 0.5f, 1.0f));
+			ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(2, 2));
+			ImGui::Checkbox("##FogMax", &settings.inheritFlags["Fog_Max"]);
+			if (settings.inheritFlags["Fog_Max"]) {
+				settings.fogProperties["Day Max"] = parentWidget->settings.fogProperties["Day Max"];
+				settings.fogProperties["Night Max"] = parentWidget->settings.fogProperties["Night Max"];
+				changed = true;
+			}
+			ImGui::PopStyleVar();
+			ImGui::PopStyleColor(2);
+			ImGui::SameLine();
+		}
+		ImGui::Text("Max");
+		ImGui::TableSetColumnIndex(1);
+		ImGui::SetNextItemWidth(-1);
+		if (ImGui::SliderFloat("##FogDayMax", &settings.fogProperties["Day Max"], 0.0f, 1.0f, "%.3f"))
+			changed = true;
+		ImGui::TableSetColumnIndex(2);
+		ImGui::SetNextItemWidth(-1);
+		if (ImGui::SliderFloat("##FogNightMax", &settings.fogProperties["Night Max"], 0.0f, 1.0f, "%.3f"))
+			changed = true;
+
+		ImGui::EndTable();
+	}
+
+	if (changed && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
+		ApplyChanges();
+	}
+}
+
+void WeatherWidget::DrawProperties(std::string category, std::map<std::string, int> properties)
+{
+	// Check if any property matches search (only check if search is active)
+	bool hasMatchingProperty = false;
+	if (searchBuffer[0] != '\0') {
+		hasMatchingProperty = MatchesSearch(category);
+		if (!hasMatchingProperty) {
+			for (auto& p : properties) {
+				if (MatchesSearch(p.first)) {
+					hasMatchingProperty = true;
+					break;
+				}
+			}
+		}
+		// Skip this entire category if nothing matches
+		if (!hasMatchingProperty) {
+			return;
 		}
 	}
 
-	void WeatherWidget::ApplyChanges()
-	{
-		SetWeatherValues();
-	}
+	ImGui::TextColored(ImVec4(0.7f, 0.9f, 1.0f, 1.0f), "%s", category.c_str());
 
-	void WeatherWidget::RevertChanges()
-	{
-		auto* weatherManager = WeatherManager::GetSingleton();
+	bool changed = false;
+	auto* editorWindow = EditorWindow::GetSingleton();
+	bool hasParent = editorWindow->settings.enableInheritFromParent && HasParent();
 
-		// If this weather is currently active, reset enabled feature overrides to user defaults
-		if (weather == weatherManager->GetCurrentWeathers().currentWeather) {
-			auto* globalRegistry = WeatherVariables::GlobalWeatherRegistry::GetSingleton();
-
-			for (const auto& [featureName, featureSettings] : settings.featureSettings) {
-				if (!featureSettings.value("__enabled", false) || !globalRegistry->HasWeatherSupport(featureName)) {
-					continue;
-				}
-
-				globalRegistry->EndFeatureTransition(featureName);
-
-				if (auto* featureRegistry = globalRegistry->GetFeatureRegistry(featureName)) {
-					for (const auto& var : featureRegistry->GetVariables()) {
-						var->SetToUserSettings();
-					}
-				}
-			}
+	for (auto& p : properties) {
+		// Filter individual properties based on search
+		if (searchBuffer[0] != '\0' && !MatchesSearch(p.first)) {
+			continue;
 		}
 
-		weatherManager->ClearAllFeatureSettingsForWeather(weather);
-		settings = vanillaSettings;
+		// Apply highlight effect if this setting should be highlighted
+		if (ShouldHighlight(p.first)) {
+			float elapsed = static_cast<float>(ImGui::GetTime()) - highlightStartTime;
+			float alpha = 0.3f * (1.0f - std::abs(elapsed - 0.5f) * 2.0f);
+			ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(0.3f, 0.6f, 1.0f, alpha));
+			ImGui::PushStyleColor(ImGuiCol_FrameBgHovered, ImVec4(0.4f, 0.7f, 1.0f, alpha));
+		}
+
+		// Inherit checkbox
+		if (hasParent) {
+			bool& inheritFlag = settings.inheritFlags[p.first];
+			if (ImGui::Checkbox(("##inherit_" + p.first).c_str(), &inheritFlag)) {
+				if (inheritFlag) {
+					InheritFromParent(p.first);
+					changed = true;
+				}
+			}
+			if (ImGui::IsItemHovered()) {
+				ImGui::SetTooltip(inheritFlag ? "Inheriting from parent" : "Inherit from parent");
+			}
+			ImGui::SameLine();
+		}
+
+		switch (p.second) {
+		case 0:
+			if (WeatherUtils::DrawSliderInt8(p.first, settings.weatherProperties[p.first]))
+				changed = true;
+			break;
+		case 1:
+			if (WeatherUtils::DrawColorEdit(p.first, settings.weatherColors[p.first]))
+				changed = true;
+			break;
+		case 2:
+			if (WeatherUtils::DrawSliderUint8(p.first, settings.weatherProperties[p.first]))
+				changed = true;
+			break;
+		case 3:
+			if (WeatherUtils::DrawSliderFloat(p.first, settings.fogProperties[p.first]))
+				changed = true;
+			break;
+		default:
+			break;
+		}
+
+		if (ShouldHighlight(p.first)) {
+			ImGui::PopStyleColor(2);
+		}
+	}
+
+	if (changed && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
 		ApplyChanges();
 	}
 
-	void WeatherWidget::Delete()
-	{
-		// Clear cache and local settings before base Delete() to prevent reloading stale data
-		auto* weatherManager = WeatherManager::GetSingleton();
-		weatherManager->ClearAllFeatureSettingsForWeather(weather);
-		settings.featureSettings.clear();
+	ImGui::Spacing();
+	ImGui::Separator();
+	ImGui::Spacing();
+}
 
-		Widget::Delete();
+void WeatherWidget::InheritFromParent(const std::string& property)
+{
+	if (!HasParent())
+		return;
+
+	WeatherWidget* parentWidget = GetParent();
+	if (!parentWidget)
+		return;
+
+	if (settings.weatherProperties.find(property) != settings.weatherProperties.end()) {
+		settings.weatherProperties[property] = parentWidget->settings.weatherProperties[property];
+	} else if (settings.weatherColors.find(property) != settings.weatherColors.end()) {
+		settings.weatherColors[property] = parentWidget->settings.weatherColors[property];
+	} else if (settings.fogProperties.find(property) != settings.fogProperties.end()) {
+		settings.fogProperties[property] = parentWidget->settings.fogProperties[property];
+	}
+}
+
+void WeatherWidget::InheritAllFromParent()
+{
+	if (!HasParent())
+		return;
+
+	WeatherWidget* parentWidget = GetParent();
+	if (!parentWidget)
+		return;
+
+	// Copy all weather properties
+	for (const auto& [key, value] : parentWidget->settings.weatherProperties) {
+		settings.weatherProperties[key] = value;
 	}
 
-	bool WeatherWidget::Settings::operator==(const Settings& o) const
-	{
-		return parent == o.parent &&
-		       inheritFlags == o.inheritFlags &&
-		       weatherProperties == o.weatherProperties &&
-		       weatherColors == o.weatherColors &&
-		       fogProperties == o.fogProperties &&
-		       std::equal(std::begin(atmosphereColors), std::end(atmosphereColors), std::begin(o.atmosphereColors)) &&
-		       std::equal(std::begin(dalc), std::end(dalc), std::begin(o.dalc)) &&
-		       std::equal(std::begin(clouds), std::end(clouds), std::begin(o.clouds)) &&
-		       std::equal(std::begin(imageSpaces), std::end(imageSpaces), std::begin(o.imageSpaces)) &&
-		       featureSettings == o.featureSettings;
+	// Copy all weather colors
+	for (const auto& [key, value] : parentWidget->settings.weatherColors) {
+		settings.weatherColors[key] = value;
 	}
 
-	bool WeatherWidget::HasUnsavedChanges() const
-	{
-		return !(settings == originalSettings);
+	// Copy all fog properties
+	for (const auto& [key, value] : parentWidget->settings.fogProperties) {
+		settings.fogProperties[key] = value;
 	}
 
-	void WeatherWidget::DrawFeatureSettings()
-	{
-		ImGui::TextWrapped(
-			"Configure feature-specific settings that will be applied when this weather is active. "
-			"These override the feature's global settings for this weather only.");
-		ImGui::Spacing();
+	// Copy atmosphere colors
+	for (int i = 0; i < ColorTypes::kTotal; i++) {
+		settings.atmosphereColors[i] = parentWidget->settings.atmosphereColors[i];
+	}
 
+	// Copy DALC settings
+	for (int i = 0; i < ColorTimes::kTotal; i++) {
+		settings.dalc[i] = parentWidget->settings.dalc[i];
+	}
+
+	// Copy cloud settings
+	for (int i = 0; i < TESWeather::kTotalLayers; i++) {
+		settings.clouds[i] = parentWidget->settings.clouds[i];
+	}
+
+	// Set all inherit flags to true
+	settings.inheritFlags["DALC_Specular"] = true;
+	settings.inheritFlags["DALC_Fresnel"] = true;
+	settings.inheritFlags["DALC_DirXMax"] = true;
+	settings.inheritFlags["DALC_DirXMin"] = true;
+	settings.inheritFlags["DALC_DirYMax"] = true;
+	settings.inheritFlags["DALC_DirYMin"] = true;
+	settings.inheritFlags["DALC_DirZMax"] = true;
+	settings.inheritFlags["DALC_DirZMin"] = true;
+
+	settings.inheritFlags["Fog_Near"] = true;
+	settings.inheritFlags["Fog_Far"] = true;
+	settings.inheritFlags["Fog_Power"] = true;
+	settings.inheritFlags["Fog_Max"] = true;
+
+	// Atmosphere colors
+	static const int displayOrder[] = { 0, 7, 8, 1, 12, 3, 4, 5, 6, 9, 10, 11, 13, 14, 15, 16, 2 };
+	for (int idx = 0; idx < ColorTypes::kTotal; idx++) {
+		int i = displayOrder[idx];
+		std::string colorTypeLabel = ColorTypeLabel(i);
+		settings.inheritFlags["Atmosphere_" + colorTypeLabel] = true;
+	}
+
+	// Cloud settings
+	for (int i = 0; i < TESWeather::kTotalLayers; i++) {
+		settings.inheritFlags[std::format("Cloud{}_Color", i)] = true;
+		settings.inheritFlags[std::format("Cloud{}_Alpha", i)] = true;
+	}
+
+	// Apply the changes
+	if (EditorWindow::GetSingleton()->settings.autoApplyChanges) {
+		ApplyChanges();
+	}
+
+	EditorWindow::GetSingleton()->ShowNotification(
+		std::format("Inherited all settings from {}", parentWidget->GetEditorID()),
+		ImVec4(0.0f, 1.0f, 0.5f, 1.0f),
+		3.0f);
+}
+
+void WeatherWidget::SaveFeatureSettings()
+{
+	auto* weatherManager = WeatherManager::GetSingleton();
+
+	// Collect all feature names from both current and original settings to detect deletions
+	std::set<std::string> allFeatureNames;
+	for (const auto& [featureName, _] : settings.featureSettings) {
+		allFeatureNames.insert(featureName);
+	}
+	for (const auto& [featureName, _] : originalSettings.featureSettings) {
+		allFeatureNames.insert(featureName);
+	}
+
+	// Save current settings or clear deleted features
+	for (const auto& featureName : allFeatureNames) {
+		auto it = settings.featureSettings.find(featureName);
+		weatherManager->SaveSettingsToWeather(
+			weather,
+			featureName,
+			it != settings.featureSettings.end() ? it->second : json::object());
+	}
+}
+
+void WeatherWidget::LoadFeatureSettings()
+{
+	auto* weatherManager = WeatherManager::GetSingleton();
+	auto* globalRegistry = WeatherVariables::GlobalWeatherRegistry::GetSingleton();
+
+	// First, validate that all feature settings in the JSON exist as loaded features.
+	// Prevents loading a .json that references features that aren't installed. (Will load only settings for installed features.)
+	// Should make it very obvious to users when they have not followed the correct installation instructions.
+	if (js.contains("featureSettings") && js["featureSettings"].is_object()) {
+		std::vector<std::string> missingFeatures;
+
+		for (const auto& [featureName, featureJson] : js["featureSettings"].items()) {
+			if (featureJson.empty()) {
+				continue;
+			}
+
+			// Check if this feature exists and is loaded
+			bool featureExists = false;
+			for (auto* feature : Feature::GetFeatureList()) {
+				if (feature && feature->loaded && feature->GetShortName() == featureName) {
+					featureExists = true;
+					break;
+				}
+			}
+
+			if (!featureExists) {
+				missingFeatures.push_back(featureName);
+			}
+		}
+
+		// If we found missing features, warn the user
+		if (!missingFeatures.empty()) {
+			std::string missingList;
+			for (size_t i = 0; i < missingFeatures.size(); ++i) {
+				if (i > 0)
+					missingList += ", ";
+				missingList += missingFeatures[i];
+			}
+
+			// Show notification
+			EditorWindow::GetSingleton()->ShowNotification(
+				std::format("Warning: {} references missing feature(s): {}", GetEditorID(), missingList),
+				ImVec4(1.0f, 0.6f, 0.0f, 1.0f),
+				5.0f);
+
+			// Add to Feature Issues system for each missing feature
+			for (const auto& featureName : missingFeatures) {
+				FeatureIssues::FeatureFileInfo fileInfo;
+				fileInfo.featureName = featureName;
+
+				FeatureIssues::AddFeatureIssue(
+					featureName,
+					"",
+					std::format("Weather '{}' contains settings for this feature, but the feature is not loaded. "
+								"The weather-specific parameters will be ignored until the feature is installed and loaded.",
+						GetEditorID()),
+					FeatureIssues::FeatureIssueInfo::IssueType::UNKNOWN,
+					fileInfo,
+					"");
+			}
+
+			logger::warn("{}: JSON contains feature settings for features that are not loaded: {}", GetEditorID(), missingList);
+		}
+	}
+
+	// Now load settings for features that ARE loaded
+	for (auto* feature : Feature::GetFeatureList()) {
+		if (!feature || !feature->loaded) {
+			continue;
+		}
+
+		std::string featureName = feature->GetShortName();
+
+		// Check if feature has registered weather variables
+		if (!globalRegistry->HasWeatherSupport(featureName)) {
+			continue;
+		}
+
+		json featureJson;
+		if (weatherManager->LoadSettingsFromWeather(weather, featureName, featureJson)) {
+			settings.featureSettings[featureName] = featureJson;
+		}
+	}
+}
+
+void WeatherWidget::ApplyChanges()
+{
+	SetWeatherValues();
+}
+
+void WeatherWidget::RevertChanges()
+{
+	auto* weatherManager = WeatherManager::GetSingleton();
+
+	// If this weather is currently active, reset enabled feature overrides to user defaults
+	if (weather == weatherManager->GetCurrentWeathers().currentWeather) {
 		auto* globalRegistry = WeatherVariables::GlobalWeatherRegistry::GetSingleton();
 
-		for (auto* feature : Feature::GetFeatureList()) {
-			if (!feature || !feature->loaded) {
+		for (const auto& [featureName, featureSettings] : settings.featureSettings) {
+			if (!featureSettings.value("__enabled", false) || !globalRegistry->HasWeatherSupport(featureName)) {
 				continue;
 			}
 
-			std::string featureName = feature->GetShortName();
-			auto* featureRegistry = globalRegistry->GetFeatureRegistry(featureName);
+			globalRegistry->EndFeatureTransition(featureName);
 
-			// Check if feature has registered weather variables
-			if (!featureRegistry) {
-				continue;
+			if (auto* featureRegistry = globalRegistry->GetFeatureRegistry(featureName)) {
+				for (const auto& var : featureRegistry->GetVariables()) {
+					var->SetToUserSettings();
+				}
+			}
+		}
+	}
+
+	weatherManager->ClearAllFeatureSettingsForWeather(weather);
+	settings = vanillaSettings;
+	ApplyChanges();
+}
+
+void WeatherWidget::Delete()
+{
+	// Clear cache and local settings before base Delete() to prevent reloading stale data
+	auto* weatherManager = WeatherManager::GetSingleton();
+	weatherManager->ClearAllFeatureSettingsForWeather(weather);
+	settings.featureSettings.clear();
+
+	Widget::Delete();
+}
+
+bool WeatherWidget::Settings::operator==(const Settings& o) const
+{
+	return parent == o.parent &&
+	       inheritFlags == o.inheritFlags &&
+	       weatherProperties == o.weatherProperties &&
+	       weatherColors == o.weatherColors &&
+	       fogProperties == o.fogProperties &&
+	       std::equal(std::begin(atmosphereColors), std::end(atmosphereColors), std::begin(o.atmosphereColors)) &&
+	       std::equal(std::begin(dalc), std::end(dalc), std::begin(o.dalc)) &&
+	       std::equal(std::begin(clouds), std::end(clouds), std::begin(o.clouds)) &&
+	       std::equal(std::begin(imageSpaces), std::end(imageSpaces), std::begin(o.imageSpaces)) &&
+	       featureSettings == o.featureSettings;
+}
+
+bool WeatherWidget::HasUnsavedChanges() const
+{
+	return !(settings == originalSettings);
+}
+
+void WeatherWidget::DrawFeatureSettings()
+{
+	ImGui::TextWrapped(
+		"Configure feature-specific settings that will be applied when this weather is active. "
+		"These override the feature's global settings for this weather only.");
+	ImGui::Spacing();
+
+	auto* globalRegistry = WeatherVariables::GlobalWeatherRegistry::GetSingleton();
+
+	for (auto* feature : Feature::GetFeatureList()) {
+		if (!feature || !feature->loaded) {
+			continue;
+		}
+
+		std::string featureName = feature->GetShortName();
+		auto* featureRegistry = globalRegistry->GetFeatureRegistry(featureName);
+
+		// Check if feature has registered weather variables
+		if (!featureRegistry) {
+			continue;
+		}
+
+		std::string displayName = feature->GetName();
+		auto featureIt = settings.featureSettings.find(featureName);
+		const json* featureJsonView = (featureIt != settings.featureSettings.end()) ? &featureIt->second : nullptr;
+		auto getFeatureJson = [&]() -> json& {
+			return settings.featureSettings.try_emplace(featureName, json::object()).first->second;
+		};
+
+		// Handle pending navigation - auto-expand this feature if it matches
+		bool shouldAutoExpand = (pendingFeatureNavigation == featureName);
+		if (shouldAutoExpand) {
+			ImGui::SetNextItemOpen(true);
+		}
+
+		if (ImGui::TreeNodeEx(displayName.c_str(), ImGuiTreeNodeFlags_SpanAvailWidth)) {
+			// Check if weather-specific overrides are enabled (using special key)
+			bool overridesEnabled = featureJsonView ? featureJsonView->value("__enabled", false) : false;
+
+			// Weather-specific override toggle
+			ImGui::PushStyleColor(ImGuiCol_Button, overridesEnabled ? ImVec4(0.2f, 0.7f, 0.2f, 1.0f) : ImVec4(0.5f, 0.5f, 0.5f, 1.0f));
+			ImGui::PushStyleColor(ImGuiCol_ButtonHovered, overridesEnabled ? ImVec4(0.3f, 0.8f, 0.3f, 1.0f) : ImVec4(0.6f, 0.6f, 0.6f, 1.0f));
+			ImGui::PushStyleColor(ImGuiCol_ButtonActive, overridesEnabled ? ImVec4(0.1f, 0.6f, 0.1f, 1.0f) : ImVec4(0.4f, 0.4f, 0.4f, 1.0f));
+
+			bool toggleClicked = ImGui::Button(overridesEnabled ? "Using Weather-Specific Settings" : "Using Global Settings", ImVec2(-1, 0));
+
+			ImGui::PopStyleColor(3);
+
+			if (auto _tt = Util::HoverTooltipWrapper()) {
+				if (overridesEnabled) {
+					ImGui::Text("This weather has custom overrides for this feature.");
+					ImGui::Text("Click to disable overrides and use global settings instead.");
+					ImGui::Text("(Settings will be preserved but not applied)");
+				} else {
+					ImGui::Text("This weather uses global feature settings.");
+					ImGui::Text("Click to enable weather-specific overrides.");
+				}
 			}
 
-			std::string displayName = feature->GetName();
-			auto featureIt = settings.featureSettings.find(featureName);
-			const json* featureJsonView = (featureIt != settings.featureSettings.end()) ? &featureIt->second : nullptr;
-			auto getFeatureJson = [&]() -> json& {
-				return settings.featureSettings.try_emplace(featureName, json::object()).first->second;
-			};
-
-			// Handle pending navigation - auto-expand this feature if it matches
-			bool shouldAutoExpand = (pendingFeatureNavigation == featureName);
-			if (shouldAutoExpand) {
-				ImGui::SetNextItemOpen(true);
-			}
-
-			if (ImGui::TreeNodeEx(displayName.c_str(), ImGuiTreeNodeFlags_SpanAvailWidth)) {
-				// Check if weather-specific overrides are enabled (using special key)
-				bool overridesEnabled = featureJsonView ? featureJsonView->value("__enabled", false) : false;
-
-				// Weather-specific override toggle
-				ImGui::PushStyleColor(ImGuiCol_Button, overridesEnabled ? ImVec4(0.2f, 0.7f, 0.2f, 1.0f) : ImVec4(0.5f, 0.5f, 0.5f, 1.0f));
-				ImGui::PushStyleColor(ImGuiCol_ButtonHovered, overridesEnabled ? ImVec4(0.3f, 0.8f, 0.3f, 1.0f) : ImVec4(0.6f, 0.6f, 0.6f, 1.0f));
-				ImGui::PushStyleColor(ImGuiCol_ButtonActive, overridesEnabled ? ImVec4(0.1f, 0.6f, 0.1f, 1.0f) : ImVec4(0.4f, 0.4f, 0.4f, 1.0f));
-
-				bool toggleClicked = ImGui::Button(overridesEnabled ? "Using Weather-Specific Settings" : "Using Global Settings", ImVec2(-1, 0));
-
-				ImGui::PopStyleColor(3);
-
-				if (auto _tt = Util::HoverTooltipWrapper()) {
-					if (overridesEnabled) {
-						ImGui::Text("This weather has custom overrides for this feature.");
-						ImGui::Text("Click to disable overrides and use global settings instead.");
-						ImGui::Text("(Settings will be preserved but not applied)");
-					} else {
-						ImGui::Text("This weather uses global feature settings.");
-						ImGui::Text("Click to enable weather-specific overrides.");
+			if (toggleClicked) {
+				auto& featureJson = getFeatureJson();
+				if (overridesEnabled) {
+					// Disable overrides - mark as disabled but keep the settings
+					featureJson["__enabled"] = false;
+				} else {
+					// Enable overrides - mark as enabled
+					featureJson["__enabled"] = true;
+					// If no settings exist yet, copy current global values as starting point
+					bool hasActualSettings = false;
+					for (auto it = featureJson.begin(); it != featureJson.end(); ++it) {
+						if (it.key() != "__enabled") {
+							hasActualSettings = true;
+							break;
+						}
+					}
+					if (!hasActualSettings) {
+						const auto& variables = featureRegistry->GetVariables();
+						for (const auto& var : variables) {
+							json tempJson;
+							var->SaveToJson(tempJson);
+							std::string varName = var->GetName();
+							if (tempJson.contains(varName)) {
+								featureJson[varName] = tempJson[varName];
+							}
+						}
 					}
 				}
+				EditorWindow::GetSingleton()->PushUndoState(this);
+				if (EditorWindow::GetSingleton()->settings.autoApplyChanges) {
+					ApplyChanges();
+				}
+			}
 
-				if (toggleClicked) {
-					auto& featureJson = getFeatureJson();
-					if (overridesEnabled) {
-						// Disable overrides - mark as disabled but keep the settings
-						featureJson["__enabled"] = false;
+			ImGui::Spacing();
+			ImGui::Separator();
+			ImGui::Spacing();
+
+			// Only show controls if weather-specific overrides are enabled
+			if (overridesEnabled) {
+				auto& featureJson = getFeatureJson();
+				// Draw UI for each registered variable
+				const auto& variables = featureRegistry->GetVariables();
+				bool modified = false;
+
+				for (const auto& var : variables) {
+					std::string varName = var->GetName();
+					std::string varDisplayName = var->GetDisplayName();
+					std::string tooltip = var->GetTooltip();
+
+					ImGui::PushID(varName.c_str());
+
+					// Check if this variable has a weather-specific value
+					bool hasOverride = featureJson.contains(varName);
+
+					json currentValue;
+					if (hasOverride) {
+						currentValue = featureJson.at(varName);
 					} else {
-						// Enable overrides - mark as enabled
-						featureJson["__enabled"] = true;
-						// If no settings exist yet, copy current global values as starting point
-						bool hasActualSettings = false;
-						for (auto it = featureJson.begin(); it != featureJson.end(); ++it) {
-							if (it.key() != "__enabled") {
-								hasActualSettings = true;
-								break;
-							}
+						json tempJson;
+						var->SaveToJson(tempJson);
+						auto it = tempJson.find(varName);
+						if (it == tempJson.end()) {
+							ImGui::PopID();
+							continue;
 						}
-						if (!hasActualSettings) {
-							const auto& variables = featureRegistry->GetVariables();
-							for (const auto& var : variables) {
-								json tempJson;
-								var->SaveToJson(tempJson);
-								std::string varName = var->GetName();
-								if (tempJson.contains(varName)) {
-									featureJson[varName] = tempJson[varName];
-								}
+						currentValue = *it;
+					}
+
+					// Try to detect variable type and render appropriate control
+					// Check if it's a bool variable first
+					if (auto* boolVar = dynamic_cast<WeatherVariables::WeatherVariable<bool>*>(var.get())) {
+						bool value = currentValue.get<bool>();
+
+						if (ImGui::Checkbox(varDisplayName.c_str(), &value)) {
+							featureJson[varName] = value;
+							modified = true;
+						}
+
+						if (auto _tt = Util::HoverTooltipWrapper()) {
+							ImGui::Text("%s", tooltip.c_str());
+						}
+
+						// Right-click context menu to reset individual values
+						if (ImGui::BeginPopupContextItem()) {
+							if (ImGui::MenuItem("Reset to Global")) {
+								featureJson.erase(varName);
+								modified = true;
 							}
+							ImGui::EndPopup();
+						}
+
+					} else if (auto* floatVar = dynamic_cast<WeatherVariables::FloatVariable*>(var.get())) {
+						float value = currentValue.get<float>();
+						float minVal = floatVar->GetMin();
+						float maxVal = floatVar->GetMax();
+
+						if (ImGui::SliderFloat(varDisplayName.c_str(), &value, minVal, maxVal, "%.3f")) {
+							featureJson[varName] = value;
+							modified = true;
+						}
+
+						if (auto _tt = Util::HoverTooltipWrapper()) {
+							ImGui::Text("%s", tooltip.c_str());
+						}
+
+						// Right-click context menu to reset individual values
+						if (ImGui::BeginPopupContextItem()) {
+							if (ImGui::MenuItem("Reset to Global")) {
+								featureJson.erase(varName);
+								modified = true;
+							}
+							ImGui::EndPopup();
+						}
+
+					} else if (auto* float3Var = dynamic_cast<WeatherVariables::Float3Variable*>(var.get())) {
+						// Handle float3 (color) variables
+						float3 value = currentValue.get<float3>();
+						float colorArray[3] = { value.x, value.y, value.z };
+
+						if (ImGui::ColorEdit3(varDisplayName.c_str(), colorArray)) {
+							featureJson[varName] = json{ colorArray[0], colorArray[1], colorArray[2] };
+							modified = true;
+						}
+
+						if (auto _tt = Util::HoverTooltipWrapper()) {
+							ImGui::Text("%s", tooltip.c_str());
+						}
+
+						if (ImGui::BeginPopupContextItem()) {
+							if (ImGui::MenuItem("Reset to Global")) {
+								featureJson.erase(varName);
+								modified = true;
+							}
+							ImGui::EndPopup();
+						}
+
+					} else if (auto* float4Var = dynamic_cast<WeatherVariables::Float4Variable*>(var.get())) {
+						// Handle float4 (color with alpha) variables
+						float4 value = currentValue.get<float4>();
+						float colorArray[4] = { value.x, value.y, value.z, value.w };
+
+						if (ImGui::ColorEdit4(varDisplayName.c_str(), colorArray)) {
+							featureJson[varName] = json{ colorArray[0], colorArray[1], colorArray[2], colorArray[3] };
+							modified = true;
+						}
+
+						if (auto _tt = Util::HoverTooltipWrapper()) {
+							ImGui::Text("%s", tooltip.c_str());
+						}
+
+						if (ImGui::BeginPopupContextItem()) {
+							if (ImGui::MenuItem("Reset to Global")) {
+								featureJson.erase(varName);
+								modified = true;
+							}
+							ImGui::EndPopup();
+						}
+
+					} else {
+						// Generic handling for other types
+						ImGui::TextDisabled("%s: %s", varDisplayName.c_str(), currentValue.dump().c_str());
+						if (auto _tt = Util::HoverTooltipWrapper()) {
+							ImGui::TextColored(ImVec4(1.0f, 0.5f, 0.0f, 1.0f), "Unsupported Variable Type");
+							ImGui::Text("%s", tooltip.c_str());
+							ImGui::Separator();
+							ImGui::TextWrapped("This variable type doesn't have a custom UI implementation yet. The raw JSON value is shown above.");
 						}
 					}
+
+					ImGui::PopID();
+				}
+
+				if (modified) {
 					EditorWindow::GetSingleton()->PushUndoState(this);
 					if (EditorWindow::GetSingleton()->settings.autoApplyChanges) {
 						ApplyChanges();
 					}
 				}
 
-				ImGui::Spacing();
-				ImGui::Separator();
-				ImGui::Spacing();
-
-				// Only show controls if weather-specific overrides are enabled
-				if (overridesEnabled) {
-					auto& featureJson = getFeatureJson();
-					// Draw UI for each registered variable
-					const auto& variables = featureRegistry->GetVariables();
-					bool modified = false;
-
-					for (const auto& var : variables) {
-						std::string varName = var->GetName();
-						std::string varDisplayName = var->GetDisplayName();
-						std::string tooltip = var->GetTooltip();
-
-						ImGui::PushID(varName.c_str());
-
-						// Check if this variable has a weather-specific value
-						bool hasOverride = featureJson.contains(varName);
-
-						json currentValue;
-						if (hasOverride) {
-							currentValue = featureJson.at(varName);
-						} else {
-							json tempJson;
-							var->SaveToJson(tempJson);
-							auto it = tempJson.find(varName);
-							if (it == tempJson.end()) {
-								ImGui::PopID();
-								continue;
-							}
-							currentValue = *it;
-						}
-
-						// Try to detect variable type and render appropriate control
-						// Check if it's a bool variable first
-						if (auto* boolVar = dynamic_cast<WeatherVariables::WeatherVariable<bool>*>(var.get())) {
-							bool value = currentValue.get<bool>();
-
-							if (ImGui::Checkbox(varDisplayName.c_str(), &value)) {
-								featureJson[varName] = value;
-								modified = true;
-							}
-
-							if (auto _tt = Util::HoverTooltipWrapper()) {
-								ImGui::Text("%s", tooltip.c_str());
-							}
-
-							// Right-click context menu to reset individual values
-							if (ImGui::BeginPopupContextItem()) {
-								if (ImGui::MenuItem("Reset to Global")) {
-									featureJson.erase(varName);
-									modified = true;
-								}
-								ImGui::EndPopup();
-							}
-
-						} else if (auto* floatVar = dynamic_cast<WeatherVariables::FloatVariable*>(var.get())) {
-							float value = currentValue.get<float>();
-							float minVal = floatVar->GetMin();
-							float maxVal = floatVar->GetMax();
-
-							if (ImGui::SliderFloat(varDisplayName.c_str(), &value, minVal, maxVal, "%.3f")) {
-								featureJson[varName] = value;
-								modified = true;
-							}
-
-							if (auto _tt = Util::HoverTooltipWrapper()) {
-								ImGui::Text("%s", tooltip.c_str());
-							}
-
-							// Right-click context menu to reset individual values
-							if (ImGui::BeginPopupContextItem()) {
-								if (ImGui::MenuItem("Reset to Global")) {
-									featureJson.erase(varName);
-									modified = true;
-								}
-								ImGui::EndPopup();
-							}
-
-						} else if (auto* float3Var = dynamic_cast<WeatherVariables::Float3Variable*>(var.get())) {
-							// Handle float3 (color) variables
-							float3 value = currentValue.get<float3>();
-							float colorArray[3] = { value.x, value.y, value.z };
-
-							if (ImGui::ColorEdit3(varDisplayName.c_str(), colorArray)) {
-								featureJson[varName] = json{ colorArray[0], colorArray[1], colorArray[2] };
-								modified = true;
-							}
-
-							if (auto _tt = Util::HoverTooltipWrapper()) {
-								ImGui::Text("%s", tooltip.c_str());
-							}
-
-							if (ImGui::BeginPopupContextItem()) {
-								if (ImGui::MenuItem("Reset to Global")) {
-									featureJson.erase(varName);
-									modified = true;
-								}
-								ImGui::EndPopup();
-							}
-
-						} else if (auto* float4Var = dynamic_cast<WeatherVariables::Float4Variable*>(var.get())) {
-							// Handle float4 (color with alpha) variables
-							float4 value = currentValue.get<float4>();
-							float colorArray[4] = { value.x, value.y, value.z, value.w };
-
-							if (ImGui::ColorEdit4(varDisplayName.c_str(), colorArray)) {
-								featureJson[varName] = json{ colorArray[0], colorArray[1], colorArray[2], colorArray[3] };
-								modified = true;
-							}
-
-							if (auto _tt = Util::HoverTooltipWrapper()) {
-								ImGui::Text("%s", tooltip.c_str());
-							}
-
-							if (ImGui::BeginPopupContextItem()) {
-								if (ImGui::MenuItem("Reset to Global")) {
-									featureJson.erase(varName);
-									modified = true;
-								}
-								ImGui::EndPopup();
-							}
-
-						} else {
-							// Generic handling for other types
-							ImGui::TextDisabled("%s: %s", varDisplayName.c_str(), currentValue.dump().c_str());
-							if (auto _tt = Util::HoverTooltipWrapper()) {
-								ImGui::TextColored(ImVec4(1.0f, 0.5f, 0.0f, 1.0f), "Unsupported Variable Type");
-								ImGui::Text("%s", tooltip.c_str());
-								ImGui::Separator();
-								ImGui::TextWrapped("This variable type doesn't have a custom UI implementation yet. The raw JSON value is shown above.");
-							}
-						}
-
-						ImGui::PopID();
-					}
-
-					if (modified) {
-						EditorWindow::GetSingleton()->PushUndoState(this);
-						if (EditorWindow::GetSingleton()->settings.autoApplyChanges) {
-							ApplyChanges();
-						}
-					}
-
-				} else {
-					ImGui::TextColored({ 0.7f, 0.7f, 0.7f, 1.0f }, "Enable weather-specific overrides above to customize settings for this weather.");
-				}
-
-				ImGui::TreePop();
+			} else {
+				ImGui::TextColored({ 0.7f, 0.7f, 0.7f, 1.0f }, "Enable weather-specific overrides above to customize settings for this weather.");
 			}
-		}
 
-		// Clear navigation state after processing
-		if (!pendingFeatureNavigation.empty()) {
-			pendingFeatureNavigation.clear();
-			pendingSettingHighlight.clear();
+			ImGui::TreePop();
 		}
 	}
 
-	void WeatherWidget::NavigateToFeatureSetting(const std::string& featureName, const std::string& settingName)
-	{
-		// Store the navigation request
-		pendingFeatureNavigation = featureName;
-		pendingSettingHighlight = settingName;
-
-		// Switch to Features tab
-		activeTabOverride = "Features";
+	// Clear navigation state after processing
+	if (!pendingFeatureNavigation.empty()) {
+		pendingFeatureNavigation.clear();
+		pendingSettingHighlight.clear();
 	}
+}
 
-	void WeatherWidget::UpdateSearchResults()
-	{
-		searchResults.clear();
+void WeatherWidget::NavigateToFeatureSetting(const std::string& featureName, const std::string& settingName)
+{
+	// Store the navigation request
+	pendingFeatureNavigation = featureName;
+	pendingSettingHighlight = settingName;
 
-		if (searchBuffer[0] == '\0')
-			return;
+	// Switch to Features tab
+	activeTabOverride = "Features";
+}
 
-		std::string searchTerm = searchBuffer;
+void WeatherWidget::UpdateSearchResults()
+{
+	searchResults.clear();
 
-		// Search in Basic tab properties
-		std::vector<std::pair<std::string, std::map<std::string, int>>> basicCategories = {
-			{ "Sun", { { "Sun Damage", 0 } } },
-			{ "Wind", { { "Wind Speed", 0 }, { "Wind Direction", 0 }, { "Wind Direction Range", 0 } } },
-			{ "Precipitation", { { "Precipitation Begin Fade In", 0 }, { "Precipitation End Fade Out", 0 } } },
-			{ "Lightning", { { "Thunder Lightning Begin Fade In", 0 }, { "Thunder Lightning End Fade Out", 0 },
-							   { "Thunder Lightning Frequency", 0 }, { "Lightning Color", 1 } } },
-			{ "Visual Effects", { { "Visual Effect Begin", 0 }, { "Visual Effect End", 0 } } },
-			{ "Weather Transition", { { "Trans Delta", 0 } } }
-		};
+	if (searchBuffer[0] == '\0')
+		return;
 
-		for (const auto& [category, properties] : basicCategories) {
-			for (const auto& [propName, type] : properties) {
-				if (ContainsStringIgnoreCase(propName, searchTerm)) {
-					searchResults.push_back({ propName, "Basic", propName });
-				}
-			}
-		}
+	std::string searchTerm = searchBuffer;
 
-		// Search in Fog tab
-		std::vector<std::string> fogProperties = {
-			"Day Near", "Day Far", "Day Power", "Day Max",
-			"Night Near", "Night Far", "Night Power", "Night Max"
-		};
-		for (const auto& propName : fogProperties) {
+	// Search in Basic tab properties
+	std::vector<std::pair<std::string, std::map<std::string, int>>> basicCategories = {
+		{ "Sun", { { "Sun Damage", 0 } } },
+		{ "Wind", { { "Wind Speed", 0 }, { "Wind Direction", 0 }, { "Wind Direction Range", 0 } } },
+		{ "Precipitation", { { "Precipitation Begin Fade In", 0 }, { "Precipitation End Fade Out", 0 } } },
+		{ "Lightning", { { "Thunder Lightning Begin Fade In", 0 }, { "Thunder Lightning End Fade Out", 0 },
+						   { "Thunder Lightning Frequency", 0 }, { "Lightning Color", 1 } } },
+		{ "Visual Effects", { { "Visual Effect Begin", 0 }, { "Visual Effect End", 0 } } },
+		{ "Weather Transition", { { "Trans Delta", 0 } } }
+	};
+
+	for (const auto& [category, properties] : basicCategories) {
+		for (const auto& [propName, type] : properties) {
 			if (ContainsStringIgnoreCase(propName, searchTerm)) {
-				searchResults.push_back({ propName, "Fog", propName });
-			}
-		}
-
-		// Search in DALC settings
-		std::vector<std::string> dalcSettings = {
-			"Fresnel Power", "Specular",
-			"Directional X Max", "Directional X Min",
-			"Directional Y Max", "Directional Y Min",
-			"Directional Z Max", "Directional Z Min"
-		};
-		for (const auto& setting : dalcSettings) {
-			if (ContainsStringIgnoreCase(setting, searchTerm)) {
-				searchResults.push_back({ setting, "Lighting (DALC)", setting });
-			}
-		}
-
-		// Search in Atmosphere Colors
-		for (int i = 0; i < ColorTypes::kTotal; i++) {
-			std::string colorType = ColorTypeLabel(i);
-			if (ContainsStringIgnoreCase(colorType, searchTerm)) {
-				searchResults.push_back({ colorType, "Atmosphere Colors", colorType });
-			}
-		}
-
-		// Search in Cloud settings
-		for (int i = 0; i < TESWeather::kTotalLayers; i++) {
-			std::string layer = std::format("Layer {}", i);
-			if (ContainsStringIgnoreCase(layer, searchTerm) ||
-				ContainsStringIgnoreCase("Cloud", searchTerm)) {
-				searchResults.push_back({ std::format("Cloud {}", layer), "Clouds", layer });
+				searchResults.push_back({ propName, "Basic", propName });
 			}
 		}
 	}
 
-	void WeatherWidget::NavigateToSetting(const SearchResult& result)
-	{
-		activeTabOverride = result.tabName;
-		highlightedSetting = result.settingId;
-		highlightStartTime = static_cast<float>(ImGui::GetTime());
+	// Search in Fog tab
+	std::vector<std::string> fogProperties = {
+		"Day Near", "Day Far", "Day Power", "Day Max",
+		"Night Near", "Night Far", "Night Power", "Night Max"
+	};
+	for (const auto& propName : fogProperties) {
+		if (ContainsStringIgnoreCase(propName, searchTerm)) {
+			searchResults.push_back({ propName, "Fog", propName });
+		}
 	}
 
-	bool WeatherWidget::ShouldHighlight(const std::string& settingId) const
-	{
-		if (highlightedSetting != settingId)
-			return false;
-
-		float elapsed = static_cast<float>(ImGui::GetTime()) - highlightStartTime;
-		return elapsed < 2.0f;
+	// Search in DALC settings
+	std::vector<std::string> dalcSettings = {
+		"Fresnel Power", "Specular",
+		"Directional X Max", "Directional X Min",
+		"Directional Y Max", "Directional Y Min",
+		"Directional Z Max", "Directional Z Min"
+	};
+	for (const auto& setting : dalcSettings) {
+		if (ContainsStringIgnoreCase(setting, searchTerm)) {
+			searchResults.push_back({ setting, "Lighting (DALC)", setting });
+		}
 	}
 
-	ID3D11ShaderResourceView* WeatherWidget::GetCloudTexture(int layerIndex)
-	{
-		if (cloudTextureCache.contains(layerIndex)) {
-			return cloudTextureCache[layerIndex];
+	// Search in Atmosphere Colors
+	for (int i = 0; i < ColorTypes::kTotal; i++) {
+		std::string colorType = ColorTypeLabel(i);
+		if (ContainsStringIgnoreCase(colorType, searchTerm)) {
+			searchResults.push_back({ colorType, "Atmosphere Colors", colorType });
 		}
+	}
 
-		const auto& texturePath = settings.clouds[layerIndex].texturePath;
-		if (texturePath.empty()) {
-			return nullptr;
+	// Search in Cloud settings
+	for (int i = 0; i < TESWeather::kTotalLayers; i++) {
+		std::string layer = std::format("Layer {}", i);
+		if (ContainsStringIgnoreCase(layer, searchTerm) ||
+			ContainsStringIgnoreCase("Cloud", searchTerm)) {
+			searchResults.push_back({ std::format("Cloud {}", layer), "Clouds", layer });
 		}
+	}
+}
 
-		// Build resource path for BSA loading: Textures\path (relative to Data folder)
-		// Note: Skyrim texture paths don't include .dds extension, so we add it
-		std::string resourcePath = std::string("Textures\\") + texturePath;
+void WeatherWidget::NavigateToSetting(const SearchResult& result)
+{
+	activeTabOverride = result.tabName;
+	highlightedSetting = result.settingId;
+	highlightStartTime = static_cast<float>(ImGui::GetTime());
+}
 
-		// Add .dds extension if not present
-		if (resourcePath.size() < 4 || resourcePath.substr(resourcePath.size() - 4) != ".dds") {
-			resourcePath += ".dds";
-		}
+bool WeatherWidget::ShouldHighlight(const std::string& settingId) const
+{
+	if (highlightedSetting != settingId)
+		return false;
 
-		ID3D11ShaderResourceView* srv = nullptr;
-		ImVec2 textureSize;
+	float elapsed = static_cast<float>(ImGui::GetTime()) - highlightStartTime;
+	return elapsed < 2.0f;
+}
 
-		if (Util::LoadDDSTextureFromFile(globals::d3d::device, resourcePath.c_str(), &srv, textureSize)) {
-			cloudTextureCache[layerIndex] = srv;
-			return srv;
-		}
+ID3D11ShaderResourceView* WeatherWidget::GetCloudTexture(int layerIndex)
+{
+	if (cloudTextureCache.contains(layerIndex)) {
+		return cloudTextureCache[layerIndex];
+	}
 
+	const auto& texturePath = settings.clouds[layerIndex].texturePath;
+	if (texturePath.empty()) {
 		return nullptr;
 	}
+
+	// Build resource path for BSA loading: Textures\path (relative to Data folder)
+	// Note: Skyrim texture paths don't include .dds extension, so we add it
+	std::string resourcePath = std::string("Textures\\") + texturePath;
+
+	// Add .dds extension if not present
+	if (resourcePath.size() < 4 || resourcePath.substr(resourcePath.size() - 4) != ".dds") {
+		resourcePath += ".dds";
+	}
+
+	ID3D11ShaderResourceView* srv = nullptr;
+	ImVec2 textureSize;
+
+	if (Util::LoadDDSTextureFromFile(globals::d3d::device, resourcePath.c_str(), &srv, textureSize)) {
+		cloudTextureCache[layerIndex] = srv;
+		return srv;
+	}
+
+	return nullptr;
+}

--- a/src/WeatherEditor/Weather/WeatherWidget.cpp
+++ b/src/WeatherEditor/Weather/WeatherWidget.cpp
@@ -170,9 +170,8 @@ void WeatherWidget::DrawWidget()
 			}
 		}
 	}
-}
 
-// Tab bar for organizing settings
+	// Tab bar for organizing settings
 if (ImGui::BeginTabBar("WeatherSettingsTabs", ImGuiTabBarFlags_None)) {
 	// Use activeTabOverride to auto-navigate to specific tab
 	ImGuiTabItemFlags basicFlags = (activeTabOverride == "Basic") ? ImGuiTabItemFlags_SetSelected : 0;

--- a/src/WeatherEditor/Weather/WeatherWidget.cpp
+++ b/src/WeatherEditor/Weather/WeatherWidget.cpp
@@ -63,291 +63,202 @@ void WeatherWidget::DrawWidget()
 	// Draw header with search and all buttons
 	DrawWidgetHeader("##WeatherSearch", false, true, true, weather);
 
-		// Update search results when search buffer changes
-		if (searchActive) {
-			UpdateSearchResults();
-		}
+	// Update search results when search buffer changes
+	if (searchActive) {
+		UpdateSearchResults();
+	}
 
-		// Show search results dropdown
-		if (searchBuffer[0] != '\0' && !searchResults.empty()) {
-			// Find the search input position for dropdown placement
-			ImGui::SetNextWindowPos(ImVec2(ImGui::GetCursorScreenPos().x, ImGui::GetCursorScreenPos().y));
-			ImGui::SetNextWindowSize(ImVec2(200.0f * 1.5f, 0));
-			ImGui::SetNextWindowFocus();
-			ImGui::PushStyleVar(ImGuiStyleVar_Alpha, 1.0f);
-			ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4(0.16f, 0.16f, 0.16f, 1.0f));
-			if (ImGui::Begin("##SearchDropdown", nullptr,
-					ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize |
-						ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoSavedSettings)) {
-				for (size_t i = 0; i < std::min(size_t(5), searchResults.size()); ++i) {
-					const auto& result = searchResults[i];
-					std::string label = std::format("{} ({})", result.displayName, result.tabName);
+	// Show search results dropdown
+	if (searchBuffer[0] != '\0' && !searchResults.empty()) {
+		// Find the search input position for dropdown placement
+		ImGui::SetNextWindowPos(ImVec2(ImGui::GetCursorScreenPos().x, ImGui::GetCursorScreenPos().y));
+		ImGui::SetNextWindowSize(ImVec2(200.0f * 1.5f, 0));
+		ImGui::SetNextWindowFocus();
+		ImGui::PushStyleVar(ImGuiStyleVar_Alpha, 1.0f);
+		ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4(0.16f, 0.16f, 0.16f, 1.0f));
+		if (ImGui::Begin("##SearchDropdown", nullptr,
+				ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoMove | ImGuiWindowFlags_NoResize |
+					ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoSavedSettings)) {
+			for (size_t i = 0; i < std::min(size_t(5), searchResults.size()); ++i) {
+				const auto& result = searchResults[i];
+				std::string label = std::format("{} ({})", result.displayName, result.tabName);
 
-					if (ImGui::Selectable(label.c_str(), false, ImGuiSelectableFlags_DontClosePopups)) {
-						NavigateToSetting(result);
-						searchBuffer[0] = '\0';
-						searchResults.clear();
-					}
-				}
-
-				if (searchResults.size() > 5) {
-					ImGui::Separator();
-					ImGui::TextDisabled("... %zu more results", searchResults.size() - 5);
-				}
-
-				// Close dropdown if clicking outside or pressing Escape
-				if (!ImGui::IsWindowFocused() || ImGui::IsKeyPressed(ImGuiKey_Escape)) {
+				if (ImGui::Selectable(label.c_str(), false, ImGuiSelectableFlags_DontClosePopups)) {
+					NavigateToSetting(result);
 					searchBuffer[0] = '\0';
 					searchResults.clear();
 				}
 			}
-			ImGui::End();
-			ImGui::PopStyleColor();
-			ImGui::PopStyleVar();
+
+			if (searchResults.size() > 5) {
+				ImGui::Separator();
+				ImGui::TextDisabled("... %zu more results", searchResults.size() - 5);
+			}
+
+			// Close dropdown if clicking outside or pressing Escape
+			if (!ImGui::IsWindowFocused() || ImGui::IsKeyPressed(ImGuiKey_Escape)) {
+				searchBuffer[0] = '\0';
+				searchResults.clear();
+			}
 		}
+		ImGui::End();
+		ImGui::PopStyleColor();
+		ImGui::PopStyleVar();
+	}
 
-		auto editorWindow = EditorWindow::GetSingleton();
-		auto& widgets = editorWindow->weatherWidgets;
+	auto editorWindow = EditorWindow::GetSingleton();
+	auto& widgets = editorWindow->weatherWidgets;
 
-		// Sets the parent widget if settings have been loaded.
-		if (settings.parent != "None") {
-			parent = GetParent();
-			if (parent == nullptr)
+	// Sets the parent widget if settings have been loaded.
+	if (settings.parent != "None") {
+		parent = GetParent();
+		if (parent == nullptr)
+			settings.parent = "None";
+	}
+
+	if (editorWindow->settings.enableInheritFromParent) {
+		if (ImGui::BeginCombo("Parent", settings.parent.c_str())) {
+			// Option for "None"
+			if (ImGui::Selectable("None", parent == nullptr)) {
+				parent = nullptr;
 				settings.parent = "None";
+			}
+
+			for (int i = 0; i < widgets.size(); i++) {
+				auto& widget = widgets[i];
+
+				// Skip self-selection
+				if (widget.get() == this)
+					continue;
+
+				// Option for each widget
+				if (ImGui::Selectable(widget->GetEditorID().c_str(), parent == widget.get())) {
+					parent = (WeatherWidget*)widget.get();
+					settings.parent = widget->GetEditorID();
+				}
+
+				// Set default focus to the current parent
+				if (parent == widget.get()) {
+					ImGui::SetItemDefaultFocus();
+				}
+			}
+			ImGui::EndCombo();
+		}
+		ImGui::SameLine();
+		ImGui::TextDisabled("(?)");
+		if (ImGui::IsItemHovered()) {
+			ImGui::BeginTooltip();
+			ImGui::TextUnformatted("Editor-only feature: Set a parent weather to copy settings from.");
+			ImGui::TextUnformatted("Use 'Inherit From Parent' checkboxes to copy specific values.");
+			ImGui::TextColored(ImVec4(1.0f, 0.7f, 0.0f, 1.0f), "Note: This is NOT the same as cell lighting template inheritance.");
+			ImGui::EndTooltip();
 		}
 
-		if (editorWindow->settings.enableInheritFromParent) {
-			if (ImGui::BeginCombo("Parent", settings.parent.c_str())) {
-				// Option for "None"
-				if (ImGui::Selectable("None", parent == nullptr)) {
-					parent = nullptr;
-					settings.parent = "None";
-				}
-
-				for (int i = 0; i < widgets.size(); i++) {
-					auto& widget = widgets[i];
-
-					// Skip self-selection
-					if (widget.get() == this)
-						continue;
-
-					// Option for each widget
-					if (ImGui::Selectable(widget->GetEditorID().c_str(), parent == widget.get())) {
-						parent = (WeatherWidget*)widget.get();
-						settings.parent = widget->GetEditorID();
-					}
-
-					// Set default focus to the current parent
-					if (parent == widget.get()) {
-						ImGui::SetItemDefaultFocus();
-					}
-				}
-				ImGui::EndCombo();
-			}
+		if (parent) {
 			ImGui::SameLine();
-			ImGui::TextDisabled("(?)");
+			if (Util::ButtonWithFlash("Inherit All")) {
+				InheritAllFromParent();
+			}
 			if (ImGui::IsItemHovered()) {
-				ImGui::BeginTooltip();
-				ImGui::TextUnformatted("Editor-only feature: Set a parent weather to copy settings from.");
-				ImGui::TextUnformatted("Use 'Inherit From Parent' checkboxes to copy specific values.");
-				ImGui::TextColored(ImVec4(1.0f, 0.7f, 0.0f, 1.0f), "Note: This is NOT the same as cell lighting template inheritance.");
-				ImGui::EndTooltip();
+				ImGui::SetTooltip("Copy all parameter values from parent weather");
 			}
 
-			if (parent) {
+			if (!parent->IsOpen()) {
 				ImGui::SameLine();
-				if (Util::ButtonWithFlash("Inherit All")) {
-					InheritAllFromParent();
-				}
-				if (ImGui::IsItemHovered()) {
-					ImGui::SetTooltip("Copy all parameter values from parent weather");
-				}
-
-				if (!parent->IsOpen()) {
-					ImGui::SameLine();
-					if (Util::ButtonWithFlash("Open"))
-						parent->SetOpen(true);
-				}
+				if (Util::ButtonWithFlash("Open"))
+					parent->SetOpen(true);
 			}
 		}
 	}
+}
 
-	// Tab bar for organizing settings
-	if (ImGui::BeginTabBar("WeatherSettingsTabs", ImGuiTabBarFlags_None)) {
-		// Use activeTabOverride to auto-navigate to specific tab
-		ImGuiTabItemFlags basicFlags = (activeTabOverride == "Basic") ? ImGuiTabItemFlags_SetSelected : 0;
-		ImGuiTabItemFlags dalcFlags = (activeTabOverride == "Lighting (DALC)") ? ImGuiTabItemFlags_SetSelected : 0;
-		ImGuiTabItemFlags atmosphereFlags = (activeTabOverride == "Atmosphere Colors") ? ImGuiTabItemFlags_SetSelected : 0;
-		ImGuiTabItemFlags cloudsFlags = (activeTabOverride == "Clouds") ? ImGuiTabItemFlags_SetSelected : 0;
-		ImGuiTabItemFlags fogFlags = (activeTabOverride == "Fog") ? ImGuiTabItemFlags_SetSelected : 0;
-		ImGuiTabItemFlags featuresFlags = (activeTabOverride == "Features") ? ImGuiTabItemFlags_SetSelected : 0;
-		ImGuiTabItemFlags recordsFlags = (activeTabOverride == "Records") ? ImGuiTabItemFlags_SetSelected : 0;
-		if (!activeTabOverride.empty()) {
-			activeTabOverride = "";  // Clear after use
-		}
+// Tab bar for organizing settings
+if (ImGui::BeginTabBar("WeatherSettingsTabs", ImGuiTabBarFlags_None)) {
+	// Use activeTabOverride to auto-navigate to specific tab
+	ImGuiTabItemFlags basicFlags = (activeTabOverride == "Basic") ? ImGuiTabItemFlags_SetSelected : 0;
+	ImGuiTabItemFlags dalcFlags = (activeTabOverride == "Lighting (DALC)") ? ImGuiTabItemFlags_SetSelected : 0;
+	ImGuiTabItemFlags atmosphereFlags = (activeTabOverride == "Atmosphere Colors") ? ImGuiTabItemFlags_SetSelected : 0;
+	ImGuiTabItemFlags cloudsFlags = (activeTabOverride == "Clouds") ? ImGuiTabItemFlags_SetSelected : 0;
+	ImGuiTabItemFlags fogFlags = (activeTabOverride == "Fog") ? ImGuiTabItemFlags_SetSelected : 0;
+	ImGuiTabItemFlags featuresFlags = (activeTabOverride == "Features") ? ImGuiTabItemFlags_SetSelected : 0;
+	ImGuiTabItemFlags recordsFlags = (activeTabOverride == "Records") ? ImGuiTabItemFlags_SetSelected : 0;
+	if (!activeTabOverride.empty()) {
+		activeTabOverride = "";  // Clear after use
+	}
 
-		if (ImGui::BeginTabItem("Basic", nullptr, basicFlags)) {
-			BeginScrollableContent("##BasicScroll");
-			DrawProperties("Sun", { { "Sun Damage", INT8_SLIDER } });
-			DrawProperties("Wind", { { "Wind Speed", UINT8_SLIDER }, { "Wind Direction", INT8_SLIDER }, { "Wind Direction Range", INT8_SLIDER } });
-			DrawProperties("Precipitation", { { "Precipitation Begin Fade In", INT8_SLIDER }, { "Precipitation End Fade Out", INT8_SLIDER } });
-			DrawProperties("Lightning", { { "Thunder Lightning Begin Fade In", INT8_SLIDER }, { "Thunder Lightning End Fade Out", INT8_SLIDER },
-											{ "Thunder Lightning Frequency", INT8_SLIDER }, { "Lightning Color", COLOR3_PICKER } });
-			DrawProperties("Visual Effects", { { "Visual Effect Begin", INT8_SLIDER }, { "Visual Effect End", INT8_SLIDER } });
-			DrawProperties("Weather Transition", { { "Trans Delta", INT8_SLIDER } });
-			EndScrollableContent();
-			ImGui::EndTabItem();
-		}
-		if (ImGui::BeginTabItem("Lighting (DALC)", nullptr, dalcFlags)) {
-			BeginScrollableContent("##DALCScroll");
-			DrawDALCSettings();
-			EndScrollableContent();
-			ImGui::EndTabItem();
-		}
+	if (ImGui::BeginTabItem("Basic", nullptr, basicFlags)) {
+		BeginScrollableContent("##BasicScroll");
+		DrawProperties("Sun", { { "Sun Damage", INT8_SLIDER } });
+		DrawProperties("Wind", { { "Wind Speed", UINT8_SLIDER }, { "Wind Direction", INT8_SLIDER }, { "Wind Direction Range", INT8_SLIDER } });
+		DrawProperties("Precipitation", { { "Precipitation Begin Fade In", INT8_SLIDER }, { "Precipitation End Fade Out", INT8_SLIDER } });
+		DrawProperties("Lightning", { { "Thunder Lightning Begin Fade In", INT8_SLIDER }, { "Thunder Lightning End Fade Out", INT8_SLIDER },
+										{ "Thunder Lightning Frequency", INT8_SLIDER }, { "Lightning Color", COLOR3_PICKER } });
+		DrawProperties("Visual Effects", { { "Visual Effect Begin", INT8_SLIDER }, { "Visual Effect End", INT8_SLIDER } });
+		DrawProperties("Weather Transition", { { "Trans Delta", INT8_SLIDER } });
+		EndScrollableContent();
+		ImGui::EndTabItem();
+	}
+	if (ImGui::BeginTabItem("Lighting (DALC)", nullptr, dalcFlags)) {
+		BeginScrollableContent("##DALCScroll");
+		DrawDALCSettings();
+		EndScrollableContent();
+		ImGui::EndTabItem();
+	}
 
-		if (ImGui::BeginTabItem("Atmosphere Colors", nullptr, atmosphereFlags)) {
-			BeginScrollableContent("##AtmosphereScroll");
-			DrawWeatherColorSettings();
-			EndScrollableContent();
-			ImGui::EndTabItem();
-		}
+	if (ImGui::BeginTabItem("Atmosphere Colors", nullptr, atmosphereFlags)) {
+		BeginScrollableContent("##AtmosphereScroll");
+		DrawWeatherColorSettings();
+		EndScrollableContent();
+		ImGui::EndTabItem();
+	}
 
-		if (ImGui::BeginTabItem("Clouds", nullptr, cloudsFlags)) {
-			BeginScrollableContent("##CloudsScroll");
-			DrawCloudSettings();
-			EndScrollableContent();
-			ImGui::EndTabItem();
-		}
+	if (ImGui::BeginTabItem("Clouds", nullptr, cloudsFlags)) {
+		BeginScrollableContent("##CloudsScroll");
+		DrawCloudSettings();
+		EndScrollableContent();
+		ImGui::EndTabItem();
+	}
 
-		if (ImGui::BeginTabItem("Fog", nullptr, fogFlags)) {
-			BeginScrollableContent("##FogScroll");
-			DrawFogSettings();
-			EndScrollableContent();
-			ImGui::EndTabItem();
-		}
+	if (ImGui::BeginTabItem("Fog", nullptr, fogFlags)) {
+		BeginScrollableContent("##FogScroll");
+		DrawFogSettings();
+		EndScrollableContent();
+		ImGui::EndTabItem();
+	}
 
-		if (ImGui::BeginTabItem("Features", nullptr, featuresFlags)) {
-			BeginScrollableContent("##FeaturesScroll");
-			DrawFeatureSettings();
-			EndScrollableContent();
-			ImGui::EndTabItem();
-		}
+	if (ImGui::BeginTabItem("Features", nullptr, featuresFlags)) {
+		BeginScrollableContent("##FeaturesScroll");
+		DrawFeatureSettings();
+		EndScrollableContent();
+		ImGui::EndTabItem();
+	}
 
-		if (ImGui::BeginTabItem("Records", nullptr, recordsFlags)) {
-			BeginScrollableContent("##RecordsScroll");
-			ImGui::Spacing();
-			ImGui::TextWrapped("Form record references used by this weather.");
-			ImGui::Spacing();
-			ImGui::Separator();
-			ImGui::Spacing();
-			auto* editorWindow = EditorWindow::GetSingleton();
+	if (ImGui::BeginTabItem("Records", nullptr, recordsFlags)) {
+		BeginScrollableContent("##RecordsScroll");
+		ImGui::Spacing();
+		ImGui::TextWrapped("Form record references used by this weather.");
+		ImGui::Spacing();
+		ImGui::Separator();
+		ImGui::Spacing();
+		auto* editorWindow = EditorWindow::GetSingleton();
 
-			bool recordChanged = false;
-			bool hasParent = editorWindow->settings.enableInheritFromParent && HasParent();
-			WeatherWidget* parentWidget = hasParent ? GetParent() : nullptr;
+		bool recordChanged = false;
+		bool hasParent = editorWindow->settings.enableInheritFromParent && HasParent();
+		WeatherWidget* parentWidget = hasParent ? GetParent() : nullptr;
 
-			// ImageSpace Records (per time of day)
-			if (ImGui::CollapsingHeader("ImageSpace", ImGuiTreeNodeFlags_DefaultOpen)) {
-				for (int i = 0; i < ColorTimes::kTotal; i++) {
-					ImGui::PushID(i);
-					std::string label = ColorTimeLabel(i);
-					std::string inheritKey = "ImageSpace_" + std::to_string(i);
+		// ImageSpace Records (per time of day)
+		if (ImGui::CollapsingHeader("ImageSpace", ImGuiTreeNodeFlags_DefaultOpen)) {
+			for (int i = 0; i < ColorTimes::kTotal; i++) {
+				ImGui::PushID(i);
+				std::string label = ColorTimeLabel(i);
+				std::string inheritKey = "ImageSpace_" + std::to_string(i);
 
-					// Inherit checkbox
-					if (hasParent) {
-						bool& inheritFlag = settings.inheritFlags[inheritKey];
-						if (ImGui::Checkbox(("##inherit_" + inheritKey).c_str(), &inheritFlag)) {
-							if (inheritFlag && parentWidget) {
-								weather->imageSpaces[i] = parentWidget->weather->imageSpaces[i];
-								recordChanged = true;
-							}
-						}
-						if (ImGui::IsItemHovered()) {
-							ImGui::SetTooltip(inheritFlag ? "Inheriting from parent" : "Inherit from parent");
-						}
-						ImGui::SameLine();
-					}
-
-					ImGui::Text("%s:", label.c_str());
-					ImGui::SameLine(hasParent ? 120.0f : 100.0f);
-					if (WeatherUtils::DrawFormPickerCached("##ImageSpace", weather->imageSpaces[i], editorWindow->imageSpaceWidgets, false, true)) {
-						recordChanged = true;
-					}  // Add "Open" button
-					if (weather->imageSpaces[i]) {
-						ImGui::SameLine();
-						if (ImGui::SmallButton(std::format("Open##{}", i).c_str())) {
-							for (auto& widget : editorWindow->imageSpaceWidgets) {
-								if (widget->form == weather->imageSpaces[i]) {
-									widget->SetOpen(true);
-									break;
-								}
-							}
-						}
-						if (ImGui::IsItemHovered()) {
-							ImGui::SetTooltip("Open this ImageSpace for editing");
-						}
-					}
-
-					ImGui::PopID();
-				}
-				ImGui::Spacing();
-			}
-
-			// Volumetric Lighting Records (per time of day)
-			if (ImGui::CollapsingHeader("Volumetric Lighting", ImGuiTreeNodeFlags_DefaultOpen)) {
-				for (int i = 0; i < ColorTimes::kTotal; i++) {
-					ImGui::PushID(100 + i);
-					std::string label = ColorTimeLabel(i);
-					std::string inheritKey = "VolumetricLighting_" + std::to_string(i);
-
-					// Inherit checkbox
-					if (hasParent) {
-						bool& inheritFlag = settings.inheritFlags[inheritKey];
-						if (ImGui::Checkbox(("##inherit_" + inheritKey).c_str(), &inheritFlag)) {
-							if (inheritFlag && parentWidget) {
-								weather->volumetricLighting[i] = parentWidget->weather->volumetricLighting[i];
-								recordChanged = true;
-							}
-						}
-						if (ImGui::IsItemHovered()) {
-							ImGui::SetTooltip(inheritFlag ? "Inheriting from parent" : "Inherit from parent");
-						}
-						ImGui::SameLine();
-					}
-
-					ImGui::Text("%s:", label.c_str());
-					ImGui::SameLine(hasParent ? 120.0f : 100.0f);
-					if (WeatherUtils::DrawFormPickerCached("##VolumetricLighting", weather->volumetricLighting[i], editorWindow->volumetricLightingWidgets, false, true)) {
-						recordChanged = true;
-					}  // Add "Open" button
-					if (weather->volumetricLighting[i]) {
-						ImGui::SameLine();
-						if (ImGui::SmallButton(std::format("Open##{}", i).c_str())) {
-							for (auto& widget : editorWindow->volumetricLightingWidgets) {
-								if (widget->form == weather->volumetricLighting[i]) {
-									widget->SetOpen(true);
-									break;
-								}
-							}
-						}
-						if (ImGui::IsItemHovered()) {
-							ImGui::SetTooltip("Open this Volumetric Lighting for editing");
-						}
-					}
-
-					ImGui::PopID();
-				}
-				ImGui::Spacing();
-			}
-
-			// Precipitation Data
-			if (ImGui::CollapsingHeader("Precipitation", ImGuiTreeNodeFlags_DefaultOpen)) {
 				// Inherit checkbox
 				if (hasParent) {
-					bool& inheritFlag = settings.inheritFlags["Precipitation"];
-					if (ImGui::Checkbox("##inherit_Precipitation", &inheritFlag)) {
+					bool& inheritFlag = settings.inheritFlags[inheritKey];
+					if (ImGui::Checkbox(("##inherit_" + inheritKey).c_str(), &inheritFlag)) {
 						if (inheritFlag && parentWidget) {
-							weather->precipitationData = parentWidget->weather->precipitationData;
+							weather->imageSpaces[i] = parentWidget->weather->imageSpaces[i];
 							recordChanged = true;
 						}
 					}
@@ -357,37 +268,44 @@ void WeatherWidget::DrawWidget()
 					ImGui::SameLine();
 				}
 
-				ImGui::Text("Particle Shader:");
-				ImGui::SameLine(hasParent ? 170.0f : 150.0f);
-				if (WeatherUtils::DrawFormPickerCached("##Precipitation", weather->precipitationData, editorWindow->precipitationWidgets, false, true)) {
+				ImGui::Text("%s:", label.c_str());
+				ImGui::SameLine(hasParent ? 120.0f : 100.0f);
+				if (WeatherUtils::DrawFormPickerCached("##ImageSpace", weather->imageSpaces[i], editorWindow->imageSpaceWidgets, false, true)) {
 					recordChanged = true;
 				}  // Add "Open" button
-				if (weather->precipitationData) {
+				if (weather->imageSpaces[i]) {
 					ImGui::SameLine();
-					if (ImGui::SmallButton("Open##Precip")) {
-						for (auto& widget : editorWindow->precipitationWidgets) {
-							if (widget->form == weather->precipitationData) {
+					if (ImGui::SmallButton(std::format("Open##{}", i).c_str())) {
+						for (auto& widget : editorWindow->imageSpaceWidgets) {
+							if (widget->form == weather->imageSpaces[i]) {
 								widget->SetOpen(true);
 								break;
 							}
 						}
 					}
 					if (ImGui::IsItemHovered()) {
-						ImGui::SetTooltip("Open this Precipitation for editing");
+						ImGui::SetTooltip("Open this ImageSpace for editing");
 					}
 				}
 
-				ImGui::Spacing();
+				ImGui::PopID();
 			}
+			ImGui::Spacing();
+		}
 
-			// Visual Effect (Reference Effect)
-			if (ImGui::CollapsingHeader("Visual Effect", ImGuiTreeNodeFlags_DefaultOpen)) {
+		// Volumetric Lighting Records (per time of day)
+		if (ImGui::CollapsingHeader("Volumetric Lighting", ImGuiTreeNodeFlags_DefaultOpen)) {
+			for (int i = 0; i < ColorTimes::kTotal; i++) {
+				ImGui::PushID(100 + i);
+				std::string label = ColorTimeLabel(i);
+				std::string inheritKey = "VolumetricLighting_" + std::to_string(i);
+
 				// Inherit checkbox
 				if (hasParent) {
-					bool& inheritFlag = settings.inheritFlags["ReferenceEffect"];
-					if (ImGui::Checkbox("##inherit_ReferenceEffect", &inheritFlag)) {
+					bool& inheritFlag = settings.inheritFlags[inheritKey];
+					if (ImGui::Checkbox(("##inherit_" + inheritKey).c_str(), &inheritFlag)) {
 						if (inheritFlag && parentWidget) {
-							weather->referenceEffect = parentWidget->weather->referenceEffect;
+							weather->volumetricLighting[i] = parentWidget->weather->volumetricLighting[i];
 							recordChanged = true;
 						}
 					}
@@ -397,37 +315,119 @@ void WeatherWidget::DrawWidget()
 					ImGui::SameLine();
 				}
 
-				ImGui::Text("Reference Effect:");
-				ImGui::SameLine(hasParent ? 170.0f : 150.0f);
-				if (WeatherUtils::DrawFormPickerCached("##ReferenceEffect", weather->referenceEffect, editorWindow->referenceEffectWidgets, false, true)) {
+				ImGui::Text("%s:", label.c_str());
+				ImGui::SameLine(hasParent ? 120.0f : 100.0f);
+				if (WeatherUtils::DrawFormPickerCached("##VolumetricLighting", weather->volumetricLighting[i], editorWindow->volumetricLightingWidgets, false, true)) {
 					recordChanged = true;
 				}  // Add "Open" button
-				if (weather->referenceEffect) {
+				if (weather->volumetricLighting[i]) {
 					ImGui::SameLine();
-					if (ImGui::SmallButton("Open##RefEffect")) {
-						for (auto& widget : editorWindow->referenceEffectWidgets) {
-							if (widget->form == weather->referenceEffect) {
+					if (ImGui::SmallButton(std::format("Open##{}", i).c_str())) {
+						for (auto& widget : editorWindow->volumetricLightingWidgets) {
+							if (widget->form == weather->volumetricLighting[i]) {
 								widget->SetOpen(true);
 								break;
 							}
 						}
 					}
 					if (ImGui::IsItemHovered()) {
-						ImGui::SetTooltip("Open this Visual Effect for editing");
+						ImGui::SetTooltip("Open this Volumetric Lighting for editing");
 					}
 				}
 
-				ImGui::Spacing();
+				ImGui::PopID();
 			}
-
-			if (recordChanged && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
-				ApplyChanges();
-			}
-
-			EndScrollableContent();
-			ImGui::EndTabItem();
+			ImGui::Spacing();
 		}
-		ImGui::EndTabBar();
+
+		// Precipitation Data
+		if (ImGui::CollapsingHeader("Precipitation", ImGuiTreeNodeFlags_DefaultOpen)) {
+			// Inherit checkbox
+			if (hasParent) {
+				bool& inheritFlag = settings.inheritFlags["Precipitation"];
+				if (ImGui::Checkbox("##inherit_Precipitation", &inheritFlag)) {
+					if (inheritFlag && parentWidget) {
+						weather->precipitationData = parentWidget->weather->precipitationData;
+						recordChanged = true;
+					}
+				}
+				if (ImGui::IsItemHovered()) {
+					ImGui::SetTooltip(inheritFlag ? "Inheriting from parent" : "Inherit from parent");
+				}
+				ImGui::SameLine();
+			}
+
+			ImGui::Text("Particle Shader:");
+			ImGui::SameLine(hasParent ? 170.0f : 150.0f);
+			if (WeatherUtils::DrawFormPickerCached("##Precipitation", weather->precipitationData, editorWindow->precipitationWidgets, false, true)) {
+				recordChanged = true;
+			}  // Add "Open" button
+			if (weather->precipitationData) {
+				ImGui::SameLine();
+				if (ImGui::SmallButton("Open##Precip")) {
+					for (auto& widget : editorWindow->precipitationWidgets) {
+						if (widget->form == weather->precipitationData) {
+							widget->SetOpen(true);
+							break;
+						}
+					}
+				}
+				if (ImGui::IsItemHovered()) {
+					ImGui::SetTooltip("Open this Precipitation for editing");
+				}
+			}
+
+			ImGui::Spacing();
+		}
+
+		// Visual Effect (Reference Effect)
+		if (ImGui::CollapsingHeader("Visual Effect", ImGuiTreeNodeFlags_DefaultOpen)) {
+			// Inherit checkbox
+			if (hasParent) {
+				bool& inheritFlag = settings.inheritFlags["ReferenceEffect"];
+				if (ImGui::Checkbox("##inherit_ReferenceEffect", &inheritFlag)) {
+					if (inheritFlag && parentWidget) {
+						weather->referenceEffect = parentWidget->weather->referenceEffect;
+						recordChanged = true;
+					}
+				}
+				if (ImGui::IsItemHovered()) {
+					ImGui::SetTooltip(inheritFlag ? "Inheriting from parent" : "Inherit from parent");
+				}
+				ImGui::SameLine();
+			}
+
+			ImGui::Text("Reference Effect:");
+			ImGui::SameLine(hasParent ? 170.0f : 150.0f);
+			if (WeatherUtils::DrawFormPickerCached("##ReferenceEffect", weather->referenceEffect, editorWindow->referenceEffectWidgets, false, true)) {
+				recordChanged = true;
+			}  // Add "Open" button
+			if (weather->referenceEffect) {
+				ImGui::SameLine();
+				if (ImGui::SmallButton("Open##RefEffect")) {
+					for (auto& widget : editorWindow->referenceEffectWidgets) {
+						if (widget->form == weather->referenceEffect) {
+							widget->SetOpen(true);
+							break;
+						}
+					}
+				}
+				if (ImGui::IsItemHovered()) {
+					ImGui::SetTooltip("Open this Visual Effect for editing");
+				}
+			}
+
+			ImGui::Spacing();
+		}
+
+		if (recordChanged && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
+			ApplyChanges();
+		}
+
+		EndScrollableContent();
+		ImGui::EndTabItem();
+	}
+	ImGui::EndTabBar();
 	ImGui::End();
 }
 

--- a/src/WeatherEditor/Weather/WeatherWidget.cpp
+++ b/src/WeatherEditor/Weather/WeatherWidget.cpp
@@ -172,1862 +172,1862 @@ void WeatherWidget::DrawWidget()
 	}
 
 	// Tab bar for organizing settings
-if (ImGui::BeginTabBar("WeatherSettingsTabs", ImGuiTabBarFlags_None)) {
-	// Use activeTabOverride to auto-navigate to specific tab
-	ImGuiTabItemFlags basicFlags = (activeTabOverride == "Basic") ? ImGuiTabItemFlags_SetSelected : 0;
-	ImGuiTabItemFlags dalcFlags = (activeTabOverride == "Lighting (DALC)") ? ImGuiTabItemFlags_SetSelected : 0;
-	ImGuiTabItemFlags atmosphereFlags = (activeTabOverride == "Atmosphere Colors") ? ImGuiTabItemFlags_SetSelected : 0;
-	ImGuiTabItemFlags cloudsFlags = (activeTabOverride == "Clouds") ? ImGuiTabItemFlags_SetSelected : 0;
-	ImGuiTabItemFlags fogFlags = (activeTabOverride == "Fog") ? ImGuiTabItemFlags_SetSelected : 0;
-	ImGuiTabItemFlags featuresFlags = (activeTabOverride == "Features") ? ImGuiTabItemFlags_SetSelected : 0;
-	ImGuiTabItemFlags recordsFlags = (activeTabOverride == "Records") ? ImGuiTabItemFlags_SetSelected : 0;
-	if (!activeTabOverride.empty()) {
-		activeTabOverride = "";  // Clear after use
-	}
+	if (ImGui::BeginTabBar("WeatherSettingsTabs", ImGuiTabBarFlags_None)) {
+		// Use activeTabOverride to auto-navigate to specific tab
+		ImGuiTabItemFlags basicFlags = (activeTabOverride == "Basic") ? ImGuiTabItemFlags_SetSelected : 0;
+		ImGuiTabItemFlags dalcFlags = (activeTabOverride == "Lighting (DALC)") ? ImGuiTabItemFlags_SetSelected : 0;
+		ImGuiTabItemFlags atmosphereFlags = (activeTabOverride == "Atmosphere Colors") ? ImGuiTabItemFlags_SetSelected : 0;
+		ImGuiTabItemFlags cloudsFlags = (activeTabOverride == "Clouds") ? ImGuiTabItemFlags_SetSelected : 0;
+		ImGuiTabItemFlags fogFlags = (activeTabOverride == "Fog") ? ImGuiTabItemFlags_SetSelected : 0;
+		ImGuiTabItemFlags featuresFlags = (activeTabOverride == "Features") ? ImGuiTabItemFlags_SetSelected : 0;
+		ImGuiTabItemFlags recordsFlags = (activeTabOverride == "Records") ? ImGuiTabItemFlags_SetSelected : 0;
+		if (!activeTabOverride.empty()) {
+			activeTabOverride = "";  // Clear after use
+		}
 
-	if (ImGui::BeginTabItem("Basic", nullptr, basicFlags)) {
-		BeginScrollableContent("##BasicScroll");
-		DrawProperties("Sun", { { "Sun Damage", INT8_SLIDER } });
-		DrawProperties("Wind", { { "Wind Speed", UINT8_SLIDER }, { "Wind Direction", INT8_SLIDER }, { "Wind Direction Range", INT8_SLIDER } });
-		DrawProperties("Precipitation", { { "Precipitation Begin Fade In", INT8_SLIDER }, { "Precipitation End Fade Out", INT8_SLIDER } });
-		DrawProperties("Lightning", { { "Thunder Lightning Begin Fade In", INT8_SLIDER }, { "Thunder Lightning End Fade Out", INT8_SLIDER },
-										{ "Thunder Lightning Frequency", INT8_SLIDER }, { "Lightning Color", COLOR3_PICKER } });
-		DrawProperties("Visual Effects", { { "Visual Effect Begin", INT8_SLIDER }, { "Visual Effect End", INT8_SLIDER } });
-		DrawProperties("Weather Transition", { { "Trans Delta", INT8_SLIDER } });
-		EndScrollableContent();
-		ImGui::EndTabItem();
-	}
-	if (ImGui::BeginTabItem("Lighting (DALC)", nullptr, dalcFlags)) {
-		BeginScrollableContent("##DALCScroll");
-		DrawDALCSettings();
-		EndScrollableContent();
-		ImGui::EndTabItem();
-	}
+		if (ImGui::BeginTabItem("Basic", nullptr, basicFlags)) {
+			BeginScrollableContent("##BasicScroll");
+			DrawProperties("Sun", { { "Sun Damage", INT8_SLIDER } });
+			DrawProperties("Wind", { { "Wind Speed", UINT8_SLIDER }, { "Wind Direction", INT8_SLIDER }, { "Wind Direction Range", INT8_SLIDER } });
+			DrawProperties("Precipitation", { { "Precipitation Begin Fade In", INT8_SLIDER }, { "Precipitation End Fade Out", INT8_SLIDER } });
+			DrawProperties("Lightning", { { "Thunder Lightning Begin Fade In", INT8_SLIDER }, { "Thunder Lightning End Fade Out", INT8_SLIDER },
+											{ "Thunder Lightning Frequency", INT8_SLIDER }, { "Lightning Color", COLOR3_PICKER } });
+			DrawProperties("Visual Effects", { { "Visual Effect Begin", INT8_SLIDER }, { "Visual Effect End", INT8_SLIDER } });
+			DrawProperties("Weather Transition", { { "Trans Delta", INT8_SLIDER } });
+			EndScrollableContent();
+			ImGui::EndTabItem();
+		}
+		if (ImGui::BeginTabItem("Lighting (DALC)", nullptr, dalcFlags)) {
+			BeginScrollableContent("##DALCScroll");
+			DrawDALCSettings();
+			EndScrollableContent();
+			ImGui::EndTabItem();
+		}
 
-	if (ImGui::BeginTabItem("Atmosphere Colors", nullptr, atmosphereFlags)) {
-		BeginScrollableContent("##AtmosphereScroll");
-		DrawWeatherColorSettings();
-		EndScrollableContent();
-		ImGui::EndTabItem();
-	}
+		if (ImGui::BeginTabItem("Atmosphere Colors", nullptr, atmosphereFlags)) {
+			BeginScrollableContent("##AtmosphereScroll");
+			DrawWeatherColorSettings();
+			EndScrollableContent();
+			ImGui::EndTabItem();
+		}
 
-	if (ImGui::BeginTabItem("Clouds", nullptr, cloudsFlags)) {
-		BeginScrollableContent("##CloudsScroll");
-		DrawCloudSettings();
-		EndScrollableContent();
-		ImGui::EndTabItem();
-	}
+		if (ImGui::BeginTabItem("Clouds", nullptr, cloudsFlags)) {
+			BeginScrollableContent("##CloudsScroll");
+			DrawCloudSettings();
+			EndScrollableContent();
+			ImGui::EndTabItem();
+		}
 
-	if (ImGui::BeginTabItem("Fog", nullptr, fogFlags)) {
-		BeginScrollableContent("##FogScroll");
-		DrawFogSettings();
-		EndScrollableContent();
-		ImGui::EndTabItem();
-	}
+		if (ImGui::BeginTabItem("Fog", nullptr, fogFlags)) {
+			BeginScrollableContent("##FogScroll");
+			DrawFogSettings();
+			EndScrollableContent();
+			ImGui::EndTabItem();
+		}
 
-	if (ImGui::BeginTabItem("Features", nullptr, featuresFlags)) {
-		BeginScrollableContent("##FeaturesScroll");
-		DrawFeatureSettings();
-		EndScrollableContent();
-		ImGui::EndTabItem();
-	}
+		if (ImGui::BeginTabItem("Features", nullptr, featuresFlags)) {
+			BeginScrollableContent("##FeaturesScroll");
+			DrawFeatureSettings();
+			EndScrollableContent();
+			ImGui::EndTabItem();
+		}
 
-	if (ImGui::BeginTabItem("Records", nullptr, recordsFlags)) {
-		BeginScrollableContent("##RecordsScroll");
-		ImGui::Spacing();
-		ImGui::TextWrapped("Form record references used by this weather.");
-		ImGui::Spacing();
-		ImGui::Separator();
-		ImGui::Spacing();
-		auto* editorWindow = EditorWindow::GetSingleton();
-
-		bool recordChanged = false;
-		bool hasParent = editorWindow->settings.enableInheritFromParent && HasParent();
-		WeatherWidget* parentWidget = hasParent ? GetParent() : nullptr;
-
-		// ImageSpace Records (per time of day)
-		if (ImGui::CollapsingHeader("ImageSpace", ImGuiTreeNodeFlags_DefaultOpen)) {
-			for (int i = 0; i < ColorTimes::kTotal; i++) {
-				ImGui::PushID(i);
-				std::string label = ColorTimeLabel(i);
-				std::string inheritKey = "ImageSpace_" + std::to_string(i);
-
-				// Inherit checkbox
-				if (hasParent) {
-					bool& inheritFlag = settings.inheritFlags[inheritKey];
-					if (ImGui::Checkbox(("##inherit_" + inheritKey).c_str(), &inheritFlag)) {
-						if (inheritFlag && parentWidget) {
-							weather->imageSpaces[i] = parentWidget->weather->imageSpaces[i];
-							recordChanged = true;
-						}
-					}
-					if (ImGui::IsItemHovered()) {
-						ImGui::SetTooltip(inheritFlag ? "Inheriting from parent" : "Inherit from parent");
-					}
-					ImGui::SameLine();
-				}
-
-				ImGui::Text("%s:", label.c_str());
-				ImGui::SameLine(hasParent ? 120.0f : 100.0f);
-				if (WeatherUtils::DrawFormPickerCached("##ImageSpace", weather->imageSpaces[i], editorWindow->imageSpaceWidgets, false, true)) {
-					recordChanged = true;
-				}  // Add "Open" button
-				if (weather->imageSpaces[i]) {
-					ImGui::SameLine();
-					if (ImGui::SmallButton(std::format("Open##{}", i).c_str())) {
-						for (auto& widget : editorWindow->imageSpaceWidgets) {
-							if (widget->form == weather->imageSpaces[i]) {
-								widget->SetOpen(true);
-								break;
-							}
-						}
-					}
-					if (ImGui::IsItemHovered()) {
-						ImGui::SetTooltip("Open this ImageSpace for editing");
-					}
-				}
-
-				ImGui::PopID();
-			}
+		if (ImGui::BeginTabItem("Records", nullptr, recordsFlags)) {
+			BeginScrollableContent("##RecordsScroll");
 			ImGui::Spacing();
-		}
-
-		// Volumetric Lighting Records (per time of day)
-		if (ImGui::CollapsingHeader("Volumetric Lighting", ImGuiTreeNodeFlags_DefaultOpen)) {
-			for (int i = 0; i < ColorTimes::kTotal; i++) {
-				ImGui::PushID(100 + i);
-				std::string label = ColorTimeLabel(i);
-				std::string inheritKey = "VolumetricLighting_" + std::to_string(i);
-
-				// Inherit checkbox
-				if (hasParent) {
-					bool& inheritFlag = settings.inheritFlags[inheritKey];
-					if (ImGui::Checkbox(("##inherit_" + inheritKey).c_str(), &inheritFlag)) {
-						if (inheritFlag && parentWidget) {
-							weather->volumetricLighting[i] = parentWidget->weather->volumetricLighting[i];
-							recordChanged = true;
-						}
-					}
-					if (ImGui::IsItemHovered()) {
-						ImGui::SetTooltip(inheritFlag ? "Inheriting from parent" : "Inherit from parent");
-					}
-					ImGui::SameLine();
-				}
-
-				ImGui::Text("%s:", label.c_str());
-				ImGui::SameLine(hasParent ? 120.0f : 100.0f);
-				if (WeatherUtils::DrawFormPickerCached("##VolumetricLighting", weather->volumetricLighting[i], editorWindow->volumetricLightingWidgets, false, true)) {
-					recordChanged = true;
-				}  // Add "Open" button
-				if (weather->volumetricLighting[i]) {
-					ImGui::SameLine();
-					if (ImGui::SmallButton(std::format("Open##{}", i).c_str())) {
-						for (auto& widget : editorWindow->volumetricLightingWidgets) {
-							if (widget->form == weather->volumetricLighting[i]) {
-								widget->SetOpen(true);
-								break;
-							}
-						}
-					}
-					if (ImGui::IsItemHovered()) {
-						ImGui::SetTooltip("Open this Volumetric Lighting for editing");
-					}
-				}
-
-				ImGui::PopID();
-			}
-			ImGui::Spacing();
-		}
-
-		// Precipitation Data
-		if (ImGui::CollapsingHeader("Precipitation", ImGuiTreeNodeFlags_DefaultOpen)) {
-			// Inherit checkbox
-			if (hasParent) {
-				bool& inheritFlag = settings.inheritFlags["Precipitation"];
-				if (ImGui::Checkbox("##inherit_Precipitation", &inheritFlag)) {
-					if (inheritFlag && parentWidget) {
-						weather->precipitationData = parentWidget->weather->precipitationData;
-						recordChanged = true;
-					}
-				}
-				if (ImGui::IsItemHovered()) {
-					ImGui::SetTooltip(inheritFlag ? "Inheriting from parent" : "Inherit from parent");
-				}
-				ImGui::SameLine();
-			}
-
-			ImGui::Text("Particle Shader:");
-			ImGui::SameLine(hasParent ? 170.0f : 150.0f);
-			if (WeatherUtils::DrawFormPickerCached("##Precipitation", weather->precipitationData, editorWindow->precipitationWidgets, false, true)) {
-				recordChanged = true;
-			}  // Add "Open" button
-			if (weather->precipitationData) {
-				ImGui::SameLine();
-				if (ImGui::SmallButton("Open##Precip")) {
-					for (auto& widget : editorWindow->precipitationWidgets) {
-						if (widget->form == weather->precipitationData) {
-							widget->SetOpen(true);
-							break;
-						}
-					}
-				}
-				if (ImGui::IsItemHovered()) {
-					ImGui::SetTooltip("Open this Precipitation for editing");
-				}
-			}
-
-			ImGui::Spacing();
-		}
-
-		// Visual Effect (Reference Effect)
-		if (ImGui::CollapsingHeader("Visual Effect", ImGuiTreeNodeFlags_DefaultOpen)) {
-			// Inherit checkbox
-			if (hasParent) {
-				bool& inheritFlag = settings.inheritFlags["ReferenceEffect"];
-				if (ImGui::Checkbox("##inherit_ReferenceEffect", &inheritFlag)) {
-					if (inheritFlag && parentWidget) {
-						weather->referenceEffect = parentWidget->weather->referenceEffect;
-						recordChanged = true;
-					}
-				}
-				if (ImGui::IsItemHovered()) {
-					ImGui::SetTooltip(inheritFlag ? "Inheriting from parent" : "Inherit from parent");
-				}
-				ImGui::SameLine();
-			}
-
-			ImGui::Text("Reference Effect:");
-			ImGui::SameLine(hasParent ? 170.0f : 150.0f);
-			if (WeatherUtils::DrawFormPickerCached("##ReferenceEffect", weather->referenceEffect, editorWindow->referenceEffectWidgets, false, true)) {
-				recordChanged = true;
-			}  // Add "Open" button
-			if (weather->referenceEffect) {
-				ImGui::SameLine();
-				if (ImGui::SmallButton("Open##RefEffect")) {
-					for (auto& widget : editorWindow->referenceEffectWidgets) {
-						if (widget->form == weather->referenceEffect) {
-							widget->SetOpen(true);
-							break;
-						}
-					}
-				}
-				if (ImGui::IsItemHovered()) {
-					ImGui::SetTooltip("Open this Visual Effect for editing");
-				}
-			}
-
-			ImGui::Spacing();
-		}
-
-		if (recordChanged && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
-			ApplyChanges();
-		}
-
-		EndScrollableContent();
-		ImGui::EndTabItem();
-	}
-	ImGui::EndTabBar();
-	ImGui::End();
-}
-
-void WeatherWidget::LoadSettings()
-{
-	bool hadErrors = false;
-	if (!js.empty()) {
-		try {
-			// Attempt to load settings from JSON
-			settings = js;
-
-			// Validate that critical fields were loaded correctly
-			if (js.contains("weatherProperties") && settings.weatherProperties.empty() && !js["weatherProperties"].empty()) {
-				logger::warn("Weather {}: weatherProperties loaded but appears empty, reverting to vanilla values", GetEditorID());
-				hadErrors = true;
-			}
-			if (js.contains("weatherColors") && settings.weatherColors.empty() && !js["weatherColors"].empty()) {
-				logger::warn("Weather {}: weatherColors loaded but appears empty, reverting to vanilla values", GetEditorID());
-				hadErrors = true;
-			}
-			if (js.contains("fogProperties") && settings.fogProperties.empty() && !js["fogProperties"].empty()) {
-				logger::warn("Weather {}: fogProperties loaded but appears empty, reverting to vanilla values", GetEditorID());
-				hadErrors = true;
-			}
-
-			if (hadErrors) {
-				// Fallback to vanilla/game values
-				settings = vanillaSettings;
-				EditorWindow::GetSingleton()->ShowNotification(
-					std::format("Some values failed to load for {}", GetEditorID()),
-					ImVec4(1.0f, 0.0f, 0.0f, 1.0f),
-					3.0f);
-			} else {
-				logger::info("Weather {}: Loaded settings - {} weather properties, {} colors, {} fog properties",
-					GetEditorID(),
-					settings.weatherProperties.size(),
-					settings.weatherColors.size(),
-					settings.fogProperties.size());
-			}
-
-		} catch (const nlohmann::json::exception& e) {
-			logger::error("Weather {}: Failed to deserialize settings from JSON: {}", GetEditorID(), e.what());
-			// Fallback to vanilla/game values on exception
-			settings = vanillaSettings;
-			EditorWindow::GetSingleton()->ShowNotification(
-				std::format("Some values failed to load for {}", GetEditorID()),
-				ImVec4(1.0f, 0.0f, 0.0f, 1.0f),
-				3.0f);
-			return;
-		}
-	} else {
-		settings = vanillaSettings;
-	}
-	InitializeInheritFlags();
-	if (!js.empty()) {
-		LoadFeatureSettings();
-	}
-	originalSettings = settings;
-	ApplyChanges();
-}
-
-void WeatherWidget::SaveSettings()
-{
-	SaveFeatureSettings();
-
-	try {
-		js = settings;
-
-		if (js.is_null()) {
-			logger::error("Weather {}: Serialization produced null JSON!", GetEditorID());
-		} else if (!js.contains("weatherProperties")) {
-			logger::error("Weather {}: Serialized JSON missing weatherProperties field!", GetEditorID());
-		} else if (!js.contains("atmosphereColors")) {
-			logger::error("Weather {}: Serialized JSON missing atmosphereColors field!", GetEditorID());
-		} else if (!js.contains("clouds")) {
-			logger::error("Weather {}: Serialized JSON missing clouds field!", GetEditorID());
-		} else {
-			originalSettings = settings;
-		}
-
-	} catch (const nlohmann::json::exception& e) {
-		logger::error("Weather {}: Failed to serialize settings to JSON: {}", GetEditorID(), e.what());
-	}
-}
-
-WeatherWidget* WeatherWidget::GetParent()
-{
-	auto editorWindow = EditorWindow::GetSingleton();
-	auto& widgets = editorWindow->weatherWidgets;
-
-	auto temp = std::find_if(widgets.begin(), widgets.end(), [&](const auto& w) { return w->GetEditorID() == settings.parent; });
-	if (temp != widgets.end())
-		return (WeatherWidget*)temp->get();
-
-	return nullptr;
-}
-
-bool WeatherWidget::HasParent() const
-{
-	return settings.parent != "None";
-}
-
-void WeatherWidget::SetWeatherValues()
-{
-	std::map<std::string, int>& weatherProps = settings.weatherProperties;
-	std::map<std::string, float3>& weatherColors = settings.weatherColors;
-	std::map<std::string, float>& fogProperties = settings.fogProperties;
-
-	auto& data = weather->data;
-	auto& colorData = weather->colorData;
-	auto& fogData = weather->fogData;
-
-	weather->data.transDelta = (int8_t)weatherProps["Trans Delta"];
-
-	// Sun
-	data.sunGlare = (int8_t)weatherProps["Sun Glare"];
-	data.sunDamage = (int8_t)weatherProps["Sun Damage"];
-
-	// Precipitation
-	data.precipitationBeginFadeIn = (int8_t)weatherProps["Precipitation Begin Fade In"];
-	data.precipitationEndFadeOut = (int8_t)weatherProps["Precipitation End Fade Out"];
-
-	// Lightning
-	data.thunderLightningBeginFadeIn = (int8_t)weatherProps["Thunder Lightning Begin Fade In"];
-	data.thunderLightningEndFadeOut = (int8_t)weatherProps["Thunder Lightning End Fade Out"];
-	data.thunderLightningFrequency = (int8_t)weatherProps["Thunder Lightning Frequency"];
-	Float3ToColor(weatherColors["Lightning Color"], weather->data.lightningColor);
-
-	// Visual Effects
-	data.visualEffectBegin = (int8_t)weatherProps["Visual Effect Begin"];
-	data.visualEffectEnd = (int8_t)weatherProps["Visual Effect End"];
-
-	// Wind
-	data.windSpeed = (uint8_t)weatherProps["Wind Speed"];
-	data.windDirection = (int8_t)weatherProps["Wind Direction"];
-	data.windDirectionRange = (int8_t)weatherProps["Wind Direction Range"];
-
-	// Fog
-	fogData.dayNear = fogProperties["Day Near"];
-	fogData.dayFar = fogProperties["Day Far"];
-	fogData.dayPower = fogProperties["Day Power"];
-	fogData.dayMax = fogProperties["Day Max"];
-	fogData.nightNear = fogProperties["Night Near"];
-	fogData.nightFar = fogProperties["Night Far"];
-	fogData.nightPower = fogProperties["Night Power"];
-	fogData.nightMax = fogProperties["Night Max"];
-
-	// Atmosphere colors
-	for (size_t i = 0; i < ColorTypes::kTotal; i++) {
-		for (size_t j = 0; j < ColorTimes::kTotal; j++) {
-			auto& color = colorData[i][j];
-			Float3ToColor(settings.atmosphereColors[i].colorTimes[j], color);
-		}
-	}
-
-	//DALC
-	for (size_t i = 0; i < ColorTimes::kTotal; i++) {
-		auto& dalc = weather->directionalAmbientLightingColors[i];
-		auto& settingsDalc = settings.dalc[i];
-		dalc.fresnelPower = settingsDalc.fresnelPower;
-
-		Float3ToColor(settingsDalc.specular, dalc.specular);
-
-		Float3ToColor(settingsDalc.directional[0].max, dalc.directional.x.max);
-		Float3ToColor(settingsDalc.directional[0].min, dalc.directional.x.min);
-
-		Float3ToColor(settingsDalc.directional[1].max, dalc.directional.y.max);
-		Float3ToColor(settingsDalc.directional[1].min, dalc.directional.y.min);
-
-		Float3ToColor(settingsDalc.directional[2].max, dalc.directional.z.max);
-		Float3ToColor(settingsDalc.directional[2].min, dalc.directional.z.min);
-	}
-
-	// Clouds
-	uint32_t disabledBits = 0;
-	for (size_t i = 0; i < TESWeather::kTotalLayers; i++) {
-		auto& settingsCloud = settings.clouds[i];
-
-		weather->cloudLayerSpeedX[i] = (int8_t)settingsCloud.cloudLayerSpeedX;
-		weather->cloudLayerSpeedY[i] = (int8_t)settingsCloud.cloudLayerSpeedY;
-
-		if (!settingsCloud.enabled) {
-			disabledBits |= (1 << i);
-		}
-
-		auto& cloudColors = weather->cloudColorData[i];
-		auto& cloudAlphas = weather->cloudAlpha[i];
-
-		for (int j = 0; j < ColorTimes::kTotal; j++) {
-			cloudAlphas[j] = settingsCloud.cloudAlpha[j];
-			Float3ToColor(settingsCloud.color[j], cloudColors[j]);
-		}
-	}
-	weather->cloudLayerDisabledBits = disabledBits;
-
-	// If this weather is currently active, immediately apply feature settings to game memory
-	auto* weatherManager = WeatherManager::GetSingleton();
-	if (weatherManager->GetCurrentWeathers().currentWeather == weather) {
-		auto* globalRegistry = WeatherVariables::GlobalWeatherRegistry::GetSingleton();
-		json emptyWeather;
-
-		for (const auto& [featureName, featureSettings] : settings.featureSettings) {
-			if (!featureSettings.value("__enabled", false) || !globalRegistry->HasWeatherSupport(featureName)) {
-				continue;
-			}
-
-			// Filter out __enabled flag and apply settings
-			json filteredSettings = featureSettings;
-			filteredSettings.erase("__enabled");
-			globalRegistry->UpdateFeatureFromWeathers(featureName, emptyWeather, filteredSettings, 1.0f);
-		}
-	}
-}
-
-void WeatherWidget::InitializeInheritFlags()
-{
-	auto& flags = settings.inheritFlags;
-	auto ensureFlag = [&](const std::string& key) {
-		flags.try_emplace(key, false);
-	};
-
-	static const char* kFixedKeys[] = {
-		"Precipitation",
-		"ReferenceEffect",
-		"DALC_Specular",
-		"DALC_Fresnel",
-		"DALC_DirXMax",
-		"DALC_DirXMin",
-		"DALC_DirYMax",
-		"DALC_DirYMin",
-		"DALC_DirZMax",
-		"DALC_DirZMin",
-		"Fog_Near",
-		"Fog_Far",
-		"Fog_Power",
-		"Fog_Max",
-		"Sun Damage",
-		"Wind Speed",
-		"Wind Direction",
-		"Wind Direction Range",
-		"Precipitation Begin Fade In",
-		"Precipitation End Fade Out",
-		"Thunder Lightning Begin Fade In",
-		"Thunder Lightning End Fade Out",
-		"Thunder Lightning Frequency",
-		"Lightning Color",
-		"Visual Effect Begin",
-		"Visual Effect End",
-		"Trans Delta",
-	};
-	for (const char* key : kFixedKeys) {
-		ensureFlag(key);
-	}
-
-	for (int i = 0; i < ColorTimes::kTotal; i++) {
-		ensureFlag(std::format("ImageSpace_{}", i));
-		ensureFlag(std::format("VolumetricLighting_{}", i));
-	}
-
-	for (int i = 0; i < ColorTypes::kTotal; i++) {
-		ensureFlag(std::format("Atmosphere_{}", ColorTypeLabel(i)));
-	}
-
-	for (int i = 0; i < TESWeather::kTotalLayers; i++) {
-		ensureFlag(std::format("Cloud{}_Color", i));
-		ensureFlag(std::format("Cloud{}_Alpha", i));
-	}
-}
-
-void WeatherWidget::LoadWeatherValues()
-{
-	std::map<std::string, int>& weatherProps = settings.weatherProperties;
-	std::map<std::string, float3>& weatherColors = settings.weatherColors;
-	std::map<std::string, float>& fogProperties = settings.fogProperties;
-
-	const auto& data = weather->data;
-	const auto& colorData = weather->colorData;
-	const auto& fogData = weather->fogData;
-
-	weatherProps["Trans Delta"] = data.transDelta;
-
-	// Sun
-	weatherProps["Sun Glare"] = data.sunGlare;
-	weatherProps["Sun Damage"] = data.sunDamage;
-
-	// Precipitation
-	weatherProps["Precipitation Begin Fade In"] = data.precipitationBeginFadeIn;
-	weatherProps["Precipitation End Fade Out"] = data.precipitationEndFadeOut;
-
-	// Lightning
-	weatherProps["Thunder Lightning Begin Fade In"] = data.thunderLightningBeginFadeIn;
-	weatherProps["Thunder Lightning End Fade Out"] = data.thunderLightningEndFadeOut;
-	weatherProps["Thunder Lightning Frequency"] = data.thunderLightningFrequency;
-	ColorToFloat3(data.lightningColor, weatherColors["Lightning Color"]);
-
-	// Visual Effects
-	weatherProps["Visual Effect Begin"] = data.visualEffectBegin;
-	weatherProps["Visual Effect End"] = data.visualEffectEnd;
-
-	// Wind
-	weatherProps["Wind Speed"] = data.windSpeed;
-	weatherProps["Wind Direction"] = data.windDirection;
-	weatherProps["Wind Direction Range"] = data.windDirectionRange;
-
-	// Fog
-	fogProperties["Day Near"] = fogData.dayNear;
-	fogProperties["Day Far"] = fogData.dayFar;
-	fogProperties["Night Near"] = fogData.nightNear;
-	fogProperties["Night Far"] = fogData.nightFar;
-	fogProperties["Day Power"] = fogData.dayPower;
-	fogProperties["Night Power"] = fogData.nightPower;
-	fogProperties["Day Max"] = fogData.dayMax;
-	fogProperties["Night Max"] = fogData.nightMax;
-
-	// Atmosphere color
-	for (size_t i = 0; i < ColorTypes::kTotal; i++) {
-		for (size_t j = 0; j < ColorTimes::kTotal; j++) {
-			auto& color = colorData[i][j];
-			ColorToFloat3(color, settings.atmosphereColors[i].colorTimes[j]);
-		}
-	}
-
-	// DALC
-	for (size_t i = 0; i < ColorTimes::kTotal; i++) {
-		auto& dalc = weather->directionalAmbientLightingColors[i];
-		auto& settingsDalc = settings.dalc[i];
-		settingsDalc.fresnelPower = dalc.fresnelPower;
-
-		ColorToFloat3(dalc.specular, settingsDalc.specular);
-
-		ColorToFloat3(dalc.directional.x.max, settingsDalc.directional[0].max);
-		ColorToFloat3(dalc.directional.x.min, settingsDalc.directional[0].min);
-
-		ColorToFloat3(dalc.directional.y.max, settingsDalc.directional[1].max);
-		ColorToFloat3(dalc.directional.y.min, settingsDalc.directional[1].min);
-
-		ColorToFloat3(dalc.directional.z.max, settingsDalc.directional[2].max);
-		ColorToFloat3(dalc.directional.z.min, settingsDalc.directional[2].min);
-	}
-
-	// Clouds
-	for (size_t i = 0; i < TESWeather::kTotalLayers; i++) {
-		auto& settingsCloud = settings.clouds[i];
-
-		settingsCloud.cloudLayerSpeedX = weather->cloudLayerSpeedX[i];
-		settingsCloud.cloudLayerSpeedY = weather->cloudLayerSpeedY[i];
-		settingsCloud.enabled = !(weather->cloudLayerDisabledBits & (1 << i));
-		settingsCloud.texturePath = weather->cloudTextures[i].textureName.c_str();
-
-		auto& cloudColors = weather->cloudColorData[i];
-		auto& cloudAlphas = weather->cloudAlpha[i];
-
-		for (int j = 0; j < ColorTimes::kTotal; j++) {
-			settingsCloud.cloudAlpha[j] = cloudAlphas[j];
-			ColorToFloat3(cloudColors[j], settingsCloud.color[j]);
-		}
-	}
-}
-
-void WeatherWidget::DrawDALCSettings()
-{
-	auto editorWindow = EditorWindow::GetSingleton();
-	bool hasParent = editorWindow->settings.enableInheritFromParent && HasParent();
-	WeatherWidget* parentWidget = hasParent ? GetParent() : nullptr;
-
-	bool changed = false;
-
-	if (TOD::BeginTODTable("DALC_TOD_Table")) {
-		TOD::RenderTODHeader();
-		TOD::DrawTODSeparator();
-
-		// Prepare arrays for TOD rendering
-		float3 specularColors[4];
-		float fresnelPowers[4];
-		float3 directionalXMax[4], directionalXMin[4];
-		float3 directionalYMax[4], directionalYMin[4];
-		float3 directionalZMax[4], directionalZMin[4];
-
-		// Parent values
-		float3 parentSpecular[4] = {};
-		float parentFresnel[4] = {};
-		float3 parentDirXMax[4] = {}, parentDirXMin[4] = {};
-		float3 parentDirYMax[4] = {}, parentDirYMin[4] = {};
-		float3 parentDirZMax[4] = {}, parentDirZMin[4] = {};
-
-		for (int i = 0; i < ColorTimes::kTotal; i++) {
-			specularColors[i] = settings.dalc[i].specular;
-			fresnelPowers[i] = settings.dalc[i].fresnelPower;
-			directionalXMax[i] = settings.dalc[i].directional[0].max;
-			directionalXMin[i] = settings.dalc[i].directional[0].min;
-			directionalYMax[i] = settings.dalc[i].directional[1].max;
-			directionalYMin[i] = settings.dalc[i].directional[1].min;
-			directionalZMax[i] = settings.dalc[i].directional[2].max;
-			directionalZMin[i] = settings.dalc[i].directional[2].min;
-
-			if (parentWidget) {
-				parentSpecular[i] = parentWidget->settings.dalc[i].specular;
-				parentFresnel[i] = parentWidget->settings.dalc[i].fresnelPower;
-				parentDirXMax[i] = parentWidget->settings.dalc[i].directional[0].max;
-				parentDirXMin[i] = parentWidget->settings.dalc[i].directional[0].min;
-				parentDirYMax[i] = parentWidget->settings.dalc[i].directional[1].max;
-				parentDirYMin[i] = parentWidget->settings.dalc[i].directional[1].min;
-				parentDirZMax[i] = parentWidget->settings.dalc[i].directional[2].max;
-				parentDirZMin[i] = parentWidget->settings.dalc[i].directional[2].min;
-			}
-		}
-
-		// Draw with per-parameter inheritance
-		if (hasParent) {
-			if (TOD::DrawTODColorRow("Specular", specularColors, settings.inheritFlags["DALC_Specular"], parentSpecular)) {
-				for (int i = 0; i < ColorTimes::kTotal; i++)
-					settings.dalc[i].specular = specularColors[i];
-				changed = true;
-			}
-
-			if (TOD::DrawTODFloatRow("Fresnel Power", fresnelPowers, settings.inheritFlags["DALC_Fresnel"], parentFresnel, 0.0f, 10.0f)) {
-				for (int i = 0; i < ColorTimes::kTotal; i++)
-					settings.dalc[i].fresnelPower = fresnelPowers[i];
-				changed = true;
-			}
-		} else {
-			if (TOD::DrawTODColorRow("Specular", specularColors)) {
-				for (int i = 0; i < ColorTimes::kTotal; i++)
-					settings.dalc[i].specular = specularColors[i];
-				changed = true;
-			}
-
-			if (TOD::DrawTODFloatRow("Fresnel Power", fresnelPowers, 0.0f, 10.0f)) {
-				for (int i = 0; i < ColorTimes::kTotal; i++)
-					settings.dalc[i].fresnelPower = fresnelPowers[i];
-				changed = true;
-			}
-		}
-
-		TOD::DrawTODSeparator();
-
-		// Directional colors with per-parameter inheritance
-		if (hasParent) {
-			if (TOD::DrawTODColorRow("Directional +X", directionalXMax, settings.inheritFlags["DALC_DirXMax"], parentDirXMax)) {
-				for (int i = 0; i < ColorTimes::kTotal; i++)
-					settings.dalc[i].directional[0].max = directionalXMax[i];
-				changed = true;
-			}
-
-			if (TOD::DrawTODColorRow("Directional -X", directionalXMin, settings.inheritFlags["DALC_DirXMin"], parentDirXMin)) {
-				for (int i = 0; i < ColorTimes::kTotal; i++)
-					settings.dalc[i].directional[0].min = directionalXMin[i];
-				changed = true;
-			}
-
-			if (TOD::DrawTODColorRow("Directional +Y", directionalYMax, settings.inheritFlags["DALC_DirYMax"], parentDirYMax)) {
-				for (int i = 0; i < ColorTimes::kTotal; i++)
-					settings.dalc[i].directional[1].max = directionalYMax[i];
-				changed = true;
-			}
-
-			if (TOD::DrawTODColorRow("Directional -Y", directionalYMin, settings.inheritFlags["DALC_DirYMin"], parentDirYMin)) {
-				for (int i = 0; i < ColorTimes::kTotal; i++)
-					settings.dalc[i].directional[1].min = directionalYMin[i];
-				changed = true;
-			}
-
-			if (TOD::DrawTODColorRow("Directional +Z", directionalZMax, settings.inheritFlags["DALC_DirZMax"], parentDirZMax)) {
-				for (int i = 0; i < ColorTimes::kTotal; i++)
-					settings.dalc[i].directional[2].max = directionalZMax[i];
-				changed = true;
-			}
-
-			if (TOD::DrawTODColorRow("Directional -Z", directionalZMin, settings.inheritFlags["DALC_DirZMin"], parentDirZMin)) {
-				for (int i = 0; i < ColorTimes::kTotal; i++)
-					settings.dalc[i].directional[2].min = directionalZMin[i];
-				changed = true;
-			}
-		} else {
-			if (TOD::DrawTODColorRow("Directional +X", directionalXMax)) {
-				for (int i = 0; i < ColorTimes::kTotal; i++)
-					settings.dalc[i].directional[0].max = directionalXMax[i];
-				changed = true;
-			}
-
-			if (TOD::DrawTODColorRow("Directional -X", directionalXMin)) {
-				for (int i = 0; i < ColorTimes::kTotal; i++)
-					settings.dalc[i].directional[0].min = directionalXMin[i];
-				changed = true;
-			}
-
-			if (TOD::DrawTODColorRow("Directional +Y", directionalYMax)) {
-				for (int i = 0; i < ColorTimes::kTotal; i++)
-					settings.dalc[i].directional[1].max = directionalYMax[i];
-				changed = true;
-			}
-
-			if (TOD::DrawTODColorRow("Directional -Y", directionalYMin)) {
-				for (int i = 0; i < ColorTimes::kTotal; i++)
-					settings.dalc[i].directional[1].min = directionalYMin[i];
-				changed = true;
-			}
-
-			if (TOD::DrawTODColorRow("Directional +Z", directionalZMax)) {
-				for (int i = 0; i < ColorTimes::kTotal; i++)
-					settings.dalc[i].directional[2].max = directionalZMax[i];
-				changed = true;
-			}
-
-			if (TOD::DrawTODColorRow("Directional -Z", directionalZMin)) {
-				for (int i = 0; i < ColorTimes::kTotal; i++)
-					settings.dalc[i].directional[2].min = directionalZMin[i];
-				changed = true;
-			}
-		}
-
-		TOD::EndTODTable();
-	}
-	if (changed && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
-		ApplyChanges();
-	}
-}
-
-void WeatherWidget::DrawWeatherColorSettings()
-{
-	auto editorWindow = EditorWindow::GetSingleton();
-	bool hasParent = editorWindow->settings.enableInheritFromParent && HasParent();
-	WeatherWidget* parentWidget = hasParent ? GetParent() : nullptr;
-
-	bool changed = false;
-
-	if (TOD::BeginTODTable("AtmosphereColors_Table")) {
-		TOD::RenderTODHeader();
-		TOD::DrawTODSeparator();
-
-		// Organized display order: group related sky/fog/lighting properties
-		static const int displayOrder[] = {
-			0,   // Sky Upper
-			7,   // Sky Lower
-			8,   // Horizon
-			1,   // Fog Near
-			12,  // Fog Far
-			3,   // Ambient
-			4,   // Sunlight
-			15,  // Sun Glare
-			5,   // Sun
-			6,   // Stars
-			16,  // Moon Glare
-			9,   // Effect Lighting
-			10,  // Cloud LOD Diffuse
-			11,  // Cloud LOD Ambient
-			13,  // Sky Statics
-			14,  // Water Multiplier
-			2,   // Unknown
-		};
-
-		for (int idx = 0; idx < ColorTypes::kTotal; idx++) {
-			int i = displayOrder[idx];
-			std::string colorTypeLabel = ColorTypeLabel(i);
-
-			if (hasParent) {
-				float3 parentColors[4];
-				for (int j = 0; j < 4; j++)
-					parentColors[j] = parentWidget->settings.atmosphereColors[i].colorTimes[j];
-
-				std::string inheritKey = "Atmosphere_" + colorTypeLabel;
-				if (TOD::DrawTODColorRow(colorTypeLabel.c_str(), settings.atmosphereColors[i].colorTimes, settings.inheritFlags[inheritKey], parentColors)) {
-					changed = true;
-				}
-			} else {
-				if (TOD::DrawTODColorRow(colorTypeLabel.c_str(), settings.atmosphereColors[i].colorTimes)) {
-					changed = true;
-				}
-			}
-		}
-
-		TOD::EndTODTable();
-	}
-
-	if (changed && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
-		ApplyChanges();
-	}
-}
-
-void WeatherWidget::DrawCloudSettings()
-{
-	auto editorWindow = EditorWindow::GetSingleton();
-	bool hasParent = editorWindow->settings.enableInheritFromParent && HasParent();
-	WeatherWidget* parentWidget = hasParent ? GetParent() : nullptr;
-
-	bool changed = false;
-	bool enableChanged = false;
-
-	// OpenOnArrow|OpenOnDoubleClick prevents accidental collapse when clicking
-	// the [Enabled] badge area that overlaps the right side of the header.
-	constexpr ImGuiTreeNodeFlags flags = ImGuiTreeNodeFlags_OpenOnArrow | ImGuiTreeNodeFlags_OpenOnDoubleClick;
-	constexpr char kEnabledBadge[] = "[Enabled]";
-
-	for (int i = 0; i < TESWeather::kTotalLayers; i++) {
-		std::string layer = std::format("Layer {}", i);
-		bool layerEnabled = settings.clouds[i].enabled;
-
-		if (!layerEnabled) {
-			ImGui::PushStyleColor(ImGuiCol_Header, ImGui::GetStyleColorVec4(ImGuiCol_FrameBg));
-			ImGui::PushStyleColor(ImGuiCol_HeaderHovered, ImGui::GetStyleColorVec4(ImGuiCol_FrameBgHovered));
-			ImGui::PushStyleColor(ImGuiCol_HeaderActive, ImGui::GetStyleColorVec4(ImGuiCol_FrameBgActive));
-		}
-
-		// Label is constant so the storage ID never changes — open/closed state always persists.
-		// [Enabled] badge is overlaid on the header via the draw list instead of altering the label.
-		float headerScreenY = ImGui::GetCursorScreenPos().y;
-		bool layerOpen = ImGui::CollapsingHeader(layer.c_str(), flags);
-
-		if (!layerEnabled)
-			ImGui::PopStyleColor(3);
-
-		if (layerEnabled) {
-			const ImVec2 badgeSize = ImGui::CalcTextSize(kEnabledBadge);
-			const float headerHeight = ImGui::GetFrameHeight();
-			const ImVec2 badgePos = {
-				ImGui::GetWindowPos().x + ImGui::GetContentRegionMax().x - badgeSize.x,
-				headerScreenY + (headerHeight - badgeSize.y) * 0.5f
-			};
-			ImGui::GetWindowDrawList()->AddText(badgePos, ImGui::GetColorU32(ImGuiCol_CheckMark), kEnabledBadge);
-		}
-
-		if (layerOpen) {
-			ImGui::Indent(10.0f);
-			ImGui::Spacing();
-
-			// Begin horizontal layout for enable checkbox and sliders on left, texture on right
-			ImGui::BeginGroup();
-
-			if (ImGui::Checkbox(std::format("Enable##{}", layer).c_str(), &layerEnabled)) {
-				settings.clouds[i].enabled = layerEnabled;
-				enableChanged = true;
-				changed = true;
-			}
-
-			ImGui::Spacing();
-			ImGui::Spacing();
-
-			// Make sliders 1/3 width
-			ImGui::PushItemWidth(ImGui::GetContentRegionAvail().x * 0.4f);
-			if (WeatherUtils::DrawSliderInt8(std::format("Cloud Layer Speed Y##{}", layer), settings.clouds[i].cloudLayerSpeedY))
-				changed = true;
-			ImGui::Spacing();
-			if (WeatherUtils::DrawSliderInt8(std::format("Cloud Layer Speed X##{}", layer), settings.clouds[i].cloudLayerSpeedX))
-				changed = true;
-			ImGui::PopItemWidth();
-
-			ImGui::EndGroup();
-
-			// Draw texture in upper right if available
-			if (!settings.clouds[i].texturePath.empty()) {
-				auto* texture = GetCloudTexture(i);
-				if (texture) {
-					ImGui::SameLine(0.0f, 20.0f);
-					ImGui::BeginGroup();
-					float textureSize = 128.0f;
-					ImGui::Image((void*)texture, ImVec2(textureSize, textureSize));
-					// Small grey subtext below image, clamped to texture width
-					ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
-					ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + textureSize);
-					ImGui::TextWrapped("%s", settings.clouds[i].texturePath.c_str());
-					ImGui::PopTextWrapPos();
-					ImGui::PopStyleColor();
-					ImGui::EndGroup();
-				}
-			}
-
-			ImGui::Spacing();
-			ImGui::Spacing();
-			if (TOD::BeginTODTable((layer + "_TOD_Table").c_str())) {
-				TOD::RenderTODHeader();
-				TOD::DrawTODSeparator();
-
-				if (hasParent) {
-					float3 parentColors[4];
-					float parentAlphas[4];
-					for (int j = 0; j < 4; j++) {
-						parentColors[j] = parentWidget->settings.clouds[i].color[j];
-						parentAlphas[j] = parentWidget->settings.clouds[i].cloudAlpha[j];
-					}
-
-					std::string colorKey = std::format("Cloud{}_Color", i);
-					std::string alphaKey = std::format("Cloud{}_Alpha", i);
-
-					if (TOD::DrawTODColorRow("Cloud Color", settings.clouds[i].color, settings.inheritFlags[colorKey], parentColors)) {
-						changed = true;
-					}
-
-					if (TOD::DrawTODFloatRow("Cloud Alpha", settings.clouds[i].cloudAlpha, settings.inheritFlags[alphaKey], parentAlphas, 0.0f, 1.0f)) {
-						changed = true;
-					}
-				} else {
-					if (TOD::DrawTODColorRow("Cloud Color", settings.clouds[i].color)) {
-						changed = true;
-					}
-
-					if (TOD::DrawTODFloatRow("Cloud Alpha", settings.clouds[i].cloudAlpha, 0.0f, 1.0f)) {
-						changed = true;
-					}
-				}
-
-				TOD::EndTODTable();
-			}
-
-			ImGui::Spacing();
-			ImGui::Unindent(10.0f);
-		}
-	}
-	if (enableChanged) {
-		// Apply enable/disable immediately for instant feedback, regardless of autoApplyChanges.
-		editorWindow->PushUndoState(this);
-		ApplyChanges();
-		if (editorWindow->IsWeatherLocked() && editorWindow->GetLockedWeather() == weather) {
-			if (auto sky = RE::Sky::GetSingleton()) {
-				sky->ForceWeather(weather, true);  // override=true for immediate application; matches "instant feedback" intent above
-			}
-		}
-	} else if (changed && editorWindow->settings.autoApplyChanges) {
-		editorWindow->PushUndoState(this);
-		ApplyChanges();
-	}
-}
-
-void WeatherWidget::DrawFogSettings()
-{
-	auto editorWindow = EditorWindow::GetSingleton();
-	bool hasParent = editorWindow->settings.enableInheritFromParent && HasParent();
-	WeatherWidget* parentWidget = hasParent ? GetParent() : nullptr;
-
-	bool changed = false;
-
-	if (ImGui::BeginTable("FogTable", 3, ImGuiTableFlags_BordersInnerV | ImGuiTableFlags_SizingFixedFit)) {
-		ImGui::TableSetupColumn("Parameter", ImGuiTableColumnFlags_WidthFixed, 200.0f);
-		ImGui::TableSetupColumn("Day", ImGuiTableColumnFlags_WidthFixed, 250.0f);
-		ImGui::TableSetupColumn("Night", ImGuiTableColumnFlags_WidthFixed, 250.0f);
-
-		// Header row
-		ImGui::TableNextRow();
-		ImGui::TableSetColumnIndex(0);
-		ImGui::TableSetColumnIndex(1);
-		ImGui::Text("Day");
-		ImGui::TableSetColumnIndex(2);
-		ImGui::Text("Night");
-
-		ImGui::TableNextRow();
-		ImGui::TableSetColumnIndex(0);
-		ImGui::Separator();
-		ImGui::TableSetColumnIndex(1);
-		ImGui::Separator();
-		ImGui::TableSetColumnIndex(2);
-		ImGui::Separator();
-
-		// Near
-		ImGui::TableNextRow();
-		ImGui::TableSetColumnIndex(0);
-		if (hasParent) {
-			ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(0.15f, 0.15f, 0.15f, 1.0f));
-			ImGui::PushStyleColor(ImGuiCol_CheckMark, ImVec4(0.5f, 0.5f, 0.5f, 1.0f));
-			ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(2, 2));
-			ImGui::Checkbox("##FogNear", &settings.inheritFlags["Fog_Near"]);
-			if (settings.inheritFlags["Fog_Near"]) {
-				settings.fogProperties["Day Near"] = parentWidget->settings.fogProperties["Day Near"];
-				settings.fogProperties["Night Near"] = parentWidget->settings.fogProperties["Night Near"];
-				changed = true;
-			}
-			ImGui::PopStyleVar();
-			ImGui::PopStyleColor(2);
-			ImGui::SameLine();
-		}
-		ImGui::Text("Near");
-		ImGui::TableSetColumnIndex(1);
-		ImGui::SetNextItemWidth(-1);
-		if (ImGui::SliderFloat("##FogDayNear", &settings.fogProperties["Day Near"], 0.0f, 1000000.0f, "%.0f"))
-			changed = true;
-		ImGui::TableSetColumnIndex(2);
-		ImGui::SetNextItemWidth(-1);
-		if (ImGui::SliderFloat("##FogNightNear", &settings.fogProperties["Night Near"], 0.0f, 1000000.0f, "%.0f"))
-			changed = true;
-
-		// Far
-		ImGui::TableNextRow();
-		ImGui::TableSetColumnIndex(0);
-		if (hasParent) {
-			ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(0.15f, 0.15f, 0.15f, 1.0f));
-			ImGui::PushStyleColor(ImGuiCol_CheckMark, ImVec4(0.5f, 0.5f, 0.5f, 1.0f));
-			ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(2, 2));
-			ImGui::Checkbox("##FogFar", &settings.inheritFlags["Fog_Far"]);
-			if (settings.inheritFlags["Fog_Far"]) {
-				settings.fogProperties["Day Far"] = parentWidget->settings.fogProperties["Day Far"];
-				settings.fogProperties["Night Far"] = parentWidget->settings.fogProperties["Night Far"];
-				changed = true;
-			}
-			ImGui::PopStyleVar();
-			ImGui::PopStyleColor(2);
-			ImGui::SameLine();
-		}
-		ImGui::Text("Far");
-		ImGui::TableSetColumnIndex(1);
-		ImGui::SetNextItemWidth(-1);
-		if (ImGui::SliderFloat("##FogDayFar", &settings.fogProperties["Day Far"], 0.0f, 1000000.0f, "%.0f"))
-			changed = true;
-		ImGui::TableSetColumnIndex(2);
-		ImGui::SetNextItemWidth(-1);
-		if (ImGui::SliderFloat("##FogNightFar", &settings.fogProperties["Night Far"], 0.0f, 1000000.0f, "%.0f"))
-			changed = true;
-
-		// Power
-		ImGui::TableNextRow();
-		ImGui::TableSetColumnIndex(0);
-		if (hasParent) {
-			ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(0.15f, 0.15f, 0.15f, 1.0f));
-			ImGui::PushStyleColor(ImGuiCol_CheckMark, ImVec4(0.5f, 0.5f, 0.5f, 1.0f));
-			ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(2, 2));
-			ImGui::Checkbox("##FogPower", &settings.inheritFlags["Fog_Power"]);
-			if (settings.inheritFlags["Fog_Power"]) {
-				settings.fogProperties["Day Power"] = parentWidget->settings.fogProperties["Day Power"];
-				settings.fogProperties["Night Power"] = parentWidget->settings.fogProperties["Night Power"];
-				changed = true;
-			}
-			ImGui::PopStyleVar();
-			ImGui::PopStyleColor(2);
-			ImGui::SameLine();
-		}
-		ImGui::Text("Power");
-		ImGui::TableSetColumnIndex(1);
-		ImGui::SetNextItemWidth(-1);
-		if (ImGui::SliderFloat("##FogDayPower", &settings.fogProperties["Day Power"], 0.0f, 10.0f, "%.3f"))
-			changed = true;
-		ImGui::TableSetColumnIndex(2);
-		ImGui::SetNextItemWidth(-1);
-		if (ImGui::SliderFloat("##FogNightPower", &settings.fogProperties["Night Power"], 0.0f, 10.0f, "%.3f"))
-			changed = true;
-
-		// Max
-		ImGui::TableNextRow();
-		ImGui::TableSetColumnIndex(0);
-		if (hasParent) {
-			ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(0.15f, 0.15f, 0.15f, 1.0f));
-			ImGui::PushStyleColor(ImGuiCol_CheckMark, ImVec4(0.5f, 0.5f, 0.5f, 1.0f));
-			ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(2, 2));
-			ImGui::Checkbox("##FogMax", &settings.inheritFlags["Fog_Max"]);
-			if (settings.inheritFlags["Fog_Max"]) {
-				settings.fogProperties["Day Max"] = parentWidget->settings.fogProperties["Day Max"];
-				settings.fogProperties["Night Max"] = parentWidget->settings.fogProperties["Night Max"];
-				changed = true;
-			}
-			ImGui::PopStyleVar();
-			ImGui::PopStyleColor(2);
-			ImGui::SameLine();
-		}
-		ImGui::Text("Max");
-		ImGui::TableSetColumnIndex(1);
-		ImGui::SetNextItemWidth(-1);
-		if (ImGui::SliderFloat("##FogDayMax", &settings.fogProperties["Day Max"], 0.0f, 1.0f, "%.3f"))
-			changed = true;
-		ImGui::TableSetColumnIndex(2);
-		ImGui::SetNextItemWidth(-1);
-		if (ImGui::SliderFloat("##FogNightMax", &settings.fogProperties["Night Max"], 0.0f, 1.0f, "%.3f"))
-			changed = true;
-
-		ImGui::EndTable();
-	}
-
-	if (changed && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
-		ApplyChanges();
-	}
-}
-
-void WeatherWidget::DrawProperties(std::string category, std::map<std::string, int> properties)
-{
-	// Check if any property matches search (only check if search is active)
-	bool hasMatchingProperty = false;
-	if (searchBuffer[0] != '\0') {
-		hasMatchingProperty = MatchesSearch(category);
-		if (!hasMatchingProperty) {
-			for (auto& p : properties) {
-				if (MatchesSearch(p.first)) {
-					hasMatchingProperty = true;
-					break;
-				}
-			}
-		}
-		// Skip this entire category if nothing matches
-		if (!hasMatchingProperty) {
-			return;
-		}
-	}
-
-	ImGui::TextColored(ImVec4(0.7f, 0.9f, 1.0f, 1.0f), "%s", category.c_str());
-
-	bool changed = false;
-	auto* editorWindow = EditorWindow::GetSingleton();
-	bool hasParent = editorWindow->settings.enableInheritFromParent && HasParent();
-
-	for (auto& p : properties) {
-		// Filter individual properties based on search
-		if (searchBuffer[0] != '\0' && !MatchesSearch(p.first)) {
-			continue;
-		}
-
-		// Apply highlight effect if this setting should be highlighted
-		if (ShouldHighlight(p.first)) {
-			float elapsed = static_cast<float>(ImGui::GetTime()) - highlightStartTime;
-			float alpha = 0.3f * (1.0f - std::abs(elapsed - 0.5f) * 2.0f);
-			ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(0.3f, 0.6f, 1.0f, alpha));
-			ImGui::PushStyleColor(ImGuiCol_FrameBgHovered, ImVec4(0.4f, 0.7f, 1.0f, alpha));
-		}
-
-		// Inherit checkbox
-		if (hasParent) {
-			bool& inheritFlag = settings.inheritFlags[p.first];
-			if (ImGui::Checkbox(("##inherit_" + p.first).c_str(), &inheritFlag)) {
-				if (inheritFlag) {
-					InheritFromParent(p.first);
-					changed = true;
-				}
-			}
-			if (ImGui::IsItemHovered()) {
-				ImGui::SetTooltip(inheritFlag ? "Inheriting from parent" : "Inherit from parent");
-			}
-			ImGui::SameLine();
-		}
-
-		switch (p.second) {
-		case 0:
-			if (WeatherUtils::DrawSliderInt8(p.first, settings.weatherProperties[p.first]))
-				changed = true;
-			break;
-		case 1:
-			if (WeatherUtils::DrawColorEdit(p.first, settings.weatherColors[p.first]))
-				changed = true;
-			break;
-		case 2:
-			if (WeatherUtils::DrawSliderUint8(p.first, settings.weatherProperties[p.first]))
-				changed = true;
-			break;
-		case 3:
-			if (WeatherUtils::DrawSliderFloat(p.first, settings.fogProperties[p.first]))
-				changed = true;
-			break;
-		default:
-			break;
-		}
-
-		if (ShouldHighlight(p.first)) {
-			ImGui::PopStyleColor(2);
-		}
-	}
-
-	if (changed && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
-		ApplyChanges();
-	}
-
-	ImGui::Spacing();
-	ImGui::Separator();
-	ImGui::Spacing();
-}
-
-void WeatherWidget::InheritFromParent(const std::string& property)
-{
-	if (!HasParent())
-		return;
-
-	WeatherWidget* parentWidget = GetParent();
-	if (!parentWidget)
-		return;
-
-	if (settings.weatherProperties.find(property) != settings.weatherProperties.end()) {
-		settings.weatherProperties[property] = parentWidget->settings.weatherProperties[property];
-	} else if (settings.weatherColors.find(property) != settings.weatherColors.end()) {
-		settings.weatherColors[property] = parentWidget->settings.weatherColors[property];
-	} else if (settings.fogProperties.find(property) != settings.fogProperties.end()) {
-		settings.fogProperties[property] = parentWidget->settings.fogProperties[property];
-	}
-}
-
-void WeatherWidget::InheritAllFromParent()
-{
-	if (!HasParent())
-		return;
-
-	WeatherWidget* parentWidget = GetParent();
-	if (!parentWidget)
-		return;
-
-	// Copy all weather properties
-	for (const auto& [key, value] : parentWidget->settings.weatherProperties) {
-		settings.weatherProperties[key] = value;
-	}
-
-	// Copy all weather colors
-	for (const auto& [key, value] : parentWidget->settings.weatherColors) {
-		settings.weatherColors[key] = value;
-	}
-
-	// Copy all fog properties
-	for (const auto& [key, value] : parentWidget->settings.fogProperties) {
-		settings.fogProperties[key] = value;
-	}
-
-	// Copy atmosphere colors
-	for (int i = 0; i < ColorTypes::kTotal; i++) {
-		settings.atmosphereColors[i] = parentWidget->settings.atmosphereColors[i];
-	}
-
-	// Copy DALC settings
-	for (int i = 0; i < ColorTimes::kTotal; i++) {
-		settings.dalc[i] = parentWidget->settings.dalc[i];
-	}
-
-	// Copy cloud settings
-	for (int i = 0; i < TESWeather::kTotalLayers; i++) {
-		settings.clouds[i] = parentWidget->settings.clouds[i];
-	}
-
-	// Set all inherit flags to true
-	settings.inheritFlags["DALC_Specular"] = true;
-	settings.inheritFlags["DALC_Fresnel"] = true;
-	settings.inheritFlags["DALC_DirXMax"] = true;
-	settings.inheritFlags["DALC_DirXMin"] = true;
-	settings.inheritFlags["DALC_DirYMax"] = true;
-	settings.inheritFlags["DALC_DirYMin"] = true;
-	settings.inheritFlags["DALC_DirZMax"] = true;
-	settings.inheritFlags["DALC_DirZMin"] = true;
-
-	settings.inheritFlags["Fog_Near"] = true;
-	settings.inheritFlags["Fog_Far"] = true;
-	settings.inheritFlags["Fog_Power"] = true;
-	settings.inheritFlags["Fog_Max"] = true;
-
-	// Atmosphere colors
-	static const int displayOrder[] = { 0, 7, 8, 1, 12, 3, 4, 5, 6, 9, 10, 11, 13, 14, 15, 16, 2 };
-	for (int idx = 0; idx < ColorTypes::kTotal; idx++) {
-		int i = displayOrder[idx];
-		std::string colorTypeLabel = ColorTypeLabel(i);
-		settings.inheritFlags["Atmosphere_" + colorTypeLabel] = true;
-	}
-
-	// Cloud settings
-	for (int i = 0; i < TESWeather::kTotalLayers; i++) {
-		settings.inheritFlags[std::format("Cloud{}_Color", i)] = true;
-		settings.inheritFlags[std::format("Cloud{}_Alpha", i)] = true;
-	}
-
-	// Apply the changes
-	if (EditorWindow::GetSingleton()->settings.autoApplyChanges) {
-		ApplyChanges();
-	}
-
-	EditorWindow::GetSingleton()->ShowNotification(
-		std::format("Inherited all settings from {}", parentWidget->GetEditorID()),
-		ImVec4(0.0f, 1.0f, 0.5f, 1.0f),
-		3.0f);
-}
-
-void WeatherWidget::SaveFeatureSettings()
-{
-	auto* weatherManager = WeatherManager::GetSingleton();
-
-	// Collect all feature names from both current and original settings to detect deletions
-	std::set<std::string> allFeatureNames;
-	for (const auto& [featureName, _] : settings.featureSettings) {
-		allFeatureNames.insert(featureName);
-	}
-	for (const auto& [featureName, _] : originalSettings.featureSettings) {
-		allFeatureNames.insert(featureName);
-	}
-
-	// Save current settings or clear deleted features
-	for (const auto& featureName : allFeatureNames) {
-		auto it = settings.featureSettings.find(featureName);
-		weatherManager->SaveSettingsToWeather(
-			weather,
-			featureName,
-			it != settings.featureSettings.end() ? it->second : json::object());
-	}
-}
-
-void WeatherWidget::LoadFeatureSettings()
-{
-	auto* weatherManager = WeatherManager::GetSingleton();
-	auto* globalRegistry = WeatherVariables::GlobalWeatherRegistry::GetSingleton();
-
-	// First, validate that all feature settings in the JSON exist as loaded features.
-	// Prevents loading a .json that references features that aren't installed. (Will load only settings for installed features.)
-	// Should make it very obvious to users when they have not followed the correct installation instructions.
-	if (js.contains("featureSettings") && js["featureSettings"].is_object()) {
-		std::vector<std::string> missingFeatures;
-
-		for (const auto& [featureName, featureJson] : js["featureSettings"].items()) {
-			if (featureJson.empty()) {
-				continue;
-			}
-
-			// Check if this feature exists and is loaded
-			bool featureExists = false;
-			for (auto* feature : Feature::GetFeatureList()) {
-				if (feature && feature->loaded && feature->GetShortName() == featureName) {
-					featureExists = true;
-					break;
-				}
-			}
-
-			if (!featureExists) {
-				missingFeatures.push_back(featureName);
-			}
-		}
-
-		// If we found missing features, warn the user
-		if (!missingFeatures.empty()) {
-			std::string missingList;
-			for (size_t i = 0; i < missingFeatures.size(); ++i) {
-				if (i > 0)
-					missingList += ", ";
-				missingList += missingFeatures[i];
-			}
-
-			// Show notification
-			EditorWindow::GetSingleton()->ShowNotification(
-				std::format("Warning: {} references missing feature(s): {}", GetEditorID(), missingList),
-				ImVec4(1.0f, 0.6f, 0.0f, 1.0f),
-				5.0f);
-
-			// Add to Feature Issues system for each missing feature
-			for (const auto& featureName : missingFeatures) {
-				FeatureIssues::FeatureFileInfo fileInfo;
-				fileInfo.featureName = featureName;
-
-				FeatureIssues::AddFeatureIssue(
-					featureName,
-					"",
-					std::format("Weather '{}' contains settings for this feature, but the feature is not loaded. "
-								"The weather-specific parameters will be ignored until the feature is installed and loaded.",
-						GetEditorID()),
-					FeatureIssues::FeatureIssueInfo::IssueType::UNKNOWN,
-					fileInfo,
-					"");
-			}
-
-			logger::warn("{}: JSON contains feature settings for features that are not loaded: {}", GetEditorID(), missingList);
-		}
-	}
-
-	// Now load settings for features that ARE loaded
-	for (auto* feature : Feature::GetFeatureList()) {
-		if (!feature || !feature->loaded) {
-			continue;
-		}
-
-		std::string featureName = feature->GetShortName();
-
-		// Check if feature has registered weather variables
-		if (!globalRegistry->HasWeatherSupport(featureName)) {
-			continue;
-		}
-
-		json featureJson;
-		if (weatherManager->LoadSettingsFromWeather(weather, featureName, featureJson)) {
-			settings.featureSettings[featureName] = featureJson;
-		}
-	}
-}
-
-void WeatherWidget::ApplyChanges()
-{
-	SetWeatherValues();
-}
-
-void WeatherWidget::RevertChanges()
-{
-	auto* weatherManager = WeatherManager::GetSingleton();
-
-	// If this weather is currently active, reset enabled feature overrides to user defaults
-	if (weather == weatherManager->GetCurrentWeathers().currentWeather) {
-		auto* globalRegistry = WeatherVariables::GlobalWeatherRegistry::GetSingleton();
-
-		for (const auto& [featureName, featureSettings] : settings.featureSettings) {
-			if (!featureSettings.value("__enabled", false) || !globalRegistry->HasWeatherSupport(featureName)) {
-				continue;
-			}
-
-			globalRegistry->EndFeatureTransition(featureName);
-
-			if (auto* featureRegistry = globalRegistry->GetFeatureRegistry(featureName)) {
-				for (const auto& var : featureRegistry->GetVariables()) {
-					var->SetToUserSettings();
-				}
-			}
-		}
-	}
-
-	weatherManager->ClearAllFeatureSettingsForWeather(weather);
-	settings = vanillaSettings;
-	ApplyChanges();
-}
-
-void WeatherWidget::Delete()
-{
-	// Clear cache and local settings before base Delete() to prevent reloading stale data
-	auto* weatherManager = WeatherManager::GetSingleton();
-	weatherManager->ClearAllFeatureSettingsForWeather(weather);
-	settings.featureSettings.clear();
-
-	Widget::Delete();
-}
-
-bool WeatherWidget::Settings::operator==(const Settings& o) const
-{
-	return parent == o.parent &&
-	       inheritFlags == o.inheritFlags &&
-	       weatherProperties == o.weatherProperties &&
-	       weatherColors == o.weatherColors &&
-	       fogProperties == o.fogProperties &&
-	       std::equal(std::begin(atmosphereColors), std::end(atmosphereColors), std::begin(o.atmosphereColors)) &&
-	       std::equal(std::begin(dalc), std::end(dalc), std::begin(o.dalc)) &&
-	       std::equal(std::begin(clouds), std::end(clouds), std::begin(o.clouds)) &&
-	       std::equal(std::begin(imageSpaces), std::end(imageSpaces), std::begin(o.imageSpaces)) &&
-	       featureSettings == o.featureSettings;
-}
-
-bool WeatherWidget::HasUnsavedChanges() const
-{
-	return !(settings == originalSettings);
-}
-
-void WeatherWidget::DrawFeatureSettings()
-{
-	ImGui::TextWrapped(
-		"Configure feature-specific settings that will be applied when this weather is active. "
-		"These override the feature's global settings for this weather only.");
-	ImGui::Spacing();
-
-	auto* globalRegistry = WeatherVariables::GlobalWeatherRegistry::GetSingleton();
-
-	for (auto* feature : Feature::GetFeatureList()) {
-		if (!feature || !feature->loaded) {
-			continue;
-		}
-
-		std::string featureName = feature->GetShortName();
-		auto* featureRegistry = globalRegistry->GetFeatureRegistry(featureName);
-
-		// Check if feature has registered weather variables
-		if (!featureRegistry) {
-			continue;
-		}
-
-		std::string displayName = feature->GetName();
-		auto featureIt = settings.featureSettings.find(featureName);
-		const json* featureJsonView = (featureIt != settings.featureSettings.end()) ? &featureIt->second : nullptr;
-		auto getFeatureJson = [&]() -> json& {
-			return settings.featureSettings.try_emplace(featureName, json::object()).first->second;
-		};
-
-		// Handle pending navigation - auto-expand this feature if it matches
-		bool shouldAutoExpand = (pendingFeatureNavigation == featureName);
-		if (shouldAutoExpand) {
-			ImGui::SetNextItemOpen(true);
-		}
-
-		if (ImGui::TreeNodeEx(displayName.c_str(), ImGuiTreeNodeFlags_SpanAvailWidth)) {
-			// Check if weather-specific overrides are enabled (using special key)
-			bool overridesEnabled = featureJsonView ? featureJsonView->value("__enabled", false) : false;
-
-			// Weather-specific override toggle
-			ImGui::PushStyleColor(ImGuiCol_Button, overridesEnabled ? ImVec4(0.2f, 0.7f, 0.2f, 1.0f) : ImVec4(0.5f, 0.5f, 0.5f, 1.0f));
-			ImGui::PushStyleColor(ImGuiCol_ButtonHovered, overridesEnabled ? ImVec4(0.3f, 0.8f, 0.3f, 1.0f) : ImVec4(0.6f, 0.6f, 0.6f, 1.0f));
-			ImGui::PushStyleColor(ImGuiCol_ButtonActive, overridesEnabled ? ImVec4(0.1f, 0.6f, 0.1f, 1.0f) : ImVec4(0.4f, 0.4f, 0.4f, 1.0f));
-
-			bool toggleClicked = ImGui::Button(overridesEnabled ? "Using Weather-Specific Settings" : "Using Global Settings", ImVec2(-1, 0));
-
-			ImGui::PopStyleColor(3);
-
-			if (auto _tt = Util::HoverTooltipWrapper()) {
-				if (overridesEnabled) {
-					ImGui::Text("This weather has custom overrides for this feature.");
-					ImGui::Text("Click to disable overrides and use global settings instead.");
-					ImGui::Text("(Settings will be preserved but not applied)");
-				} else {
-					ImGui::Text("This weather uses global feature settings.");
-					ImGui::Text("Click to enable weather-specific overrides.");
-				}
-			}
-
-			if (toggleClicked) {
-				auto& featureJson = getFeatureJson();
-				if (overridesEnabled) {
-					// Disable overrides - mark as disabled but keep the settings
-					featureJson["__enabled"] = false;
-				} else {
-					// Enable overrides - mark as enabled
-					featureJson["__enabled"] = true;
-					// If no settings exist yet, copy current global values as starting point
-					bool hasActualSettings = false;
-					for (auto it = featureJson.begin(); it != featureJson.end(); ++it) {
-						if (it.key() != "__enabled") {
-							hasActualSettings = true;
-							break;
-						}
-					}
-					if (!hasActualSettings) {
-						const auto& variables = featureRegistry->GetVariables();
-						for (const auto& var : variables) {
-							json tempJson;
-							var->SaveToJson(tempJson);
-							std::string varName = var->GetName();
-							if (tempJson.contains(varName)) {
-								featureJson[varName] = tempJson[varName];
-							}
-						}
-					}
-				}
-				EditorWindow::GetSingleton()->PushUndoState(this);
-				if (EditorWindow::GetSingleton()->settings.autoApplyChanges) {
-					ApplyChanges();
-				}
-			}
-
+			ImGui::TextWrapped("Form record references used by this weather.");
 			ImGui::Spacing();
 			ImGui::Separator();
 			ImGui::Spacing();
+			auto* editorWindow = EditorWindow::GetSingleton();
 
-			// Only show controls if weather-specific overrides are enabled
-			if (overridesEnabled) {
-				auto& featureJson = getFeatureJson();
-				// Draw UI for each registered variable
-				const auto& variables = featureRegistry->GetVariables();
-				bool modified = false;
+			bool recordChanged = false;
+			bool hasParent = editorWindow->settings.enableInheritFromParent && HasParent();
+			WeatherWidget* parentWidget = hasParent ? GetParent() : nullptr;
 
-				for (const auto& var : variables) {
-					std::string varName = var->GetName();
-					std::string varDisplayName = var->GetDisplayName();
-					std::string tooltip = var->GetTooltip();
+			// ImageSpace Records (per time of day)
+			if (ImGui::CollapsingHeader("ImageSpace", ImGuiTreeNodeFlags_DefaultOpen)) {
+				for (int i = 0; i < ColorTimes::kTotal; i++) {
+					ImGui::PushID(i);
+					std::string label = ColorTimeLabel(i);
+					std::string inheritKey = "ImageSpace_" + std::to_string(i);
 
-					ImGui::PushID(varName.c_str());
-
-					// Check if this variable has a weather-specific value
-					bool hasOverride = featureJson.contains(varName);
-
-					json currentValue;
-					if (hasOverride) {
-						currentValue = featureJson.at(varName);
-					} else {
-						json tempJson;
-						var->SaveToJson(tempJson);
-						auto it = tempJson.find(varName);
-						if (it == tempJson.end()) {
-							ImGui::PopID();
-							continue;
+					// Inherit checkbox
+					if (hasParent) {
+						bool& inheritFlag = settings.inheritFlags[inheritKey];
+						if (ImGui::Checkbox(("##inherit_" + inheritKey).c_str(), &inheritFlag)) {
+							if (inheritFlag && parentWidget) {
+								weather->imageSpaces[i] = parentWidget->weather->imageSpaces[i];
+								recordChanged = true;
+							}
 						}
-						currentValue = *it;
+						if (ImGui::IsItemHovered()) {
+							ImGui::SetTooltip(inheritFlag ? "Inheriting from parent" : "Inherit from parent");
+						}
+						ImGui::SameLine();
 					}
 
-					// Try to detect variable type and render appropriate control
-					// Check if it's a bool variable first
-					if (auto* boolVar = dynamic_cast<WeatherVariables::WeatherVariable<bool>*>(var.get())) {
-						bool value = currentValue.get<bool>();
-
-						if (ImGui::Checkbox(varDisplayName.c_str(), &value)) {
-							featureJson[varName] = value;
-							modified = true;
-						}
-
-						if (auto _tt = Util::HoverTooltipWrapper()) {
-							ImGui::Text("%s", tooltip.c_str());
-						}
-
-						// Right-click context menu to reset individual values
-						if (ImGui::BeginPopupContextItem()) {
-							if (ImGui::MenuItem("Reset to Global")) {
-								featureJson.erase(varName);
-								modified = true;
+					ImGui::Text("%s:", label.c_str());
+					ImGui::SameLine(hasParent ? 120.0f : 100.0f);
+					if (WeatherUtils::DrawFormPickerCached("##ImageSpace", weather->imageSpaces[i], editorWindow->imageSpaceWidgets, false, true)) {
+						recordChanged = true;
+					}  // Add "Open" button
+					if (weather->imageSpaces[i]) {
+						ImGui::SameLine();
+						if (ImGui::SmallButton(std::format("Open##{}", i).c_str())) {
+							for (auto& widget : editorWindow->imageSpaceWidgets) {
+								if (widget->form == weather->imageSpaces[i]) {
+									widget->SetOpen(true);
+									break;
+								}
 							}
-							ImGui::EndPopup();
 						}
-
-					} else if (auto* floatVar = dynamic_cast<WeatherVariables::FloatVariable*>(var.get())) {
-						float value = currentValue.get<float>();
-						float minVal = floatVar->GetMin();
-						float maxVal = floatVar->GetMax();
-
-						if (ImGui::SliderFloat(varDisplayName.c_str(), &value, minVal, maxVal, "%.3f")) {
-							featureJson[varName] = value;
-							modified = true;
-						}
-
-						if (auto _tt = Util::HoverTooltipWrapper()) {
-							ImGui::Text("%s", tooltip.c_str());
-						}
-
-						// Right-click context menu to reset individual values
-						if (ImGui::BeginPopupContextItem()) {
-							if (ImGui::MenuItem("Reset to Global")) {
-								featureJson.erase(varName);
-								modified = true;
-							}
-							ImGui::EndPopup();
-						}
-
-					} else if (auto* float3Var = dynamic_cast<WeatherVariables::Float3Variable*>(var.get())) {
-						// Handle float3 (color) variables
-						float3 value = currentValue.get<float3>();
-						float colorArray[3] = { value.x, value.y, value.z };
-
-						if (ImGui::ColorEdit3(varDisplayName.c_str(), colorArray)) {
-							featureJson[varName] = json{ colorArray[0], colorArray[1], colorArray[2] };
-							modified = true;
-						}
-
-						if (auto _tt = Util::HoverTooltipWrapper()) {
-							ImGui::Text("%s", tooltip.c_str());
-						}
-
-						if (ImGui::BeginPopupContextItem()) {
-							if (ImGui::MenuItem("Reset to Global")) {
-								featureJson.erase(varName);
-								modified = true;
-							}
-							ImGui::EndPopup();
-						}
-
-					} else if (auto* float4Var = dynamic_cast<WeatherVariables::Float4Variable*>(var.get())) {
-						// Handle float4 (color with alpha) variables
-						float4 value = currentValue.get<float4>();
-						float colorArray[4] = { value.x, value.y, value.z, value.w };
-
-						if (ImGui::ColorEdit4(varDisplayName.c_str(), colorArray)) {
-							featureJson[varName] = json{ colorArray[0], colorArray[1], colorArray[2], colorArray[3] };
-							modified = true;
-						}
-
-						if (auto _tt = Util::HoverTooltipWrapper()) {
-							ImGui::Text("%s", tooltip.c_str());
-						}
-
-						if (ImGui::BeginPopupContextItem()) {
-							if (ImGui::MenuItem("Reset to Global")) {
-								featureJson.erase(varName);
-								modified = true;
-							}
-							ImGui::EndPopup();
-						}
-
-					} else {
-						// Generic handling for other types
-						ImGui::TextDisabled("%s: %s", varDisplayName.c_str(), currentValue.dump().c_str());
-						if (auto _tt = Util::HoverTooltipWrapper()) {
-							ImGui::TextColored(ImVec4(1.0f, 0.5f, 0.0f, 1.0f), "Unsupported Variable Type");
-							ImGui::Text("%s", tooltip.c_str());
-							ImGui::Separator();
-							ImGui::TextWrapped("This variable type doesn't have a custom UI implementation yet. The raw JSON value is shown above.");
+						if (ImGui::IsItemHovered()) {
+							ImGui::SetTooltip("Open this ImageSpace for editing");
 						}
 					}
 
 					ImGui::PopID();
 				}
+				ImGui::Spacing();
+			}
 
-				if (modified) {
+			// Volumetric Lighting Records (per time of day)
+			if (ImGui::CollapsingHeader("Volumetric Lighting", ImGuiTreeNodeFlags_DefaultOpen)) {
+				for (int i = 0; i < ColorTimes::kTotal; i++) {
+					ImGui::PushID(100 + i);
+					std::string label = ColorTimeLabel(i);
+					std::string inheritKey = "VolumetricLighting_" + std::to_string(i);
+
+					// Inherit checkbox
+					if (hasParent) {
+						bool& inheritFlag = settings.inheritFlags[inheritKey];
+						if (ImGui::Checkbox(("##inherit_" + inheritKey).c_str(), &inheritFlag)) {
+							if (inheritFlag && parentWidget) {
+								weather->volumetricLighting[i] = parentWidget->weather->volumetricLighting[i];
+								recordChanged = true;
+							}
+						}
+						if (ImGui::IsItemHovered()) {
+							ImGui::SetTooltip(inheritFlag ? "Inheriting from parent" : "Inherit from parent");
+						}
+						ImGui::SameLine();
+					}
+
+					ImGui::Text("%s:", label.c_str());
+					ImGui::SameLine(hasParent ? 120.0f : 100.0f);
+					if (WeatherUtils::DrawFormPickerCached("##VolumetricLighting", weather->volumetricLighting[i], editorWindow->volumetricLightingWidgets, false, true)) {
+						recordChanged = true;
+					}  // Add "Open" button
+					if (weather->volumetricLighting[i]) {
+						ImGui::SameLine();
+						if (ImGui::SmallButton(std::format("Open##{}", i).c_str())) {
+							for (auto& widget : editorWindow->volumetricLightingWidgets) {
+								if (widget->form == weather->volumetricLighting[i]) {
+									widget->SetOpen(true);
+									break;
+								}
+							}
+						}
+						if (ImGui::IsItemHovered()) {
+							ImGui::SetTooltip("Open this Volumetric Lighting for editing");
+						}
+					}
+
+					ImGui::PopID();
+				}
+				ImGui::Spacing();
+			}
+
+			// Precipitation Data
+			if (ImGui::CollapsingHeader("Precipitation", ImGuiTreeNodeFlags_DefaultOpen)) {
+				// Inherit checkbox
+				if (hasParent) {
+					bool& inheritFlag = settings.inheritFlags["Precipitation"];
+					if (ImGui::Checkbox("##inherit_Precipitation", &inheritFlag)) {
+						if (inheritFlag && parentWidget) {
+							weather->precipitationData = parentWidget->weather->precipitationData;
+							recordChanged = true;
+						}
+					}
+					if (ImGui::IsItemHovered()) {
+						ImGui::SetTooltip(inheritFlag ? "Inheriting from parent" : "Inherit from parent");
+					}
+					ImGui::SameLine();
+				}
+
+				ImGui::Text("Particle Shader:");
+				ImGui::SameLine(hasParent ? 170.0f : 150.0f);
+				if (WeatherUtils::DrawFormPickerCached("##Precipitation", weather->precipitationData, editorWindow->precipitationWidgets, false, true)) {
+					recordChanged = true;
+				}  // Add "Open" button
+				if (weather->precipitationData) {
+					ImGui::SameLine();
+					if (ImGui::SmallButton("Open##Precip")) {
+						for (auto& widget : editorWindow->precipitationWidgets) {
+							if (widget->form == weather->precipitationData) {
+								widget->SetOpen(true);
+								break;
+							}
+						}
+					}
+					if (ImGui::IsItemHovered()) {
+						ImGui::SetTooltip("Open this Precipitation for editing");
+					}
+				}
+
+				ImGui::Spacing();
+			}
+
+			// Visual Effect (Reference Effect)
+			if (ImGui::CollapsingHeader("Visual Effect", ImGuiTreeNodeFlags_DefaultOpen)) {
+				// Inherit checkbox
+				if (hasParent) {
+					bool& inheritFlag = settings.inheritFlags["ReferenceEffect"];
+					if (ImGui::Checkbox("##inherit_ReferenceEffect", &inheritFlag)) {
+						if (inheritFlag && parentWidget) {
+							weather->referenceEffect = parentWidget->weather->referenceEffect;
+							recordChanged = true;
+						}
+					}
+					if (ImGui::IsItemHovered()) {
+						ImGui::SetTooltip(inheritFlag ? "Inheriting from parent" : "Inherit from parent");
+					}
+					ImGui::SameLine();
+				}
+
+				ImGui::Text("Reference Effect:");
+				ImGui::SameLine(hasParent ? 170.0f : 150.0f);
+				if (WeatherUtils::DrawFormPickerCached("##ReferenceEffect", weather->referenceEffect, editorWindow->referenceEffectWidgets, false, true)) {
+					recordChanged = true;
+				}  // Add "Open" button
+				if (weather->referenceEffect) {
+					ImGui::SameLine();
+					if (ImGui::SmallButton("Open##RefEffect")) {
+						for (auto& widget : editorWindow->referenceEffectWidgets) {
+							if (widget->form == weather->referenceEffect) {
+								widget->SetOpen(true);
+								break;
+							}
+						}
+					}
+					if (ImGui::IsItemHovered()) {
+						ImGui::SetTooltip("Open this Visual Effect for editing");
+					}
+				}
+
+				ImGui::Spacing();
+			}
+
+			if (recordChanged && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
+				ApplyChanges();
+			}
+
+			EndScrollableContent();
+			ImGui::EndTabItem();
+		}
+		ImGui::EndTabBar();
+		ImGui::End();
+	}
+
+	void WeatherWidget::LoadSettings()
+	{
+		bool hadErrors = false;
+		if (!js.empty()) {
+			try {
+				// Attempt to load settings from JSON
+				settings = js;
+
+				// Validate that critical fields were loaded correctly
+				if (js.contains("weatherProperties") && settings.weatherProperties.empty() && !js["weatherProperties"].empty()) {
+					logger::warn("Weather {}: weatherProperties loaded but appears empty, reverting to vanilla values", GetEditorID());
+					hadErrors = true;
+				}
+				if (js.contains("weatherColors") && settings.weatherColors.empty() && !js["weatherColors"].empty()) {
+					logger::warn("Weather {}: weatherColors loaded but appears empty, reverting to vanilla values", GetEditorID());
+					hadErrors = true;
+				}
+				if (js.contains("fogProperties") && settings.fogProperties.empty() && !js["fogProperties"].empty()) {
+					logger::warn("Weather {}: fogProperties loaded but appears empty, reverting to vanilla values", GetEditorID());
+					hadErrors = true;
+				}
+
+				if (hadErrors) {
+					// Fallback to vanilla/game values
+					settings = vanillaSettings;
+					EditorWindow::GetSingleton()->ShowNotification(
+						std::format("Some values failed to load for {}", GetEditorID()),
+						ImVec4(1.0f, 0.0f, 0.0f, 1.0f),
+						3.0f);
+				} else {
+					logger::info("Weather {}: Loaded settings - {} weather properties, {} colors, {} fog properties",
+						GetEditorID(),
+						settings.weatherProperties.size(),
+						settings.weatherColors.size(),
+						settings.fogProperties.size());
+				}
+
+			} catch (const nlohmann::json::exception& e) {
+				logger::error("Weather {}: Failed to deserialize settings from JSON: {}", GetEditorID(), e.what());
+				// Fallback to vanilla/game values on exception
+				settings = vanillaSettings;
+				EditorWindow::GetSingleton()->ShowNotification(
+					std::format("Some values failed to load for {}", GetEditorID()),
+					ImVec4(1.0f, 0.0f, 0.0f, 1.0f),
+					3.0f);
+				return;
+			}
+		} else {
+			settings = vanillaSettings;
+		}
+		InitializeInheritFlags();
+		if (!js.empty()) {
+			LoadFeatureSettings();
+		}
+		originalSettings = settings;
+		ApplyChanges();
+	}
+
+	void WeatherWidget::SaveSettings()
+	{
+		SaveFeatureSettings();
+
+		try {
+			js = settings;
+
+			if (js.is_null()) {
+				logger::error("Weather {}: Serialization produced null JSON!", GetEditorID());
+			} else if (!js.contains("weatherProperties")) {
+				logger::error("Weather {}: Serialized JSON missing weatherProperties field!", GetEditorID());
+			} else if (!js.contains("atmosphereColors")) {
+				logger::error("Weather {}: Serialized JSON missing atmosphereColors field!", GetEditorID());
+			} else if (!js.contains("clouds")) {
+				logger::error("Weather {}: Serialized JSON missing clouds field!", GetEditorID());
+			} else {
+				originalSettings = settings;
+			}
+
+		} catch (const nlohmann::json::exception& e) {
+			logger::error("Weather {}: Failed to serialize settings to JSON: {}", GetEditorID(), e.what());
+		}
+	}
+
+	WeatherWidget* WeatherWidget::GetParent()
+	{
+		auto editorWindow = EditorWindow::GetSingleton();
+		auto& widgets = editorWindow->weatherWidgets;
+
+		auto temp = std::find_if(widgets.begin(), widgets.end(), [&](const auto& w) { return w->GetEditorID() == settings.parent; });
+		if (temp != widgets.end())
+			return (WeatherWidget*)temp->get();
+
+		return nullptr;
+	}
+
+	bool WeatherWidget::HasParent() const
+	{
+		return settings.parent != "None";
+	}
+
+	void WeatherWidget::SetWeatherValues()
+	{
+		std::map<std::string, int>& weatherProps = settings.weatherProperties;
+		std::map<std::string, float3>& weatherColors = settings.weatherColors;
+		std::map<std::string, float>& fogProperties = settings.fogProperties;
+
+		auto& data = weather->data;
+		auto& colorData = weather->colorData;
+		auto& fogData = weather->fogData;
+
+		weather->data.transDelta = (int8_t)weatherProps["Trans Delta"];
+
+		// Sun
+		data.sunGlare = (int8_t)weatherProps["Sun Glare"];
+		data.sunDamage = (int8_t)weatherProps["Sun Damage"];
+
+		// Precipitation
+		data.precipitationBeginFadeIn = (int8_t)weatherProps["Precipitation Begin Fade In"];
+		data.precipitationEndFadeOut = (int8_t)weatherProps["Precipitation End Fade Out"];
+
+		// Lightning
+		data.thunderLightningBeginFadeIn = (int8_t)weatherProps["Thunder Lightning Begin Fade In"];
+		data.thunderLightningEndFadeOut = (int8_t)weatherProps["Thunder Lightning End Fade Out"];
+		data.thunderLightningFrequency = (int8_t)weatherProps["Thunder Lightning Frequency"];
+		Float3ToColor(weatherColors["Lightning Color"], weather->data.lightningColor);
+
+		// Visual Effects
+		data.visualEffectBegin = (int8_t)weatherProps["Visual Effect Begin"];
+		data.visualEffectEnd = (int8_t)weatherProps["Visual Effect End"];
+
+		// Wind
+		data.windSpeed = (uint8_t)weatherProps["Wind Speed"];
+		data.windDirection = (int8_t)weatherProps["Wind Direction"];
+		data.windDirectionRange = (int8_t)weatherProps["Wind Direction Range"];
+
+		// Fog
+		fogData.dayNear = fogProperties["Day Near"];
+		fogData.dayFar = fogProperties["Day Far"];
+		fogData.dayPower = fogProperties["Day Power"];
+		fogData.dayMax = fogProperties["Day Max"];
+		fogData.nightNear = fogProperties["Night Near"];
+		fogData.nightFar = fogProperties["Night Far"];
+		fogData.nightPower = fogProperties["Night Power"];
+		fogData.nightMax = fogProperties["Night Max"];
+
+		// Atmosphere colors
+		for (size_t i = 0; i < ColorTypes::kTotal; i++) {
+			for (size_t j = 0; j < ColorTimes::kTotal; j++) {
+				auto& color = colorData[i][j];
+				Float3ToColor(settings.atmosphereColors[i].colorTimes[j], color);
+			}
+		}
+
+		//DALC
+		for (size_t i = 0; i < ColorTimes::kTotal; i++) {
+			auto& dalc = weather->directionalAmbientLightingColors[i];
+			auto& settingsDalc = settings.dalc[i];
+			dalc.fresnelPower = settingsDalc.fresnelPower;
+
+			Float3ToColor(settingsDalc.specular, dalc.specular);
+
+			Float3ToColor(settingsDalc.directional[0].max, dalc.directional.x.max);
+			Float3ToColor(settingsDalc.directional[0].min, dalc.directional.x.min);
+
+			Float3ToColor(settingsDalc.directional[1].max, dalc.directional.y.max);
+			Float3ToColor(settingsDalc.directional[1].min, dalc.directional.y.min);
+
+			Float3ToColor(settingsDalc.directional[2].max, dalc.directional.z.max);
+			Float3ToColor(settingsDalc.directional[2].min, dalc.directional.z.min);
+		}
+
+		// Clouds
+		uint32_t disabledBits = 0;
+		for (size_t i = 0; i < TESWeather::kTotalLayers; i++) {
+			auto& settingsCloud = settings.clouds[i];
+
+			weather->cloudLayerSpeedX[i] = (int8_t)settingsCloud.cloudLayerSpeedX;
+			weather->cloudLayerSpeedY[i] = (int8_t)settingsCloud.cloudLayerSpeedY;
+
+			if (!settingsCloud.enabled) {
+				disabledBits |= (1 << i);
+			}
+
+			auto& cloudColors = weather->cloudColorData[i];
+			auto& cloudAlphas = weather->cloudAlpha[i];
+
+			for (int j = 0; j < ColorTimes::kTotal; j++) {
+				cloudAlphas[j] = settingsCloud.cloudAlpha[j];
+				Float3ToColor(settingsCloud.color[j], cloudColors[j]);
+			}
+		}
+		weather->cloudLayerDisabledBits = disabledBits;
+
+		// If this weather is currently active, immediately apply feature settings to game memory
+		auto* weatherManager = WeatherManager::GetSingleton();
+		if (weatherManager->GetCurrentWeathers().currentWeather == weather) {
+			auto* globalRegistry = WeatherVariables::GlobalWeatherRegistry::GetSingleton();
+			json emptyWeather;
+
+			for (const auto& [featureName, featureSettings] : settings.featureSettings) {
+				if (!featureSettings.value("__enabled", false) || !globalRegistry->HasWeatherSupport(featureName)) {
+					continue;
+				}
+
+				// Filter out __enabled flag and apply settings
+				json filteredSettings = featureSettings;
+				filteredSettings.erase("__enabled");
+				globalRegistry->UpdateFeatureFromWeathers(featureName, emptyWeather, filteredSettings, 1.0f);
+			}
+		}
+	}
+
+	void WeatherWidget::InitializeInheritFlags()
+	{
+		auto& flags = settings.inheritFlags;
+		auto ensureFlag = [&](const std::string& key) {
+			flags.try_emplace(key, false);
+		};
+
+		static const char* kFixedKeys[] = {
+			"Precipitation",
+			"ReferenceEffect",
+			"DALC_Specular",
+			"DALC_Fresnel",
+			"DALC_DirXMax",
+			"DALC_DirXMin",
+			"DALC_DirYMax",
+			"DALC_DirYMin",
+			"DALC_DirZMax",
+			"DALC_DirZMin",
+			"Fog_Near",
+			"Fog_Far",
+			"Fog_Power",
+			"Fog_Max",
+			"Sun Damage",
+			"Wind Speed",
+			"Wind Direction",
+			"Wind Direction Range",
+			"Precipitation Begin Fade In",
+			"Precipitation End Fade Out",
+			"Thunder Lightning Begin Fade In",
+			"Thunder Lightning End Fade Out",
+			"Thunder Lightning Frequency",
+			"Lightning Color",
+			"Visual Effect Begin",
+			"Visual Effect End",
+			"Trans Delta",
+		};
+		for (const char* key : kFixedKeys) {
+			ensureFlag(key);
+		}
+
+		for (int i = 0; i < ColorTimes::kTotal; i++) {
+			ensureFlag(std::format("ImageSpace_{}", i));
+			ensureFlag(std::format("VolumetricLighting_{}", i));
+		}
+
+		for (int i = 0; i < ColorTypes::kTotal; i++) {
+			ensureFlag(std::format("Atmosphere_{}", ColorTypeLabel(i)));
+		}
+
+		for (int i = 0; i < TESWeather::kTotalLayers; i++) {
+			ensureFlag(std::format("Cloud{}_Color", i));
+			ensureFlag(std::format("Cloud{}_Alpha", i));
+		}
+	}
+
+	void WeatherWidget::LoadWeatherValues()
+	{
+		std::map<std::string, int>& weatherProps = settings.weatherProperties;
+		std::map<std::string, float3>& weatherColors = settings.weatherColors;
+		std::map<std::string, float>& fogProperties = settings.fogProperties;
+
+		const auto& data = weather->data;
+		const auto& colorData = weather->colorData;
+		const auto& fogData = weather->fogData;
+
+		weatherProps["Trans Delta"] = data.transDelta;
+
+		// Sun
+		weatherProps["Sun Glare"] = data.sunGlare;
+		weatherProps["Sun Damage"] = data.sunDamage;
+
+		// Precipitation
+		weatherProps["Precipitation Begin Fade In"] = data.precipitationBeginFadeIn;
+		weatherProps["Precipitation End Fade Out"] = data.precipitationEndFadeOut;
+
+		// Lightning
+		weatherProps["Thunder Lightning Begin Fade In"] = data.thunderLightningBeginFadeIn;
+		weatherProps["Thunder Lightning End Fade Out"] = data.thunderLightningEndFadeOut;
+		weatherProps["Thunder Lightning Frequency"] = data.thunderLightningFrequency;
+		ColorToFloat3(data.lightningColor, weatherColors["Lightning Color"]);
+
+		// Visual Effects
+		weatherProps["Visual Effect Begin"] = data.visualEffectBegin;
+		weatherProps["Visual Effect End"] = data.visualEffectEnd;
+
+		// Wind
+		weatherProps["Wind Speed"] = data.windSpeed;
+		weatherProps["Wind Direction"] = data.windDirection;
+		weatherProps["Wind Direction Range"] = data.windDirectionRange;
+
+		// Fog
+		fogProperties["Day Near"] = fogData.dayNear;
+		fogProperties["Day Far"] = fogData.dayFar;
+		fogProperties["Night Near"] = fogData.nightNear;
+		fogProperties["Night Far"] = fogData.nightFar;
+		fogProperties["Day Power"] = fogData.dayPower;
+		fogProperties["Night Power"] = fogData.nightPower;
+		fogProperties["Day Max"] = fogData.dayMax;
+		fogProperties["Night Max"] = fogData.nightMax;
+
+		// Atmosphere color
+		for (size_t i = 0; i < ColorTypes::kTotal; i++) {
+			for (size_t j = 0; j < ColorTimes::kTotal; j++) {
+				auto& color = colorData[i][j];
+				ColorToFloat3(color, settings.atmosphereColors[i].colorTimes[j]);
+			}
+		}
+
+		// DALC
+		for (size_t i = 0; i < ColorTimes::kTotal; i++) {
+			auto& dalc = weather->directionalAmbientLightingColors[i];
+			auto& settingsDalc = settings.dalc[i];
+			settingsDalc.fresnelPower = dalc.fresnelPower;
+
+			ColorToFloat3(dalc.specular, settingsDalc.specular);
+
+			ColorToFloat3(dalc.directional.x.max, settingsDalc.directional[0].max);
+			ColorToFloat3(dalc.directional.x.min, settingsDalc.directional[0].min);
+
+			ColorToFloat3(dalc.directional.y.max, settingsDalc.directional[1].max);
+			ColorToFloat3(dalc.directional.y.min, settingsDalc.directional[1].min);
+
+			ColorToFloat3(dalc.directional.z.max, settingsDalc.directional[2].max);
+			ColorToFloat3(dalc.directional.z.min, settingsDalc.directional[2].min);
+		}
+
+		// Clouds
+		for (size_t i = 0; i < TESWeather::kTotalLayers; i++) {
+			auto& settingsCloud = settings.clouds[i];
+
+			settingsCloud.cloudLayerSpeedX = weather->cloudLayerSpeedX[i];
+			settingsCloud.cloudLayerSpeedY = weather->cloudLayerSpeedY[i];
+			settingsCloud.enabled = !(weather->cloudLayerDisabledBits & (1 << i));
+			settingsCloud.texturePath = weather->cloudTextures[i].textureName.c_str();
+
+			auto& cloudColors = weather->cloudColorData[i];
+			auto& cloudAlphas = weather->cloudAlpha[i];
+
+			for (int j = 0; j < ColorTimes::kTotal; j++) {
+				settingsCloud.cloudAlpha[j] = cloudAlphas[j];
+				ColorToFloat3(cloudColors[j], settingsCloud.color[j]);
+			}
+		}
+	}
+
+	void WeatherWidget::DrawDALCSettings()
+	{
+		auto editorWindow = EditorWindow::GetSingleton();
+		bool hasParent = editorWindow->settings.enableInheritFromParent && HasParent();
+		WeatherWidget* parentWidget = hasParent ? GetParent() : nullptr;
+
+		bool changed = false;
+
+		if (TOD::BeginTODTable("DALC_TOD_Table")) {
+			TOD::RenderTODHeader();
+			TOD::DrawTODSeparator();
+
+			// Prepare arrays for TOD rendering
+			float3 specularColors[4];
+			float fresnelPowers[4];
+			float3 directionalXMax[4], directionalXMin[4];
+			float3 directionalYMax[4], directionalYMin[4];
+			float3 directionalZMax[4], directionalZMin[4];
+
+			// Parent values
+			float3 parentSpecular[4] = {};
+			float parentFresnel[4] = {};
+			float3 parentDirXMax[4] = {}, parentDirXMin[4] = {};
+			float3 parentDirYMax[4] = {}, parentDirYMin[4] = {};
+			float3 parentDirZMax[4] = {}, parentDirZMin[4] = {};
+
+			for (int i = 0; i < ColorTimes::kTotal; i++) {
+				specularColors[i] = settings.dalc[i].specular;
+				fresnelPowers[i] = settings.dalc[i].fresnelPower;
+				directionalXMax[i] = settings.dalc[i].directional[0].max;
+				directionalXMin[i] = settings.dalc[i].directional[0].min;
+				directionalYMax[i] = settings.dalc[i].directional[1].max;
+				directionalYMin[i] = settings.dalc[i].directional[1].min;
+				directionalZMax[i] = settings.dalc[i].directional[2].max;
+				directionalZMin[i] = settings.dalc[i].directional[2].min;
+
+				if (parentWidget) {
+					parentSpecular[i] = parentWidget->settings.dalc[i].specular;
+					parentFresnel[i] = parentWidget->settings.dalc[i].fresnelPower;
+					parentDirXMax[i] = parentWidget->settings.dalc[i].directional[0].max;
+					parentDirXMin[i] = parentWidget->settings.dalc[i].directional[0].min;
+					parentDirYMax[i] = parentWidget->settings.dalc[i].directional[1].max;
+					parentDirYMin[i] = parentWidget->settings.dalc[i].directional[1].min;
+					parentDirZMax[i] = parentWidget->settings.dalc[i].directional[2].max;
+					parentDirZMin[i] = parentWidget->settings.dalc[i].directional[2].min;
+				}
+			}
+
+			// Draw with per-parameter inheritance
+			if (hasParent) {
+				if (TOD::DrawTODColorRow("Specular", specularColors, settings.inheritFlags["DALC_Specular"], parentSpecular)) {
+					for (int i = 0; i < ColorTimes::kTotal; i++)
+						settings.dalc[i].specular = specularColors[i];
+					changed = true;
+				}
+
+				if (TOD::DrawTODFloatRow("Fresnel Power", fresnelPowers, settings.inheritFlags["DALC_Fresnel"], parentFresnel, 0.0f, 10.0f)) {
+					for (int i = 0; i < ColorTimes::kTotal; i++)
+						settings.dalc[i].fresnelPower = fresnelPowers[i];
+					changed = true;
+				}
+			} else {
+				if (TOD::DrawTODColorRow("Specular", specularColors)) {
+					for (int i = 0; i < ColorTimes::kTotal; i++)
+						settings.dalc[i].specular = specularColors[i];
+					changed = true;
+				}
+
+				if (TOD::DrawTODFloatRow("Fresnel Power", fresnelPowers, 0.0f, 10.0f)) {
+					for (int i = 0; i < ColorTimes::kTotal; i++)
+						settings.dalc[i].fresnelPower = fresnelPowers[i];
+					changed = true;
+				}
+			}
+
+			TOD::DrawTODSeparator();
+
+			// Directional colors with per-parameter inheritance
+			if (hasParent) {
+				if (TOD::DrawTODColorRow("Directional +X", directionalXMax, settings.inheritFlags["DALC_DirXMax"], parentDirXMax)) {
+					for (int i = 0; i < ColorTimes::kTotal; i++)
+						settings.dalc[i].directional[0].max = directionalXMax[i];
+					changed = true;
+				}
+
+				if (TOD::DrawTODColorRow("Directional -X", directionalXMin, settings.inheritFlags["DALC_DirXMin"], parentDirXMin)) {
+					for (int i = 0; i < ColorTimes::kTotal; i++)
+						settings.dalc[i].directional[0].min = directionalXMin[i];
+					changed = true;
+				}
+
+				if (TOD::DrawTODColorRow("Directional +Y", directionalYMax, settings.inheritFlags["DALC_DirYMax"], parentDirYMax)) {
+					for (int i = 0; i < ColorTimes::kTotal; i++)
+						settings.dalc[i].directional[1].max = directionalYMax[i];
+					changed = true;
+				}
+
+				if (TOD::DrawTODColorRow("Directional -Y", directionalYMin, settings.inheritFlags["DALC_DirYMin"], parentDirYMin)) {
+					for (int i = 0; i < ColorTimes::kTotal; i++)
+						settings.dalc[i].directional[1].min = directionalYMin[i];
+					changed = true;
+				}
+
+				if (TOD::DrawTODColorRow("Directional +Z", directionalZMax, settings.inheritFlags["DALC_DirZMax"], parentDirZMax)) {
+					for (int i = 0; i < ColorTimes::kTotal; i++)
+						settings.dalc[i].directional[2].max = directionalZMax[i];
+					changed = true;
+				}
+
+				if (TOD::DrawTODColorRow("Directional -Z", directionalZMin, settings.inheritFlags["DALC_DirZMin"], parentDirZMin)) {
+					for (int i = 0; i < ColorTimes::kTotal; i++)
+						settings.dalc[i].directional[2].min = directionalZMin[i];
+					changed = true;
+				}
+			} else {
+				if (TOD::DrawTODColorRow("Directional +X", directionalXMax)) {
+					for (int i = 0; i < ColorTimes::kTotal; i++)
+						settings.dalc[i].directional[0].max = directionalXMax[i];
+					changed = true;
+				}
+
+				if (TOD::DrawTODColorRow("Directional -X", directionalXMin)) {
+					for (int i = 0; i < ColorTimes::kTotal; i++)
+						settings.dalc[i].directional[0].min = directionalXMin[i];
+					changed = true;
+				}
+
+				if (TOD::DrawTODColorRow("Directional +Y", directionalYMax)) {
+					for (int i = 0; i < ColorTimes::kTotal; i++)
+						settings.dalc[i].directional[1].max = directionalYMax[i];
+					changed = true;
+				}
+
+				if (TOD::DrawTODColorRow("Directional -Y", directionalYMin)) {
+					for (int i = 0; i < ColorTimes::kTotal; i++)
+						settings.dalc[i].directional[1].min = directionalYMin[i];
+					changed = true;
+				}
+
+				if (TOD::DrawTODColorRow("Directional +Z", directionalZMax)) {
+					for (int i = 0; i < ColorTimes::kTotal; i++)
+						settings.dalc[i].directional[2].max = directionalZMax[i];
+					changed = true;
+				}
+
+				if (TOD::DrawTODColorRow("Directional -Z", directionalZMin)) {
+					for (int i = 0; i < ColorTimes::kTotal; i++)
+						settings.dalc[i].directional[2].min = directionalZMin[i];
+					changed = true;
+				}
+			}
+
+			TOD::EndTODTable();
+		}
+		if (changed && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
+			ApplyChanges();
+		}
+	}
+
+	void WeatherWidget::DrawWeatherColorSettings()
+	{
+		auto editorWindow = EditorWindow::GetSingleton();
+		bool hasParent = editorWindow->settings.enableInheritFromParent && HasParent();
+		WeatherWidget* parentWidget = hasParent ? GetParent() : nullptr;
+
+		bool changed = false;
+
+		if (TOD::BeginTODTable("AtmosphereColors_Table")) {
+			TOD::RenderTODHeader();
+			TOD::DrawTODSeparator();
+
+			// Organized display order: group related sky/fog/lighting properties
+			static const int displayOrder[] = {
+				0,   // Sky Upper
+				7,   // Sky Lower
+				8,   // Horizon
+				1,   // Fog Near
+				12,  // Fog Far
+				3,   // Ambient
+				4,   // Sunlight
+				15,  // Sun Glare
+				5,   // Sun
+				6,   // Stars
+				16,  // Moon Glare
+				9,   // Effect Lighting
+				10,  // Cloud LOD Diffuse
+				11,  // Cloud LOD Ambient
+				13,  // Sky Statics
+				14,  // Water Multiplier
+				2,   // Unknown
+			};
+
+			for (int idx = 0; idx < ColorTypes::kTotal; idx++) {
+				int i = displayOrder[idx];
+				std::string colorTypeLabel = ColorTypeLabel(i);
+
+				if (hasParent) {
+					float3 parentColors[4];
+					for (int j = 0; j < 4; j++)
+						parentColors[j] = parentWidget->settings.atmosphereColors[i].colorTimes[j];
+
+					std::string inheritKey = "Atmosphere_" + colorTypeLabel;
+					if (TOD::DrawTODColorRow(colorTypeLabel.c_str(), settings.atmosphereColors[i].colorTimes, settings.inheritFlags[inheritKey], parentColors)) {
+						changed = true;
+					}
+				} else {
+					if (TOD::DrawTODColorRow(colorTypeLabel.c_str(), settings.atmosphereColors[i].colorTimes)) {
+						changed = true;
+					}
+				}
+			}
+
+			TOD::EndTODTable();
+		}
+
+		if (changed && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
+			ApplyChanges();
+		}
+	}
+
+	void WeatherWidget::DrawCloudSettings()
+	{
+		auto editorWindow = EditorWindow::GetSingleton();
+		bool hasParent = editorWindow->settings.enableInheritFromParent && HasParent();
+		WeatherWidget* parentWidget = hasParent ? GetParent() : nullptr;
+
+		bool changed = false;
+		bool enableChanged = false;
+
+		// OpenOnArrow|OpenOnDoubleClick prevents accidental collapse when clicking
+		// the [Enabled] badge area that overlaps the right side of the header.
+		constexpr ImGuiTreeNodeFlags flags = ImGuiTreeNodeFlags_OpenOnArrow | ImGuiTreeNodeFlags_OpenOnDoubleClick;
+		constexpr char kEnabledBadge[] = "[Enabled]";
+
+		for (int i = 0; i < TESWeather::kTotalLayers; i++) {
+			std::string layer = std::format("Layer {}", i);
+			bool layerEnabled = settings.clouds[i].enabled;
+
+			if (!layerEnabled) {
+				ImGui::PushStyleColor(ImGuiCol_Header, ImGui::GetStyleColorVec4(ImGuiCol_FrameBg));
+				ImGui::PushStyleColor(ImGuiCol_HeaderHovered, ImGui::GetStyleColorVec4(ImGuiCol_FrameBgHovered));
+				ImGui::PushStyleColor(ImGuiCol_HeaderActive, ImGui::GetStyleColorVec4(ImGuiCol_FrameBgActive));
+			}
+
+			// Label is constant so the storage ID never changes — open/closed state always persists.
+			// [Enabled] badge is overlaid on the header via the draw list instead of altering the label.
+			float headerScreenY = ImGui::GetCursorScreenPos().y;
+			bool layerOpen = ImGui::CollapsingHeader(layer.c_str(), flags);
+
+			if (!layerEnabled)
+				ImGui::PopStyleColor(3);
+
+			if (layerEnabled) {
+				const ImVec2 badgeSize = ImGui::CalcTextSize(kEnabledBadge);
+				const float headerHeight = ImGui::GetFrameHeight();
+				const ImVec2 badgePos = {
+					ImGui::GetWindowPos().x + ImGui::GetContentRegionMax().x - badgeSize.x,
+					headerScreenY + (headerHeight - badgeSize.y) * 0.5f
+				};
+				ImGui::GetWindowDrawList()->AddText(badgePos, ImGui::GetColorU32(ImGuiCol_CheckMark), kEnabledBadge);
+			}
+
+			if (layerOpen) {
+				ImGui::Indent(10.0f);
+				ImGui::Spacing();
+
+				// Begin horizontal layout for enable checkbox and sliders on left, texture on right
+				ImGui::BeginGroup();
+
+				if (ImGui::Checkbox(std::format("Enable##{}", layer).c_str(), &layerEnabled)) {
+					settings.clouds[i].enabled = layerEnabled;
+					enableChanged = true;
+					changed = true;
+				}
+
+				ImGui::Spacing();
+				ImGui::Spacing();
+
+				// Make sliders 1/3 width
+				ImGui::PushItemWidth(ImGui::GetContentRegionAvail().x * 0.4f);
+				if (WeatherUtils::DrawSliderInt8(std::format("Cloud Layer Speed Y##{}", layer), settings.clouds[i].cloudLayerSpeedY))
+					changed = true;
+				ImGui::Spacing();
+				if (WeatherUtils::DrawSliderInt8(std::format("Cloud Layer Speed X##{}", layer), settings.clouds[i].cloudLayerSpeedX))
+					changed = true;
+				ImGui::PopItemWidth();
+
+				ImGui::EndGroup();
+
+				// Draw texture in upper right if available
+				if (!settings.clouds[i].texturePath.empty()) {
+					auto* texture = GetCloudTexture(i);
+					if (texture) {
+						ImGui::SameLine(0.0f, 20.0f);
+						ImGui::BeginGroup();
+						float textureSize = 128.0f;
+						ImGui::Image((void*)texture, ImVec2(textureSize, textureSize));
+						// Small grey subtext below image, clamped to texture width
+						ImGui::PushStyleColor(ImGuiCol_Text, ImGui::GetStyleColorVec4(ImGuiCol_TextDisabled));
+						ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + textureSize);
+						ImGui::TextWrapped("%s", settings.clouds[i].texturePath.c_str());
+						ImGui::PopTextWrapPos();
+						ImGui::PopStyleColor();
+						ImGui::EndGroup();
+					}
+				}
+
+				ImGui::Spacing();
+				ImGui::Spacing();
+				if (TOD::BeginTODTable((layer + "_TOD_Table").c_str())) {
+					TOD::RenderTODHeader();
+					TOD::DrawTODSeparator();
+
+					if (hasParent) {
+						float3 parentColors[4];
+						float parentAlphas[4];
+						for (int j = 0; j < 4; j++) {
+							parentColors[j] = parentWidget->settings.clouds[i].color[j];
+							parentAlphas[j] = parentWidget->settings.clouds[i].cloudAlpha[j];
+						}
+
+						std::string colorKey = std::format("Cloud{}_Color", i);
+						std::string alphaKey = std::format("Cloud{}_Alpha", i);
+
+						if (TOD::DrawTODColorRow("Cloud Color", settings.clouds[i].color, settings.inheritFlags[colorKey], parentColors)) {
+							changed = true;
+						}
+
+						if (TOD::DrawTODFloatRow("Cloud Alpha", settings.clouds[i].cloudAlpha, settings.inheritFlags[alphaKey], parentAlphas, 0.0f, 1.0f)) {
+							changed = true;
+						}
+					} else {
+						if (TOD::DrawTODColorRow("Cloud Color", settings.clouds[i].color)) {
+							changed = true;
+						}
+
+						if (TOD::DrawTODFloatRow("Cloud Alpha", settings.clouds[i].cloudAlpha, 0.0f, 1.0f)) {
+							changed = true;
+						}
+					}
+
+					TOD::EndTODTable();
+				}
+
+				ImGui::Spacing();
+				ImGui::Unindent(10.0f);
+			}
+		}
+		if (enableChanged) {
+			// Apply enable/disable immediately for instant feedback, regardless of autoApplyChanges.
+			editorWindow->PushUndoState(this);
+			ApplyChanges();
+			if (editorWindow->IsWeatherLocked() && editorWindow->GetLockedWeather() == weather) {
+				if (auto sky = RE::Sky::GetSingleton()) {
+					sky->ForceWeather(weather, true);  // override=true for immediate application; matches "instant feedback" intent above
+				}
+			}
+		} else if (changed && editorWindow->settings.autoApplyChanges) {
+			editorWindow->PushUndoState(this);
+			ApplyChanges();
+		}
+	}
+
+	void WeatherWidget::DrawFogSettings()
+	{
+		auto editorWindow = EditorWindow::GetSingleton();
+		bool hasParent = editorWindow->settings.enableInheritFromParent && HasParent();
+		WeatherWidget* parentWidget = hasParent ? GetParent() : nullptr;
+
+		bool changed = false;
+
+		if (ImGui::BeginTable("FogTable", 3, ImGuiTableFlags_BordersInnerV | ImGuiTableFlags_SizingFixedFit)) {
+			ImGui::TableSetupColumn("Parameter", ImGuiTableColumnFlags_WidthFixed, 200.0f);
+			ImGui::TableSetupColumn("Day", ImGuiTableColumnFlags_WidthFixed, 250.0f);
+			ImGui::TableSetupColumn("Night", ImGuiTableColumnFlags_WidthFixed, 250.0f);
+
+			// Header row
+			ImGui::TableNextRow();
+			ImGui::TableSetColumnIndex(0);
+			ImGui::TableSetColumnIndex(1);
+			ImGui::Text("Day");
+			ImGui::TableSetColumnIndex(2);
+			ImGui::Text("Night");
+
+			ImGui::TableNextRow();
+			ImGui::TableSetColumnIndex(0);
+			ImGui::Separator();
+			ImGui::TableSetColumnIndex(1);
+			ImGui::Separator();
+			ImGui::TableSetColumnIndex(2);
+			ImGui::Separator();
+
+			// Near
+			ImGui::TableNextRow();
+			ImGui::TableSetColumnIndex(0);
+			if (hasParent) {
+				ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(0.15f, 0.15f, 0.15f, 1.0f));
+				ImGui::PushStyleColor(ImGuiCol_CheckMark, ImVec4(0.5f, 0.5f, 0.5f, 1.0f));
+				ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(2, 2));
+				ImGui::Checkbox("##FogNear", &settings.inheritFlags["Fog_Near"]);
+				if (settings.inheritFlags["Fog_Near"]) {
+					settings.fogProperties["Day Near"] = parentWidget->settings.fogProperties["Day Near"];
+					settings.fogProperties["Night Near"] = parentWidget->settings.fogProperties["Night Near"];
+					changed = true;
+				}
+				ImGui::PopStyleVar();
+				ImGui::PopStyleColor(2);
+				ImGui::SameLine();
+			}
+			ImGui::Text("Near");
+			ImGui::TableSetColumnIndex(1);
+			ImGui::SetNextItemWidth(-1);
+			if (ImGui::SliderFloat("##FogDayNear", &settings.fogProperties["Day Near"], 0.0f, 1000000.0f, "%.0f"))
+				changed = true;
+			ImGui::TableSetColumnIndex(2);
+			ImGui::SetNextItemWidth(-1);
+			if (ImGui::SliderFloat("##FogNightNear", &settings.fogProperties["Night Near"], 0.0f, 1000000.0f, "%.0f"))
+				changed = true;
+
+			// Far
+			ImGui::TableNextRow();
+			ImGui::TableSetColumnIndex(0);
+			if (hasParent) {
+				ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(0.15f, 0.15f, 0.15f, 1.0f));
+				ImGui::PushStyleColor(ImGuiCol_CheckMark, ImVec4(0.5f, 0.5f, 0.5f, 1.0f));
+				ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(2, 2));
+				ImGui::Checkbox("##FogFar", &settings.inheritFlags["Fog_Far"]);
+				if (settings.inheritFlags["Fog_Far"]) {
+					settings.fogProperties["Day Far"] = parentWidget->settings.fogProperties["Day Far"];
+					settings.fogProperties["Night Far"] = parentWidget->settings.fogProperties["Night Far"];
+					changed = true;
+				}
+				ImGui::PopStyleVar();
+				ImGui::PopStyleColor(2);
+				ImGui::SameLine();
+			}
+			ImGui::Text("Far");
+			ImGui::TableSetColumnIndex(1);
+			ImGui::SetNextItemWidth(-1);
+			if (ImGui::SliderFloat("##FogDayFar", &settings.fogProperties["Day Far"], 0.0f, 1000000.0f, "%.0f"))
+				changed = true;
+			ImGui::TableSetColumnIndex(2);
+			ImGui::SetNextItemWidth(-1);
+			if (ImGui::SliderFloat("##FogNightFar", &settings.fogProperties["Night Far"], 0.0f, 1000000.0f, "%.0f"))
+				changed = true;
+
+			// Power
+			ImGui::TableNextRow();
+			ImGui::TableSetColumnIndex(0);
+			if (hasParent) {
+				ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(0.15f, 0.15f, 0.15f, 1.0f));
+				ImGui::PushStyleColor(ImGuiCol_CheckMark, ImVec4(0.5f, 0.5f, 0.5f, 1.0f));
+				ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(2, 2));
+				ImGui::Checkbox("##FogPower", &settings.inheritFlags["Fog_Power"]);
+				if (settings.inheritFlags["Fog_Power"]) {
+					settings.fogProperties["Day Power"] = parentWidget->settings.fogProperties["Day Power"];
+					settings.fogProperties["Night Power"] = parentWidget->settings.fogProperties["Night Power"];
+					changed = true;
+				}
+				ImGui::PopStyleVar();
+				ImGui::PopStyleColor(2);
+				ImGui::SameLine();
+			}
+			ImGui::Text("Power");
+			ImGui::TableSetColumnIndex(1);
+			ImGui::SetNextItemWidth(-1);
+			if (ImGui::SliderFloat("##FogDayPower", &settings.fogProperties["Day Power"], 0.0f, 10.0f, "%.3f"))
+				changed = true;
+			ImGui::TableSetColumnIndex(2);
+			ImGui::SetNextItemWidth(-1);
+			if (ImGui::SliderFloat("##FogNightPower", &settings.fogProperties["Night Power"], 0.0f, 10.0f, "%.3f"))
+				changed = true;
+
+			// Max
+			ImGui::TableNextRow();
+			ImGui::TableSetColumnIndex(0);
+			if (hasParent) {
+				ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(0.15f, 0.15f, 0.15f, 1.0f));
+				ImGui::PushStyleColor(ImGuiCol_CheckMark, ImVec4(0.5f, 0.5f, 0.5f, 1.0f));
+				ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(2, 2));
+				ImGui::Checkbox("##FogMax", &settings.inheritFlags["Fog_Max"]);
+				if (settings.inheritFlags["Fog_Max"]) {
+					settings.fogProperties["Day Max"] = parentWidget->settings.fogProperties["Day Max"];
+					settings.fogProperties["Night Max"] = parentWidget->settings.fogProperties["Night Max"];
+					changed = true;
+				}
+				ImGui::PopStyleVar();
+				ImGui::PopStyleColor(2);
+				ImGui::SameLine();
+			}
+			ImGui::Text("Max");
+			ImGui::TableSetColumnIndex(1);
+			ImGui::SetNextItemWidth(-1);
+			if (ImGui::SliderFloat("##FogDayMax", &settings.fogProperties["Day Max"], 0.0f, 1.0f, "%.3f"))
+				changed = true;
+			ImGui::TableSetColumnIndex(2);
+			ImGui::SetNextItemWidth(-1);
+			if (ImGui::SliderFloat("##FogNightMax", &settings.fogProperties["Night Max"], 0.0f, 1.0f, "%.3f"))
+				changed = true;
+
+			ImGui::EndTable();
+		}
+
+		if (changed && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
+			ApplyChanges();
+		}
+	}
+
+	void WeatherWidget::DrawProperties(std::string category, std::map<std::string, int> properties)
+	{
+		// Check if any property matches search (only check if search is active)
+		bool hasMatchingProperty = false;
+		if (searchBuffer[0] != '\0') {
+			hasMatchingProperty = MatchesSearch(category);
+			if (!hasMatchingProperty) {
+				for (auto& p : properties) {
+					if (MatchesSearch(p.first)) {
+						hasMatchingProperty = true;
+						break;
+					}
+				}
+			}
+			// Skip this entire category if nothing matches
+			if (!hasMatchingProperty) {
+				return;
+			}
+		}
+
+		ImGui::TextColored(ImVec4(0.7f, 0.9f, 1.0f, 1.0f), "%s", category.c_str());
+
+		bool changed = false;
+		auto* editorWindow = EditorWindow::GetSingleton();
+		bool hasParent = editorWindow->settings.enableInheritFromParent && HasParent();
+
+		for (auto& p : properties) {
+			// Filter individual properties based on search
+			if (searchBuffer[0] != '\0' && !MatchesSearch(p.first)) {
+				continue;
+			}
+
+			// Apply highlight effect if this setting should be highlighted
+			if (ShouldHighlight(p.first)) {
+				float elapsed = static_cast<float>(ImGui::GetTime()) - highlightStartTime;
+				float alpha = 0.3f * (1.0f - std::abs(elapsed - 0.5f) * 2.0f);
+				ImGui::PushStyleColor(ImGuiCol_FrameBg, ImVec4(0.3f, 0.6f, 1.0f, alpha));
+				ImGui::PushStyleColor(ImGuiCol_FrameBgHovered, ImVec4(0.4f, 0.7f, 1.0f, alpha));
+			}
+
+			// Inherit checkbox
+			if (hasParent) {
+				bool& inheritFlag = settings.inheritFlags[p.first];
+				if (ImGui::Checkbox(("##inherit_" + p.first).c_str(), &inheritFlag)) {
+					if (inheritFlag) {
+						InheritFromParent(p.first);
+						changed = true;
+					}
+				}
+				if (ImGui::IsItemHovered()) {
+					ImGui::SetTooltip(inheritFlag ? "Inheriting from parent" : "Inherit from parent");
+				}
+				ImGui::SameLine();
+			}
+
+			switch (p.second) {
+			case 0:
+				if (WeatherUtils::DrawSliderInt8(p.first, settings.weatherProperties[p.first]))
+					changed = true;
+				break;
+			case 1:
+				if (WeatherUtils::DrawColorEdit(p.first, settings.weatherColors[p.first]))
+					changed = true;
+				break;
+			case 2:
+				if (WeatherUtils::DrawSliderUint8(p.first, settings.weatherProperties[p.first]))
+					changed = true;
+				break;
+			case 3:
+				if (WeatherUtils::DrawSliderFloat(p.first, settings.fogProperties[p.first]))
+					changed = true;
+				break;
+			default:
+				break;
+			}
+
+			if (ShouldHighlight(p.first)) {
+				ImGui::PopStyleColor(2);
+			}
+		}
+
+		if (changed && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
+			ApplyChanges();
+		}
+
+		ImGui::Spacing();
+		ImGui::Separator();
+		ImGui::Spacing();
+	}
+
+	void WeatherWidget::InheritFromParent(const std::string& property)
+	{
+		if (!HasParent())
+			return;
+
+		WeatherWidget* parentWidget = GetParent();
+		if (!parentWidget)
+			return;
+
+		if (settings.weatherProperties.find(property) != settings.weatherProperties.end()) {
+			settings.weatherProperties[property] = parentWidget->settings.weatherProperties[property];
+		} else if (settings.weatherColors.find(property) != settings.weatherColors.end()) {
+			settings.weatherColors[property] = parentWidget->settings.weatherColors[property];
+		} else if (settings.fogProperties.find(property) != settings.fogProperties.end()) {
+			settings.fogProperties[property] = parentWidget->settings.fogProperties[property];
+		}
+	}
+
+	void WeatherWidget::InheritAllFromParent()
+	{
+		if (!HasParent())
+			return;
+
+		WeatherWidget* parentWidget = GetParent();
+		if (!parentWidget)
+			return;
+
+		// Copy all weather properties
+		for (const auto& [key, value] : parentWidget->settings.weatherProperties) {
+			settings.weatherProperties[key] = value;
+		}
+
+		// Copy all weather colors
+		for (const auto& [key, value] : parentWidget->settings.weatherColors) {
+			settings.weatherColors[key] = value;
+		}
+
+		// Copy all fog properties
+		for (const auto& [key, value] : parentWidget->settings.fogProperties) {
+			settings.fogProperties[key] = value;
+		}
+
+		// Copy atmosphere colors
+		for (int i = 0; i < ColorTypes::kTotal; i++) {
+			settings.atmosphereColors[i] = parentWidget->settings.atmosphereColors[i];
+		}
+
+		// Copy DALC settings
+		for (int i = 0; i < ColorTimes::kTotal; i++) {
+			settings.dalc[i] = parentWidget->settings.dalc[i];
+		}
+
+		// Copy cloud settings
+		for (int i = 0; i < TESWeather::kTotalLayers; i++) {
+			settings.clouds[i] = parentWidget->settings.clouds[i];
+		}
+
+		// Set all inherit flags to true
+		settings.inheritFlags["DALC_Specular"] = true;
+		settings.inheritFlags["DALC_Fresnel"] = true;
+		settings.inheritFlags["DALC_DirXMax"] = true;
+		settings.inheritFlags["DALC_DirXMin"] = true;
+		settings.inheritFlags["DALC_DirYMax"] = true;
+		settings.inheritFlags["DALC_DirYMin"] = true;
+		settings.inheritFlags["DALC_DirZMax"] = true;
+		settings.inheritFlags["DALC_DirZMin"] = true;
+
+		settings.inheritFlags["Fog_Near"] = true;
+		settings.inheritFlags["Fog_Far"] = true;
+		settings.inheritFlags["Fog_Power"] = true;
+		settings.inheritFlags["Fog_Max"] = true;
+
+		// Atmosphere colors
+		static const int displayOrder[] = { 0, 7, 8, 1, 12, 3, 4, 5, 6, 9, 10, 11, 13, 14, 15, 16, 2 };
+		for (int idx = 0; idx < ColorTypes::kTotal; idx++) {
+			int i = displayOrder[idx];
+			std::string colorTypeLabel = ColorTypeLabel(i);
+			settings.inheritFlags["Atmosphere_" + colorTypeLabel] = true;
+		}
+
+		// Cloud settings
+		for (int i = 0; i < TESWeather::kTotalLayers; i++) {
+			settings.inheritFlags[std::format("Cloud{}_Color", i)] = true;
+			settings.inheritFlags[std::format("Cloud{}_Alpha", i)] = true;
+		}
+
+		// Apply the changes
+		if (EditorWindow::GetSingleton()->settings.autoApplyChanges) {
+			ApplyChanges();
+		}
+
+		EditorWindow::GetSingleton()->ShowNotification(
+			std::format("Inherited all settings from {}", parentWidget->GetEditorID()),
+			ImVec4(0.0f, 1.0f, 0.5f, 1.0f),
+			3.0f);
+	}
+
+	void WeatherWidget::SaveFeatureSettings()
+	{
+		auto* weatherManager = WeatherManager::GetSingleton();
+
+		// Collect all feature names from both current and original settings to detect deletions
+		std::set<std::string> allFeatureNames;
+		for (const auto& [featureName, _] : settings.featureSettings) {
+			allFeatureNames.insert(featureName);
+		}
+		for (const auto& [featureName, _] : originalSettings.featureSettings) {
+			allFeatureNames.insert(featureName);
+		}
+
+		// Save current settings or clear deleted features
+		for (const auto& featureName : allFeatureNames) {
+			auto it = settings.featureSettings.find(featureName);
+			weatherManager->SaveSettingsToWeather(
+				weather,
+				featureName,
+				it != settings.featureSettings.end() ? it->second : json::object());
+		}
+	}
+
+	void WeatherWidget::LoadFeatureSettings()
+	{
+		auto* weatherManager = WeatherManager::GetSingleton();
+		auto* globalRegistry = WeatherVariables::GlobalWeatherRegistry::GetSingleton();
+
+		// First, validate that all feature settings in the JSON exist as loaded features.
+		// Prevents loading a .json that references features that aren't installed. (Will load only settings for installed features.)
+		// Should make it very obvious to users when they have not followed the correct installation instructions.
+		if (js.contains("featureSettings") && js["featureSettings"].is_object()) {
+			std::vector<std::string> missingFeatures;
+
+			for (const auto& [featureName, featureJson] : js["featureSettings"].items()) {
+				if (featureJson.empty()) {
+					continue;
+				}
+
+				// Check if this feature exists and is loaded
+				bool featureExists = false;
+				for (auto* feature : Feature::GetFeatureList()) {
+					if (feature && feature->loaded && feature->GetShortName() == featureName) {
+						featureExists = true;
+						break;
+					}
+				}
+
+				if (!featureExists) {
+					missingFeatures.push_back(featureName);
+				}
+			}
+
+			// If we found missing features, warn the user
+			if (!missingFeatures.empty()) {
+				std::string missingList;
+				for (size_t i = 0; i < missingFeatures.size(); ++i) {
+					if (i > 0)
+						missingList += ", ";
+					missingList += missingFeatures[i];
+				}
+
+				// Show notification
+				EditorWindow::GetSingleton()->ShowNotification(
+					std::format("Warning: {} references missing feature(s): {}", GetEditorID(), missingList),
+					ImVec4(1.0f, 0.6f, 0.0f, 1.0f),
+					5.0f);
+
+				// Add to Feature Issues system for each missing feature
+				for (const auto& featureName : missingFeatures) {
+					FeatureIssues::FeatureFileInfo fileInfo;
+					fileInfo.featureName = featureName;
+
+					FeatureIssues::AddFeatureIssue(
+						featureName,
+						"",
+						std::format("Weather '{}' contains settings for this feature, but the feature is not loaded. "
+									"The weather-specific parameters will be ignored until the feature is installed and loaded.",
+							GetEditorID()),
+						FeatureIssues::FeatureIssueInfo::IssueType::UNKNOWN,
+						fileInfo,
+						"");
+				}
+
+				logger::warn("{}: JSON contains feature settings for features that are not loaded: {}", GetEditorID(), missingList);
+			}
+		}
+
+		// Now load settings for features that ARE loaded
+		for (auto* feature : Feature::GetFeatureList()) {
+			if (!feature || !feature->loaded) {
+				continue;
+			}
+
+			std::string featureName = feature->GetShortName();
+
+			// Check if feature has registered weather variables
+			if (!globalRegistry->HasWeatherSupport(featureName)) {
+				continue;
+			}
+
+			json featureJson;
+			if (weatherManager->LoadSettingsFromWeather(weather, featureName, featureJson)) {
+				settings.featureSettings[featureName] = featureJson;
+			}
+		}
+	}
+
+	void WeatherWidget::ApplyChanges()
+	{
+		SetWeatherValues();
+	}
+
+	void WeatherWidget::RevertChanges()
+	{
+		auto* weatherManager = WeatherManager::GetSingleton();
+
+		// If this weather is currently active, reset enabled feature overrides to user defaults
+		if (weather == weatherManager->GetCurrentWeathers().currentWeather) {
+			auto* globalRegistry = WeatherVariables::GlobalWeatherRegistry::GetSingleton();
+
+			for (const auto& [featureName, featureSettings] : settings.featureSettings) {
+				if (!featureSettings.value("__enabled", false) || !globalRegistry->HasWeatherSupport(featureName)) {
+					continue;
+				}
+
+				globalRegistry->EndFeatureTransition(featureName);
+
+				if (auto* featureRegistry = globalRegistry->GetFeatureRegistry(featureName)) {
+					for (const auto& var : featureRegistry->GetVariables()) {
+						var->SetToUserSettings();
+					}
+				}
+			}
+		}
+
+		weatherManager->ClearAllFeatureSettingsForWeather(weather);
+		settings = vanillaSettings;
+		ApplyChanges();
+	}
+
+	void WeatherWidget::Delete()
+	{
+		// Clear cache and local settings before base Delete() to prevent reloading stale data
+		auto* weatherManager = WeatherManager::GetSingleton();
+		weatherManager->ClearAllFeatureSettingsForWeather(weather);
+		settings.featureSettings.clear();
+
+		Widget::Delete();
+	}
+
+	bool WeatherWidget::Settings::operator==(const Settings& o) const
+	{
+		return parent == o.parent &&
+		       inheritFlags == o.inheritFlags &&
+		       weatherProperties == o.weatherProperties &&
+		       weatherColors == o.weatherColors &&
+		       fogProperties == o.fogProperties &&
+		       std::equal(std::begin(atmosphereColors), std::end(atmosphereColors), std::begin(o.atmosphereColors)) &&
+		       std::equal(std::begin(dalc), std::end(dalc), std::begin(o.dalc)) &&
+		       std::equal(std::begin(clouds), std::end(clouds), std::begin(o.clouds)) &&
+		       std::equal(std::begin(imageSpaces), std::end(imageSpaces), std::begin(o.imageSpaces)) &&
+		       featureSettings == o.featureSettings;
+	}
+
+	bool WeatherWidget::HasUnsavedChanges() const
+	{
+		return !(settings == originalSettings);
+	}
+
+	void WeatherWidget::DrawFeatureSettings()
+	{
+		ImGui::TextWrapped(
+			"Configure feature-specific settings that will be applied when this weather is active. "
+			"These override the feature's global settings for this weather only.");
+		ImGui::Spacing();
+
+		auto* globalRegistry = WeatherVariables::GlobalWeatherRegistry::GetSingleton();
+
+		for (auto* feature : Feature::GetFeatureList()) {
+			if (!feature || !feature->loaded) {
+				continue;
+			}
+
+			std::string featureName = feature->GetShortName();
+			auto* featureRegistry = globalRegistry->GetFeatureRegistry(featureName);
+
+			// Check if feature has registered weather variables
+			if (!featureRegistry) {
+				continue;
+			}
+
+			std::string displayName = feature->GetName();
+			auto featureIt = settings.featureSettings.find(featureName);
+			const json* featureJsonView = (featureIt != settings.featureSettings.end()) ? &featureIt->second : nullptr;
+			auto getFeatureJson = [&]() -> json& {
+				return settings.featureSettings.try_emplace(featureName, json::object()).first->second;
+			};
+
+			// Handle pending navigation - auto-expand this feature if it matches
+			bool shouldAutoExpand = (pendingFeatureNavigation == featureName);
+			if (shouldAutoExpand) {
+				ImGui::SetNextItemOpen(true);
+			}
+
+			if (ImGui::TreeNodeEx(displayName.c_str(), ImGuiTreeNodeFlags_SpanAvailWidth)) {
+				// Check if weather-specific overrides are enabled (using special key)
+				bool overridesEnabled = featureJsonView ? featureJsonView->value("__enabled", false) : false;
+
+				// Weather-specific override toggle
+				ImGui::PushStyleColor(ImGuiCol_Button, overridesEnabled ? ImVec4(0.2f, 0.7f, 0.2f, 1.0f) : ImVec4(0.5f, 0.5f, 0.5f, 1.0f));
+				ImGui::PushStyleColor(ImGuiCol_ButtonHovered, overridesEnabled ? ImVec4(0.3f, 0.8f, 0.3f, 1.0f) : ImVec4(0.6f, 0.6f, 0.6f, 1.0f));
+				ImGui::PushStyleColor(ImGuiCol_ButtonActive, overridesEnabled ? ImVec4(0.1f, 0.6f, 0.1f, 1.0f) : ImVec4(0.4f, 0.4f, 0.4f, 1.0f));
+
+				bool toggleClicked = ImGui::Button(overridesEnabled ? "Using Weather-Specific Settings" : "Using Global Settings", ImVec2(-1, 0));
+
+				ImGui::PopStyleColor(3);
+
+				if (auto _tt = Util::HoverTooltipWrapper()) {
+					if (overridesEnabled) {
+						ImGui::Text("This weather has custom overrides for this feature.");
+						ImGui::Text("Click to disable overrides and use global settings instead.");
+						ImGui::Text("(Settings will be preserved but not applied)");
+					} else {
+						ImGui::Text("This weather uses global feature settings.");
+						ImGui::Text("Click to enable weather-specific overrides.");
+					}
+				}
+
+				if (toggleClicked) {
+					auto& featureJson = getFeatureJson();
+					if (overridesEnabled) {
+						// Disable overrides - mark as disabled but keep the settings
+						featureJson["__enabled"] = false;
+					} else {
+						// Enable overrides - mark as enabled
+						featureJson["__enabled"] = true;
+						// If no settings exist yet, copy current global values as starting point
+						bool hasActualSettings = false;
+						for (auto it = featureJson.begin(); it != featureJson.end(); ++it) {
+							if (it.key() != "__enabled") {
+								hasActualSettings = true;
+								break;
+							}
+						}
+						if (!hasActualSettings) {
+							const auto& variables = featureRegistry->GetVariables();
+							for (const auto& var : variables) {
+								json tempJson;
+								var->SaveToJson(tempJson);
+								std::string varName = var->GetName();
+								if (tempJson.contains(varName)) {
+									featureJson[varName] = tempJson[varName];
+								}
+							}
+						}
+					}
 					EditorWindow::GetSingleton()->PushUndoState(this);
 					if (EditorWindow::GetSingleton()->settings.autoApplyChanges) {
 						ApplyChanges();
 					}
 				}
 
-			} else {
-				ImGui::TextColored({ 0.7f, 0.7f, 0.7f, 1.0f }, "Enable weather-specific overrides above to customize settings for this weather.");
-			}
+				ImGui::Spacing();
+				ImGui::Separator();
+				ImGui::Spacing();
 
-			ImGui::TreePop();
+				// Only show controls if weather-specific overrides are enabled
+				if (overridesEnabled) {
+					auto& featureJson = getFeatureJson();
+					// Draw UI for each registered variable
+					const auto& variables = featureRegistry->GetVariables();
+					bool modified = false;
+
+					for (const auto& var : variables) {
+						std::string varName = var->GetName();
+						std::string varDisplayName = var->GetDisplayName();
+						std::string tooltip = var->GetTooltip();
+
+						ImGui::PushID(varName.c_str());
+
+						// Check if this variable has a weather-specific value
+						bool hasOverride = featureJson.contains(varName);
+
+						json currentValue;
+						if (hasOverride) {
+							currentValue = featureJson.at(varName);
+						} else {
+							json tempJson;
+							var->SaveToJson(tempJson);
+							auto it = tempJson.find(varName);
+							if (it == tempJson.end()) {
+								ImGui::PopID();
+								continue;
+							}
+							currentValue = *it;
+						}
+
+						// Try to detect variable type and render appropriate control
+						// Check if it's a bool variable first
+						if (auto* boolVar = dynamic_cast<WeatherVariables::WeatherVariable<bool>*>(var.get())) {
+							bool value = currentValue.get<bool>();
+
+							if (ImGui::Checkbox(varDisplayName.c_str(), &value)) {
+								featureJson[varName] = value;
+								modified = true;
+							}
+
+							if (auto _tt = Util::HoverTooltipWrapper()) {
+								ImGui::Text("%s", tooltip.c_str());
+							}
+
+							// Right-click context menu to reset individual values
+							if (ImGui::BeginPopupContextItem()) {
+								if (ImGui::MenuItem("Reset to Global")) {
+									featureJson.erase(varName);
+									modified = true;
+								}
+								ImGui::EndPopup();
+							}
+
+						} else if (auto* floatVar = dynamic_cast<WeatherVariables::FloatVariable*>(var.get())) {
+							float value = currentValue.get<float>();
+							float minVal = floatVar->GetMin();
+							float maxVal = floatVar->GetMax();
+
+							if (ImGui::SliderFloat(varDisplayName.c_str(), &value, minVal, maxVal, "%.3f")) {
+								featureJson[varName] = value;
+								modified = true;
+							}
+
+							if (auto _tt = Util::HoverTooltipWrapper()) {
+								ImGui::Text("%s", tooltip.c_str());
+							}
+
+							// Right-click context menu to reset individual values
+							if (ImGui::BeginPopupContextItem()) {
+								if (ImGui::MenuItem("Reset to Global")) {
+									featureJson.erase(varName);
+									modified = true;
+								}
+								ImGui::EndPopup();
+							}
+
+						} else if (auto* float3Var = dynamic_cast<WeatherVariables::Float3Variable*>(var.get())) {
+							// Handle float3 (color) variables
+							float3 value = currentValue.get<float3>();
+							float colorArray[3] = { value.x, value.y, value.z };
+
+							if (ImGui::ColorEdit3(varDisplayName.c_str(), colorArray)) {
+								featureJson[varName] = json{ colorArray[0], colorArray[1], colorArray[2] };
+								modified = true;
+							}
+
+							if (auto _tt = Util::HoverTooltipWrapper()) {
+								ImGui::Text("%s", tooltip.c_str());
+							}
+
+							if (ImGui::BeginPopupContextItem()) {
+								if (ImGui::MenuItem("Reset to Global")) {
+									featureJson.erase(varName);
+									modified = true;
+								}
+								ImGui::EndPopup();
+							}
+
+						} else if (auto* float4Var = dynamic_cast<WeatherVariables::Float4Variable*>(var.get())) {
+							// Handle float4 (color with alpha) variables
+							float4 value = currentValue.get<float4>();
+							float colorArray[4] = { value.x, value.y, value.z, value.w };
+
+							if (ImGui::ColorEdit4(varDisplayName.c_str(), colorArray)) {
+								featureJson[varName] = json{ colorArray[0], colorArray[1], colorArray[2], colorArray[3] };
+								modified = true;
+							}
+
+							if (auto _tt = Util::HoverTooltipWrapper()) {
+								ImGui::Text("%s", tooltip.c_str());
+							}
+
+							if (ImGui::BeginPopupContextItem()) {
+								if (ImGui::MenuItem("Reset to Global")) {
+									featureJson.erase(varName);
+									modified = true;
+								}
+								ImGui::EndPopup();
+							}
+
+						} else {
+							// Generic handling for other types
+							ImGui::TextDisabled("%s: %s", varDisplayName.c_str(), currentValue.dump().c_str());
+							if (auto _tt = Util::HoverTooltipWrapper()) {
+								ImGui::TextColored(ImVec4(1.0f, 0.5f, 0.0f, 1.0f), "Unsupported Variable Type");
+								ImGui::Text("%s", tooltip.c_str());
+								ImGui::Separator();
+								ImGui::TextWrapped("This variable type doesn't have a custom UI implementation yet. The raw JSON value is shown above.");
+							}
+						}
+
+						ImGui::PopID();
+					}
+
+					if (modified) {
+						EditorWindow::GetSingleton()->PushUndoState(this);
+						if (EditorWindow::GetSingleton()->settings.autoApplyChanges) {
+							ApplyChanges();
+						}
+					}
+
+				} else {
+					ImGui::TextColored({ 0.7f, 0.7f, 0.7f, 1.0f }, "Enable weather-specific overrides above to customize settings for this weather.");
+				}
+
+				ImGui::TreePop();
+			}
+		}
+
+		// Clear navigation state after processing
+		if (!pendingFeatureNavigation.empty()) {
+			pendingFeatureNavigation.clear();
+			pendingSettingHighlight.clear();
 		}
 	}
 
-	// Clear navigation state after processing
-	if (!pendingFeatureNavigation.empty()) {
-		pendingFeatureNavigation.clear();
-		pendingSettingHighlight.clear();
+	void WeatherWidget::NavigateToFeatureSetting(const std::string& featureName, const std::string& settingName)
+	{
+		// Store the navigation request
+		pendingFeatureNavigation = featureName;
+		pendingSettingHighlight = settingName;
+
+		// Switch to Features tab
+		activeTabOverride = "Features";
 	}
-}
 
-void WeatherWidget::NavigateToFeatureSetting(const std::string& featureName, const std::string& settingName)
-{
-	// Store the navigation request
-	pendingFeatureNavigation = featureName;
-	pendingSettingHighlight = settingName;
+	void WeatherWidget::UpdateSearchResults()
+	{
+		searchResults.clear();
 
-	// Switch to Features tab
-	activeTabOverride = "Features";
-}
+		if (searchBuffer[0] == '\0')
+			return;
 
-void WeatherWidget::UpdateSearchResults()
-{
-	searchResults.clear();
+		std::string searchTerm = searchBuffer;
 
-	if (searchBuffer[0] == '\0')
-		return;
+		// Search in Basic tab properties
+		std::vector<std::pair<std::string, std::map<std::string, int>>> basicCategories = {
+			{ "Sun", { { "Sun Damage", 0 } } },
+			{ "Wind", { { "Wind Speed", 0 }, { "Wind Direction", 0 }, { "Wind Direction Range", 0 } } },
+			{ "Precipitation", { { "Precipitation Begin Fade In", 0 }, { "Precipitation End Fade Out", 0 } } },
+			{ "Lightning", { { "Thunder Lightning Begin Fade In", 0 }, { "Thunder Lightning End Fade Out", 0 },
+							   { "Thunder Lightning Frequency", 0 }, { "Lightning Color", 1 } } },
+			{ "Visual Effects", { { "Visual Effect Begin", 0 }, { "Visual Effect End", 0 } } },
+			{ "Weather Transition", { { "Trans Delta", 0 } } }
+		};
 
-	std::string searchTerm = searchBuffer;
+		for (const auto& [category, properties] : basicCategories) {
+			for (const auto& [propName, type] : properties) {
+				if (ContainsStringIgnoreCase(propName, searchTerm)) {
+					searchResults.push_back({ propName, "Basic", propName });
+				}
+			}
+		}
 
-	// Search in Basic tab properties
-	std::vector<std::pair<std::string, std::map<std::string, int>>> basicCategories = {
-		{ "Sun", { { "Sun Damage", 0 } } },
-		{ "Wind", { { "Wind Speed", 0 }, { "Wind Direction", 0 }, { "Wind Direction Range", 0 } } },
-		{ "Precipitation", { { "Precipitation Begin Fade In", 0 }, { "Precipitation End Fade Out", 0 } } },
-		{ "Lightning", { { "Thunder Lightning Begin Fade In", 0 }, { "Thunder Lightning End Fade Out", 0 },
-						   { "Thunder Lightning Frequency", 0 }, { "Lightning Color", 1 } } },
-		{ "Visual Effects", { { "Visual Effect Begin", 0 }, { "Visual Effect End", 0 } } },
-		{ "Weather Transition", { { "Trans Delta", 0 } } }
-	};
-
-	for (const auto& [category, properties] : basicCategories) {
-		for (const auto& [propName, type] : properties) {
+		// Search in Fog tab
+		std::vector<std::string> fogProperties = {
+			"Day Near", "Day Far", "Day Power", "Day Max",
+			"Night Near", "Night Far", "Night Power", "Night Max"
+		};
+		for (const auto& propName : fogProperties) {
 			if (ContainsStringIgnoreCase(propName, searchTerm)) {
-				searchResults.push_back({ propName, "Basic", propName });
+				searchResults.push_back({ propName, "Fog", propName });
+			}
+		}
+
+		// Search in DALC settings
+		std::vector<std::string> dalcSettings = {
+			"Fresnel Power", "Specular",
+			"Directional X Max", "Directional X Min",
+			"Directional Y Max", "Directional Y Min",
+			"Directional Z Max", "Directional Z Min"
+		};
+		for (const auto& setting : dalcSettings) {
+			if (ContainsStringIgnoreCase(setting, searchTerm)) {
+				searchResults.push_back({ setting, "Lighting (DALC)", setting });
+			}
+		}
+
+		// Search in Atmosphere Colors
+		for (int i = 0; i < ColorTypes::kTotal; i++) {
+			std::string colorType = ColorTypeLabel(i);
+			if (ContainsStringIgnoreCase(colorType, searchTerm)) {
+				searchResults.push_back({ colorType, "Atmosphere Colors", colorType });
+			}
+		}
+
+		// Search in Cloud settings
+		for (int i = 0; i < TESWeather::kTotalLayers; i++) {
+			std::string layer = std::format("Layer {}", i);
+			if (ContainsStringIgnoreCase(layer, searchTerm) ||
+				ContainsStringIgnoreCase("Cloud", searchTerm)) {
+				searchResults.push_back({ std::format("Cloud {}", layer), "Clouds", layer });
 			}
 		}
 	}
 
-	// Search in Fog tab
-	std::vector<std::string> fogProperties = {
-		"Day Near", "Day Far", "Day Power", "Day Max",
-		"Night Near", "Night Far", "Night Power", "Night Max"
-	};
-	for (const auto& propName : fogProperties) {
-		if (ContainsStringIgnoreCase(propName, searchTerm)) {
-			searchResults.push_back({ propName, "Fog", propName });
+	void WeatherWidget::NavigateToSetting(const SearchResult& result)
+	{
+		activeTabOverride = result.tabName;
+		highlightedSetting = result.settingId;
+		highlightStartTime = static_cast<float>(ImGui::GetTime());
+	}
+
+	bool WeatherWidget::ShouldHighlight(const std::string& settingId) const
+	{
+		if (highlightedSetting != settingId)
+			return false;
+
+		float elapsed = static_cast<float>(ImGui::GetTime()) - highlightStartTime;
+		return elapsed < 2.0f;
+	}
+
+	ID3D11ShaderResourceView* WeatherWidget::GetCloudTexture(int layerIndex)
+	{
+		if (cloudTextureCache.contains(layerIndex)) {
+			return cloudTextureCache[layerIndex];
 		}
-	}
 
-	// Search in DALC settings
-	std::vector<std::string> dalcSettings = {
-		"Fresnel Power", "Specular",
-		"Directional X Max", "Directional X Min",
-		"Directional Y Max", "Directional Y Min",
-		"Directional Z Max", "Directional Z Min"
-	};
-	for (const auto& setting : dalcSettings) {
-		if (ContainsStringIgnoreCase(setting, searchTerm)) {
-			searchResults.push_back({ setting, "Lighting (DALC)", setting });
+		const auto& texturePath = settings.clouds[layerIndex].texturePath;
+		if (texturePath.empty()) {
+			return nullptr;
 		}
-	}
 
-	// Search in Atmosphere Colors
-	for (int i = 0; i < ColorTypes::kTotal; i++) {
-		std::string colorType = ColorTypeLabel(i);
-		if (ContainsStringIgnoreCase(colorType, searchTerm)) {
-			searchResults.push_back({ colorType, "Atmosphere Colors", colorType });
+		// Build resource path for BSA loading: Textures\path (relative to Data folder)
+		// Note: Skyrim texture paths don't include .dds extension, so we add it
+		std::string resourcePath = std::string("Textures\\") + texturePath;
+
+		// Add .dds extension if not present
+		if (resourcePath.size() < 4 || resourcePath.substr(resourcePath.size() - 4) != ".dds") {
+			resourcePath += ".dds";
 		}
-	}
 
-	// Search in Cloud settings
-	for (int i = 0; i < TESWeather::kTotalLayers; i++) {
-		std::string layer = std::format("Layer {}", i);
-		if (ContainsStringIgnoreCase(layer, searchTerm) ||
-			ContainsStringIgnoreCase("Cloud", searchTerm)) {
-			searchResults.push_back({ std::format("Cloud {}", layer), "Clouds", layer });
+		ID3D11ShaderResourceView* srv = nullptr;
+		ImVec2 textureSize;
+
+		if (Util::LoadDDSTextureFromFile(globals::d3d::device, resourcePath.c_str(), &srv, textureSize)) {
+			cloudTextureCache[layerIndex] = srv;
+			return srv;
 		}
-	}
-}
 
-void WeatherWidget::NavigateToSetting(const SearchResult& result)
-{
-	activeTabOverride = result.tabName;
-	highlightedSetting = result.settingId;
-	highlightStartTime = static_cast<float>(ImGui::GetTime());
-}
-
-bool WeatherWidget::ShouldHighlight(const std::string& settingId) const
-{
-	if (highlightedSetting != settingId)
-		return false;
-
-	float elapsed = static_cast<float>(ImGui::GetTime()) - highlightStartTime;
-	return elapsed < 2.0f;
-}
-
-ID3D11ShaderResourceView* WeatherWidget::GetCloudTexture(int layerIndex)
-{
-	if (cloudTextureCache.contains(layerIndex)) {
-		return cloudTextureCache[layerIndex];
-	}
-
-	const auto& texturePath = settings.clouds[layerIndex].texturePath;
-	if (texturePath.empty()) {
 		return nullptr;
 	}
-
-	// Build resource path for BSA loading: Textures\path (relative to Data folder)
-	// Note: Skyrim texture paths don't include .dds extension, so we add it
-	std::string resourcePath = std::string("Textures\\") + texturePath;
-
-	// Add .dds extension if not present
-	if (resourcePath.size() < 4 || resourcePath.substr(resourcePath.size() - 4) != ".dds") {
-		resourcePath += ".dds";
-	}
-
-	ID3D11ShaderResourceView* srv = nullptr;
-	ImVec2 textureSize;
-
-	if (Util::LoadDDSTextureFromFile(globals::d3d::device, resourcePath.c_str(), &srv, textureSize)) {
-		cloudTextureCache[layerIndex] = srv;
-		return srv;
-	}
-
-	return nullptr;
-}

--- a/src/WeatherEditor/Weather/WeatherWidget.cpp
+++ b/src/WeatherEditor/Weather/WeatherWidget.cpp
@@ -56,9 +56,12 @@ void WeatherWidget::DrawWidget()
 {
 	WeatherUtils::SetCurrentWidget(this);
 	ImGui::SetNextWindowSizeConstraints(ImVec2(600, 0), ImVec2(FLT_MAX, FLT_MAX));
-	if (ImGui::Begin(GetEditorID().c_str(), &open, ImGuiWindowFlags_NoSavedSettings | kStickyHeaderFlags)) {
-		// Draw header with search and all buttons
-		DrawWidgetHeader("##WeatherSearch", false, true, true, weather);
+	if (!ImGui::Begin(GetEditorID().c_str(), &open, ImGuiWindowFlags_NoSavedSettings | kStickyHeaderFlags)) {
+		ImGui::End();
+		return;
+	}
+	// Draw header with search and all buttons
+	DrawWidgetHeader("##WeatherSearch", false, true, true, weather);
 
 		// Update search results when search buffer changes
 		if (searchActive) {
@@ -425,7 +428,6 @@ void WeatherWidget::DrawWidget()
 			ImGui::EndTabItem();
 		}
 		ImGui::EndTabBar();
-	}
 	ImGui::End();
 }
 

--- a/src/WeatherEditor/Weather/WeatherWidget.cpp
+++ b/src/WeatherEditor/Weather/WeatherWidget.cpp
@@ -124,8 +124,7 @@ void WeatherWidget::DrawWidget()
 				settings.parent = "None";
 			}
 
-			for (int i = 0; i < widgets.size(); i++) {
-				auto& widget = widgets[i];
+			for (auto& widget : widgets) {
 
 				// Skip self-selection
 				if (widget.get() == this)
@@ -942,6 +941,7 @@ void WeatherWidget::DrawDALCSettings()
 		TOD::EndTODTable();
 	}
 	if (changed && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
+		EditorWindow::GetSingleton()->PushUndoState(this);
 		ApplyChanges();
 	}
 }
@@ -1003,6 +1003,7 @@ void WeatherWidget::DrawWeatherColorSettings()
 	}
 
 	if (changed && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
+		EditorWindow::GetSingleton()->PushUndoState(this);
 		ApplyChanges();
 	}
 }
@@ -1291,6 +1292,7 @@ void WeatherWidget::DrawFogSettings()
 	}
 
 	if (changed && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
+		EditorWindow::GetSingleton()->PushUndoState(this);
 		ApplyChanges();
 	}
 }
@@ -1377,6 +1379,7 @@ void WeatherWidget::DrawProperties(std::string category, std::map<std::string, i
 	}
 
 	if (changed && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
+		EditorWindow::GetSingleton()->PushUndoState(this);
 		ApplyChanges();
 	}
 
@@ -1473,6 +1476,7 @@ void WeatherWidget::InheritAllFromParent()
 
 	// Apply the changes
 	if (EditorWindow::GetSingleton()->settings.autoApplyChanges) {
+		EditorWindow::GetSingleton()->PushUndoState(this);
 		ApplyChanges();
 	}
 
@@ -2017,8 +2021,14 @@ ID3D11ShaderResourceView* WeatherWidget::GetCloudTexture(int layerIndex)
 	// Note: Skyrim texture paths don't include .dds extension, so we add it
 	std::string resourcePath = std::string("Textures\\") + texturePath;
 
-	// Add .dds extension if not present
-	if (resourcePath.size() < 4 || resourcePath.substr(resourcePath.size() - 4) != ".dds") {
+	// Add .dds extension if not present (case-insensitive check)
+	if (resourcePath.size() >= 4) {
+		std::string ext = resourcePath.substr(resourcePath.size() - 4);
+		std::transform(ext.begin(), ext.end(), ext.begin(), [](unsigned char c) { return std::tolower(c); });
+		if (ext != ".dds") {
+			resourcePath += ".dds";
+		}
+	} else {
 		resourcePath += ".dds";
 	}
 


### PR DESCRIPTION
The aim of this PR is not to change any functionality, but to clean up the code and reduce the amount of lines used, as well as removing dead code from the weather widgets. Compiles fine and no obvious bugs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized Weather Editor widgets for consistent Begin/End flows, tabs, headers, and unified change-tracking; many widgets now support loading/saving via consolidated Settings with sensible defaults.
  * Added safer load/apply/revert flows and explicit "load from game" handling across multiple weather panels.

* **Bug Fixes**
  * Early-exit guards prevent empty windows; values are clamped/sanitized on apply; undo support and clearer inline tooltips/UI polish added.
  * Improved stability for search/dropdown and parent/inherit workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->