### PR TITLE
chore(wetness-effects): set default MaxPuddleWetness to 1.5

### DIFF
--- a/src/Features/WetnessEffects.h
+++ b/src/Features/WetnessEffects.h
@@ -32,7 +32,7 @@ public:
 	{
 		uint EnableWetnessEffects = true;
 		float MaxRainWetness = 1.0f;
-		float MaxPuddleWetness = 2.5f;
+		float MaxPuddleWetness = 1.5f;
 		float MaxShoreWetness = 1.0f;
 		uint ShoreRange = 32;
 		float PuddleRadius = 1.0f;


### PR DESCRIPTION
May not fix potential underlying issues with wetness effects, but does set a more reasonable default value that doesn't cause overly wet surfaces.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Adjustments**
  * Reduced maximum puddle wetness effect intensity to provide more balanced visual effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->