### PR TITLE
fix(sky sync): early return for invalid cells

### DIFF
--- a/src/Features/SkySync.cpp
+++ b/src/Features/SkySync.cpp
@@ -130,8 +130,9 @@ void SkySync::Update(const RE::Sky* sky)
 	const auto cell = player->GetParentCell();
 
 	if (cell != currentCell) {
+		const auto prevCell = currentCell;
 		SetSkyRotation(sky, cell);
-		if (currentCell && (cell->IsInteriorCell() != currentCell->IsInteriorCell() || cell->GetRuntimeData().worldSpace != currentCell->GetRuntimeData().worldSpace))
+		if (prevCell && (cell->IsInteriorCell() != prevCell->IsInteriorCell() || cell->GetRuntimeData().worldSpace != prevCell->GetRuntimeData().worldSpace))
 			shadowFader.Reset();
 	}
 

--- a/src/Features/SkySync.cpp
+++ b/src/Features/SkySync.cpp
@@ -127,11 +127,17 @@ void SkySync::Update(const RE::Sky* sky)
 	if (!sun || !climate || !player)
 		return;
 
-	if (const auto cell = player->GetParentCell(); cell != currentCell) {
+	const auto cell = player->GetParentCell();
+
+	if (cell != currentCell) {
 		SetSkyRotation(sky, cell);
 		if (currentCell && (cell->IsInteriorCell() != currentCell->IsInteriorCell() || cell->GetRuntimeData().worldSpace != currentCell->GetRuntimeData().worldSpace))
 			shadowFader.Reset();
 	}
+
+	// Exterior worldspaces always run; interior cells require the sunlight-shadows flag.
+	if (cell && cell->IsInteriorCell() && !cell->cellFlags.all(RE::TESObjectCELL::Flag::kShowSky, static_cast<RE::TESObjectCELL::Flag>(CellFlagExt::kSunlightShadows)))
+		return;
 
 	const float time = sky->currentGameHour;
 	const bool isDayTime = time > timings.sunriseFadeOutMoonEnd && time < timings.sunsetFadeInMoonStart;

--- a/src/Features/SkySync.cpp
+++ b/src/Features/SkySync.cpp
@@ -136,7 +136,7 @@ void SkySync::Update(const RE::Sky* sky)
 	}
 
 	// Exterior worldspaces always run; interior cells require the sunlight-shadows flag.
-	if (cell && cell->IsInteriorCell() && !cell->cellFlags.all(RE::TESObjectCELL::Flag::kShowSky, static_cast<RE::TESObjectCELL::Flag>(CellFlagExt::kSunlightShadows)))
+	if (cell && cell->IsInteriorCell() && !cell->cellFlags.all(static_cast<RE::TESObjectCELL::Flag>(CellFlagExt::kSunlightShadows)))
 		return;
 
 	const float time = sky->currentGameHour;

--- a/src/Features/SkySync.cpp
+++ b/src/Features/SkySync.cpp
@@ -131,8 +131,9 @@ void SkySync::Update(const RE::Sky* sky)
 
 	if (cell != currentCell) {
 		const auto prevCell = currentCell;
-		SetSkyRotation(sky, cell);
-		if (prevCell && (cell->IsInteriorCell() != prevCell->IsInteriorCell() || cell->GetRuntimeData().worldSpace != prevCell->GetRuntimeData().worldSpace))
+		if (cell)
+			SetSkyRotation(sky, cell);
+		if (cell && prevCell && (cell->IsInteriorCell() != prevCell->IsInteriorCell() || cell->GetRuntimeData().worldSpace != prevCell->GetRuntimeData().worldSpace))
 			shadowFader.Reset();
 	}
 

--- a/src/Features/SkySync.cpp
+++ b/src/Features/SkySync.cpp
@@ -138,8 +138,10 @@ void SkySync::Update(const RE::Sky* sky)
 	}
 
 	// Exterior worldspaces always run; interior cells require the sunlight-shadows flag.
-	if (cell && cell->IsInteriorCell() && !cell->cellFlags.all(static_cast<RE::TESObjectCELL::Flag>(CellFlagExt::kSunlightShadows)))
+	if (cell && cell->IsInteriorCell() && !cell->cellFlags.all(static_cast<RE::TESObjectCELL::Flag>(CellFlagExt::kSunlightShadows))) {
+		volumetricLightingIntensityFactor = 1.0f;
 		return;
+	}
 
 	const float time = sky->currentGameHour;
 	const bool isDayTime = time > timings.sunriseFadeOutMoonEnd && time < timings.sunsetFadeInMoonStart;

--- a/src/Features/SkySync.h
+++ b/src/Features/SkySync.h
@@ -83,6 +83,11 @@ public:
 	inline static float volumetricLightingIntensityFactor = 1.0f;
 
 private:
+	enum class CellFlagExt : uint16_t
+	{
+		kSunlightShadows = 1 << 15,
+	};
+
 	enum class MoonLightSource : uint8_t
 	{
 		Brightest,


### PR DESCRIPTION
Adds an early return for when the player is in a cell that is not set up to make use of sun shadows. This prevents sky sync from hijacking the directional light from the lighting templates as if it was the sun and moving it around, causing weird lighting behaviour. as shown in this video from isoprovophlex

https://github.com/user-attachments/assets/9c399fe3-90ab-416a-8627-3d6faf92bafe


And here is also an example from leostevano:
With Skysync
<img width="1920" height="1080" alt="Screenshot526" src="https://github.com/user-attachments/assets/b1c112f5-8a77-4118-b11a-93ed66f0769d" />
Without Skysync
<img width="1920" height="1080" alt="Screenshot527" src="https://github.com/user-attachments/assets/ff822470-f5ed-46e5-8dfe-bad4c6181e8e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More consistent sun/moon lighting and sky rotation when moving between areas; shadows now update only on meaningful area changes.
  * Interiors without sunlight-shadow support no longer show incorrect lighting shifts.

* **Performance**
  * Sky updates skip unnecessary processing in many interior scenarios, reducing redundant per-frame work.

* **Refactor**
  * Improved area-transition tracking to avoid spurious lighting and shadow resets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->