### PR TITLE
feat(weather-editor): option to hide viewport

### DIFF
--- a/src/WeatherEditor/EditorWindow.cpp
+++ b/src/WeatherEditor/EditorWindow.cpp
@@ -819,13 +819,6 @@ void EditorWindow::ShowViewportWindow()
 {
 	ImGui::Begin("Viewport", nullptr, ImGuiWindowFlags_NoFocusOnAppearing);
 
-	// Top bar
-	if (DrawGameHourSlider("##ViewportSlider", "Time: %.2f")) {
-		ImGui::SameLine();
-		int activePeriod = TOD::GetActivePeriod();
-		ImGui::Text("(%s)", TOD::GetPeriodName(activePeriod));
-	}
-
 	// The size of the image in ImGui																														   // Get the available space in the current window
 	ImVec2 availableSpace = ImGui::GetContentRegionAvail();
 
@@ -1185,9 +1178,22 @@ void EditorWindow::RenderUI()
 			ImGui::PopStyleColor();
 		}
 
+		// Time slider anchored to the right of the menu bar
 		// Close button on the right side
 		float menuBarHeight = ImGui::GetFrameHeight();
 		float closeButtonSize = menuBarHeight * 0.9f;  // 10% smaller than menu bar
+
+		// Time slider anchored to the right of the menu bar
+		{
+			const float& itemSpacing = ImGui::GetStyle().ItemSpacing.x;
+			ImGui::SameLine(ImGui::GetWindowWidth() - closeButtonSize - 10.0f - itemSpacing - kMenuBarSliderWidth);
+			ImGui::SetNextItemWidth(kMenuBarSliderWidth);
+			if (DrawGameHourSlider("##MenuBarSlider", "Time: %.2f")) {
+				ImGui::SameLine();
+				ImGui::Text("(%s)", TOD::GetPeriodName(TOD::GetActivePeriod()));
+			}
+		}
+
 		ImGui::SameLine(ImGui::GetWindowWidth() - closeButtonSize - 10.0f);
 		auto errorColor = Menu::GetSingleton()->GetSettings().Theme.StatusPalette.Error;
 		auto errorHoverColor = errorColor;

--- a/src/WeatherEditor/EditorWindow.cpp
+++ b/src/WeatherEditor/EditorWindow.cpp
@@ -1368,11 +1368,11 @@ void EditorWindow::Draw()
 					texture->GetDesc(&texDesc);
 
 					const bool needsRecreate = !tempTexture || !tempTexture->resource || !tempTexture->srv ||
-						tempTexture->desc.Width != texDesc.Width || tempTexture->desc.Height != texDesc.Height ||
-						tempTexture->desc.MipLevels != texDesc.MipLevels || tempTexture->desc.ArraySize != texDesc.ArraySize ||
-						tempTexture->desc.Format != texDesc.Format ||
-						tempTexture->desc.SampleDesc.Count != texDesc.SampleDesc.Count ||
-						tempTexture->desc.SampleDesc.Quality != texDesc.SampleDesc.Quality;
+					                           tempTexture->desc.Width != texDesc.Width || tempTexture->desc.Height != texDesc.Height ||
+					                           tempTexture->desc.MipLevels != texDesc.MipLevels || tempTexture->desc.ArraySize != texDesc.ArraySize ||
+					                           tempTexture->desc.Format != texDesc.Format ||
+					                           tempTexture->desc.SampleDesc.Count != texDesc.SampleDesc.Count ||
+					                           tempTexture->desc.SampleDesc.Quality != texDesc.SampleDesc.Quality;
 
 					if (needsRecreate) {
 						delete tempTexture;

--- a/src/WeatherEditor/EditorWindow.cpp
+++ b/src/WeatherEditor/EditorWindow.cpp
@@ -817,7 +817,7 @@ void EditorWindow::ShowObjectsWindow()
 
 void EditorWindow::ShowViewportWindow()
 {
-	ImGui::Begin("Viewport");
+	ImGui::Begin("Viewport", nullptr, ImGuiWindowFlags_NoFocusOnAppearing);
 
 	// Top bar
 	if (DrawGameHourSlider("##ViewportSlider", "Time: %.2f")) {
@@ -1016,12 +1016,9 @@ void EditorWindow::RenderUI()
 			ImGui::EndMenu();
 		}
 		if (ImGui::BeginMenu("Window")) {
-			if (ImGui::MenuItem("Hide Viewport", nullptr, settings.hideViewport)) {
-				settings.hideViewport = !settings.hideViewport;
+			if (ImGui::Checkbox("Hide Viewport", &settings.hideViewport))
 				Save();
-			}
-			if (ImGui::MenuItem("Palette", nullptr, PaletteWindow::GetSingleton()->open)) {
-				PaletteWindow::GetSingleton()->open = !PaletteWindow::GetSingleton()->open;
+			if (ImGui::Checkbox("Palette", &PaletteWindow::GetSingleton()->open)) {
 			}
 
 			ImGui::Separator();

--- a/src/WeatherEditor/EditorWindow.cpp
+++ b/src/WeatherEditor/EditorWindow.cpp
@@ -10,7 +10,7 @@
 #include "WeatherUtils.h"
 #include "imgui_internal.h"
 
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(EditorWindow::Settings, recordMarkers, markedRecords, autoApplyChanges, useTextButtons, enableInheritFromParent, editorUIScale, favoriteWidgets, recentWidgets, maxRecentWidgets, rememberOpenWidgets, lastOpenWidgets)
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(EditorWindow::Settings, recordMarkers, markedRecords, autoApplyChanges, useTextButtons, enableInheritFromParent, editorUIScale, favoriteWidgets, recentWidgets, maxRecentWidgets, rememberOpenWidgets, lastOpenWidgets, hideViewport)
 
 void DrawIconStar(ImVec2 center, float radius, ImU32 color, bool filled)
 {
@@ -882,7 +882,8 @@ void EditorWindow::RenderUI()
 	auto& framebuffer = renderer->GetRuntimeData().renderTargets[RE::RENDER_TARGETS::kFRAMEBUFFER];
 	auto& context = globals::d3d::context;
 
-	context->ClearRenderTargetView(framebuffer.RTV, (float*)&ImGui::GetStyle().Colors[ImGuiCol_WindowBg]);
+	if (!settings.hideViewport)
+		context->ClearRenderTargetView(framebuffer.RTV, (float*)&ImGui::GetStyle().Colors[ImGuiCol_WindowBg]);
 
 	// Apply editor UI scale
 	ImGuiIO& io = ImGui::GetIO();
@@ -890,7 +891,8 @@ void EditorWindow::RenderUI()
 	io.FontGlobalScale = settings.editorUIScale;
 
 	// Increase background opacity for all editor windows
-	ImGui::PushStyleVar(ImGuiStyleVar_Alpha, 1.0f);
+	if (!settings.hideViewport)
+		ImGui::PushStyleVar(ImGuiStyleVar_Alpha, 1.0f);
 
 	// Check for Ctrl+Z to undo
 	if ((ImGui::IsKeyDown(ImGuiKey_LeftCtrl) || ImGui::IsKeyDown(ImGuiKey_RightCtrl)) && ImGui::IsKeyPressed(ImGuiKey_Z, false)) {
@@ -1020,6 +1022,10 @@ void EditorWindow::RenderUI()
 			ImGui::EndMenu();
 		}
 		if (ImGui::BeginMenu("Window")) {
+			if (ImGui::MenuItem("Hide Viewport", nullptr, settings.hideViewport)) {
+				settings.hideViewport = !settings.hideViewport;
+				Save();
+			}
 			if (ImGui::MenuItem("Palette", nullptr, PaletteWindow::GetSingleton()->open)) {
 				PaletteWindow::GetSingleton()->open = !PaletteWindow::GetSingleton()->open;
 			}
@@ -1222,8 +1228,10 @@ void EditorWindow::RenderUI()
 	ImGui::SetNextWindowSize(ImVec2(sideWidth, ImGui::GetIO().DisplaySize.y * 0.75f), ImGuiCond_FirstUseEver);
 	ShowObjectsWindow();
 
-	ImGui::SetNextWindowSize(ImVec2(viewportWidth, ImGui::GetIO().DisplaySize.y * 0.5f), ImGuiCond_FirstUseEver);
-	ShowViewportWindow();
+	if (!settings.hideViewport) {
+		ImGui::SetNextWindowSize(ImVec2(viewportWidth, ImGui::GetIO().DisplaySize.y * 0.5f), ImGuiCond_FirstUseEver);
+		ShowViewportWindow();
+	}
 
 	auto settingsWindowHeight = height * 0.25f;
 	auto settingsWindowWidth = width * 0.25f;
@@ -1242,7 +1250,8 @@ void EditorWindow::RenderUI()
 	RenderNotifications();
 
 	// Pop the alpha style var
-	ImGui::PopStyleVar();
+	if (!settings.hideViewport)
+		ImGui::PopStyleVar();
 
 	// Restore previous font scale
 	io.FontGlobalScale = previousScale;

--- a/src/WeatherEditor/EditorWindow.cpp
+++ b/src/WeatherEditor/EditorWindow.cpp
@@ -837,7 +837,11 @@ void EditorWindow::ShowViewportWindow()
 		imageSize.x = availableSpace.y * aspectRatio;
 	}
 
-	ImGui::Image((void*)tempTexture->srv.get(), imageSize);
+	if (tempTexture && tempTexture->srv) {
+		ImGui::Image((void*)tempTexture->srv.get(), imageSize);
+	} else {
+		ImGui::TextDisabled("Viewport unavailable");
+	}
 
 	ImGui::End();
 }
@@ -1347,29 +1351,48 @@ void EditorWindow::Draw()
 		}
 	}
 
-	auto renderer = RE::BSGraphics::Renderer::GetSingleton();
-	auto& framebuffer = renderer->GetRuntimeData().renderTargets[RE::RENDER_TARGETS::kFRAMEBUFFER];
+	if (!settings.showViewport) {
+		delete tempTexture;
+		tempTexture = nullptr;
+	} else {
+		auto renderer = RE::BSGraphics::Renderer::GetSingleton();
+		if (renderer) {
+			auto& framebuffer = renderer->GetRuntimeData().renderTargets[RE::RENDER_TARGETS::kFRAMEBUFFER];
+			if (framebuffer.SRV) {
+				ID3D11Resource* resource = nullptr;
+				framebuffer.SRV->GetResource(&resource);
 
-	ID3D11Resource* resource = nullptr;
-	framebuffer.SRV->GetResource(&resource);
+				if (resource) {
+					auto texture = static_cast<ID3D11Texture2D*>(resource);
+					D3D11_TEXTURE2D_DESC texDesc{};
+					texture->GetDesc(&texDesc);
 
-	if (!tempTexture) {
-		D3D11_TEXTURE2D_DESC texDesc{};
-		((ID3D11Texture2D*)resource)->GetDesc(&texDesc);
+					const bool needsRecreate = !tempTexture || !tempTexture->resource || !tempTexture->srv ||
+						tempTexture->desc.Width != texDesc.Width || tempTexture->desc.Height != texDesc.Height ||
+						tempTexture->desc.MipLevels != texDesc.MipLevels || tempTexture->desc.ArraySize != texDesc.ArraySize ||
+						tempTexture->desc.Format != texDesc.Format ||
+						tempTexture->desc.SampleDesc.Count != texDesc.SampleDesc.Count ||
+						tempTexture->desc.SampleDesc.Quality != texDesc.SampleDesc.Quality;
 
-		D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc{};
-		framebuffer.SRV->GetDesc(&srvDesc);
+					if (needsRecreate) {
+						delete tempTexture;
+						tempTexture = nullptr;
 
-		tempTexture = new Texture2D(texDesc);
-		tempTexture->CreateSRV(srvDesc);
-	}
+						D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc{};
+						framebuffer.SRV->GetDesc(&srvDesc);
 
-	auto& context = globals::d3d::context;
+						tempTexture = new Texture2D(texDesc);
+						tempTexture->CreateSRV(srvDesc);
+					}
 
-	context->CopyResource(tempTexture->resource.get(), resource);
+					if (tempTexture && tempTexture->resource) {
+						globals::d3d::context->CopyResource(tempTexture->resource.get(), resource);
+					}
 
-	if (resource) {
-		resource->Release();
+					resource->Release();
+				}
+			}
+		}
 	}
 
 	RenderUI();

--- a/src/WeatherEditor/EditorWindow.cpp
+++ b/src/WeatherEditor/EditorWindow.cpp
@@ -10,7 +10,7 @@
 #include "WeatherUtils.h"
 #include "imgui_internal.h"
 
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(EditorWindow::Settings, recordMarkers, markedRecords, autoApplyChanges, useTextButtons, enableInheritFromParent, editorUIScale, favoriteWidgets, recentWidgets, maxRecentWidgets, rememberOpenWidgets, lastOpenWidgets, hideViewport)
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(EditorWindow::Settings, recordMarkers, markedRecords, autoApplyChanges, useTextButtons, enableInheritFromParent, editorUIScale, favoriteWidgets, recentWidgets, maxRecentWidgets, rememberOpenWidgets, lastOpenWidgets, showViewport)
 
 void DrawIconStar(ImVec2 center, float radius, ImU32 color, bool filled)
 {
@@ -876,7 +876,7 @@ void EditorWindow::RenderUI()
 	float previousScale = io.FontGlobalScale;
 	io.FontGlobalScale = settings.editorUIScale;
 
-	if (!settings.hideViewport) {
+	if (settings.showViewport) {
 		// Dim the game scene using the theme's modal dim background color
 		ImGui::GetBackgroundDrawList()->AddRectFilled({ 0, 0 }, io.DisplaySize, ImGui::GetColorU32(ImGuiCol_ModalWindowDimBg));
 	}
@@ -1009,8 +1009,9 @@ void EditorWindow::RenderUI()
 			ImGui::EndMenu();
 		}
 		if (ImGui::BeginMenu("Window")) {
-			if (ImGui::Checkbox("Hide Viewport", &settings.hideViewport))
+			if (ImGui::Checkbox("Viewport", &settings.showViewport)) {
 				Save();
+			}
 			if (ImGui::Checkbox("Palette", &PaletteWindow::GetSingleton()->open)) {
 			}
 
@@ -1186,11 +1187,17 @@ void EditorWindow::RenderUI()
 		// Time slider anchored to the right of the menu bar
 		{
 			const float& itemSpacing = ImGui::GetStyle().ItemSpacing.x;
-			ImGui::SameLine(ImGui::GetWindowWidth() - closeButtonSize - 10.0f - itemSpacing - kMenuBarSliderWidth);
-			ImGui::SetNextItemWidth(kMenuBarSliderWidth);
-			if (DrawGameHourSlider("##MenuBarSlider", "Time: %.2f")) {
-				ImGui::SameLine();
-				ImGui::Text("(%s)", TOD::GetPeriodName(TOD::GetActivePeriod()));
+			char periodBuf[64];
+			std::snprintf(periodBuf, sizeof(periodBuf), "(%s)", TOD::GetPeriodName(TOD::GetActivePeriod()));
+			float periodWidth = ImGui::CalcTextSize(periodBuf).x;
+			const float sliderStartX = ImGui::GetWindowWidth() - closeButtonSize - 10.0f - itemSpacing - kMenuBarSliderWidth;
+			auto calendar = globals::game::calendar ? globals::game::calendar : RE::Calendar::GetSingleton();
+			if (calendar && calendar->gameHour) {
+				ImGui::SameLine(sliderStartX - itemSpacing - periodWidth);
+				ImGui::TextUnformatted(periodBuf);
+				ImGui::SameLine(sliderStartX);
+				ImGui::SetNextItemWidth(kMenuBarSliderWidth);
+				DrawGameHourSlider("##MenuBarSlider", "Time: %.2f");
 			}
 		}
 
@@ -1225,7 +1232,7 @@ void EditorWindow::RenderUI()
 	ImGui::SetNextWindowSize(ImVec2(sideWidth, ImGui::GetIO().DisplaySize.y * 0.75f), ImGuiCond_FirstUseEver);
 	ShowObjectsWindow();
 
-	if (!settings.hideViewport) {
+	if (settings.showViewport) {
 		ImGui::SetNextWindowSize(ImVec2(viewportWidth, ImGui::GetIO().DisplaySize.y * 0.5f), ImGuiCond_FirstUseEver);
 		ShowViewportWindow();
 	}

--- a/src/WeatherEditor/EditorWindow.cpp
+++ b/src/WeatherEditor/EditorWindow.cpp
@@ -878,21 +878,15 @@ void EditorWindow::ShowWidgetWindow()
 
 void EditorWindow::RenderUI()
 {
-	auto renderer = RE::BSGraphics::Renderer::GetSingleton();
-	auto& framebuffer = renderer->GetRuntimeData().renderTargets[RE::RENDER_TARGETS::kFRAMEBUFFER];
-	auto& context = globals::d3d::context;
-
-	if (!settings.hideViewport)
-		context->ClearRenderTargetView(framebuffer.RTV, (float*)&ImGui::GetStyle().Colors[ImGuiCol_WindowBg]);
-
 	// Apply editor UI scale
 	ImGuiIO& io = ImGui::GetIO();
 	float previousScale = io.FontGlobalScale;
 	io.FontGlobalScale = settings.editorUIScale;
 
-	// Increase background opacity for all editor windows
-	if (!settings.hideViewport)
-		ImGui::PushStyleVar(ImGuiStyleVar_Alpha, 1.0f);
+	if (!settings.hideViewport) {
+		// Dim the game scene using the theme's modal dim background color
+		ImGui::GetBackgroundDrawList()->AddRectFilled({ 0, 0 }, io.DisplaySize, ImGui::GetColorU32(ImGuiCol_ModalWindowDimBg));
+	}
 
 	// Check for Ctrl+Z to undo
 	if ((ImGui::IsKeyDown(ImGuiKey_LeftCtrl) || ImGui::IsKeyDown(ImGuiKey_RightCtrl)) && ImGui::IsKeyPressed(ImGuiKey_Z, false)) {
@@ -1248,10 +1242,6 @@ void EditorWindow::RenderUI()
 
 	// Render notifications on top of everything
 	RenderNotifications();
-
-	// Pop the alpha style var
-	if (!settings.hideViewport)
-		ImGui::PopStyleVar();
 
 	// Restore previous font scale
 	io.FontGlobalScale = previousScale;

--- a/src/WeatherEditor/EditorWindow.h
+++ b/src/WeatherEditor/EditorWindow.h
@@ -53,7 +53,7 @@ public:
 	static constexpr float kGameHourMax = 23.99f;
 	static constexpr float kTimeScaleMin = 0.1f;
 	static constexpr float kTimeScaleMax = 4000.0f;
-	static constexpr float kMenuBarSliderWidth = 200.0f;
+	static constexpr float kMenuBarSliderWidth = 400.0f;
 
 	// Vanity camera control
 	bool vanityCameraDisabled = false;
@@ -142,7 +142,7 @@ public:
 		int maxRecentWidgets = 10;
 		bool rememberOpenWidgets = true;
 		std::vector<std::string> lastOpenWidgets;
-		bool hideViewport = false;
+		bool showViewport = true;
 
 		// Palette settings
 		struct PaletteColorEntry

--- a/src/WeatherEditor/EditorWindow.h
+++ b/src/WeatherEditor/EditorWindow.h
@@ -53,6 +53,7 @@ public:
 	static constexpr float kGameHourMax = 23.99f;
 	static constexpr float kTimeScaleMin = 0.1f;
 	static constexpr float kTimeScaleMax = 4000.0f;
+	static constexpr float kMenuBarSliderWidth = 200.0f;
 
 	// Vanity camera control
 	bool vanityCameraDisabled = false;

--- a/src/WeatherEditor/EditorWindow.h
+++ b/src/WeatherEditor/EditorWindow.h
@@ -141,6 +141,7 @@ public:
 		int maxRecentWidgets = 10;
 		bool rememberOpenWidgets = true;
 		std::vector<std::string> lastOpenWidgets;
+		bool hideViewport = false;
 
 		// Palette settings
 		struct PaletteColorEntry

--- a/src/WeatherEditor/PaletteWindow.cpp
+++ b/src/WeatherEditor/PaletteWindow.cpp
@@ -11,7 +11,7 @@ void PaletteWindow::Draw()
 
 	ImGui::SetNextWindowSize(ImVec2(600, 400), ImGuiCond_FirstUseEver);
 	ImGui::SetNextWindowPos(ImVec2(ImGui::GetIO().DisplaySize.x - 620, ImGui::GetIO().DisplaySize.y - 420), ImGuiCond_FirstUseEver);
-	if (ImGui::Begin("Palette", &open)) {
+	if (ImGui::Begin("Palette", &open, ImGuiWindowFlags_NoFocusOnAppearing)) {
 		if (ImGui::BeginTabBar("PaletteTabs")) {
 			if (ImGui::BeginTabItem("Colours")) {
 				DrawColorsTab();


### PR DESCRIPTION
Added a toggle to allow the user to hide the viewport, This will come in useful for when HDR is merged and it has been requested by multiple people.

Also changed for for the purpose of usability with this feature:
- Changed the options from buttons to checkboxes to prevent the dropdown menu from closing when clicking them.
- Moved the time slider to the header bar so that it is always available independently from the the viewport.

Fixed:
- Background turned black when viewport was opened, must have snuck in earlier

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Toggle to show/hide the viewport to reduce visual clutter and rendering work
  * Time slider added to the menu bar for quick time adjustments

* **Improvements**
  * Window focus behavior refined for smoother workflow
  * UI now dims background when the viewport is active for clearer context
  * Safer viewport handling: missing textures show a disabled message and resources are created/deleted as needed
<!-- end of auto-generated comment: release notes by coderabbit.ai -->