### PR TITLE
feat(ISL-editor): add light counters and fix filtering

### DIFF
--- a/src/Features/InverseSquareLighting/LightEditor.cpp
+++ b/src/Features/InverseSquareLighting/LightEditor.cpp
@@ -194,15 +194,13 @@ void LightEditor::GatherLights()
 			ligh = RE::TESForm::LookupByID(runtimeData->lighFormId)->As<RE::TESObjectLIGH>();
 
 		const bool isShadow = ligh && ligh->data.flags.any(RE::TES_LIGHT_FLAGS::kHemiShadow, RE::TES_LIGHT_FLAGS::kOmniShadow, RE::TES_LIGHT_FLAGS::kSpotShadow);
-		
+
 		if ((shadowsOnly) && (!ligh || !isShadow)) {
 			return;
 		}
 
-
 		current.isAttached = !current.isRef && refr != nullptr;
 		current.isOther = (!current.isRef && !current.isAttached) || (current.isSpotlight);
-
 
 		totalLightCount++;
 		if (isShadow)
@@ -258,7 +256,7 @@ void LightEditor::GatherLights()
 	for (auto& light : activeShadowLights) {
 		addLight(light);
 	}
-	
+
 	if (!foundSelected) {
 		previous = selected;
 		selected = {};

--- a/src/Features/InverseSquareLighting/LightEditor.cpp
+++ b/src/Features/InverseSquareLighting/LightEditor.cpp
@@ -87,8 +87,12 @@ void LightEditor::DrawSettings()
 	ImGui::Spacing();
 	ImGui::Spacing();
 
+	if (selected.isSpotlight)
+		ImGui::TextDisabled("Spotlight: ISL light type flags not applicable");
+	ImGui::BeginDisabled(selected.isSpotlight);
 	ImGui::CheckboxFlags("Inverse Square Light", reinterpret_cast<uint32_t*>(&current.data.flags), static_cast<uint32_t>(LightLimitFix::LightFlags::InverseSquare));
 	ImGui::CheckboxFlags("Linear Light", reinterpret_cast<uint32_t*>(&current.data.flags), static_cast<uint32_t>(LightLimitFix::LightFlags::Linear));
+	ImGui::EndDisabled();
 
 	ImGui::Spacing();
 	ImGui::Spacing();
@@ -187,16 +191,15 @@ void LightEditor::GatherLights()
 		if (!current.isRef && runtimeData->lighFormId != 0)
 			ligh = RE::TESForm::LookupByID(runtimeData->lighFormId)->As<RE::TESObjectLIGH>();
 
-		if (ligh && ligh->data.flags.any(RE::TES_LIGHT_FLAGS::kSpotlight, RE::TES_LIGHT_FLAGS::kSpotShadow))
-			return;
+		current.isSpotlight = ligh && ligh->data.flags.any(RE::TES_LIGHT_FLAGS::kSpotlight, RE::TES_LIGHT_FLAGS::kSpotShadow);
 
 		if (shadowsOnly) {
 			if (!ligh || !ligh->data.flags.any(RE::TES_LIGHT_FLAGS::kHemiShadow, RE::TES_LIGHT_FLAGS::kOmniShadow))
 				return;
 		}
 
-		current.isOther = ligh == nullptr;
-		current.isAttached = refr && !current.isRef && !current.isOther;
+		current.isAttached = !current.isRef && refr != nullptr;
+		current.isOther = !current.isRef && !current.isAttached;
 
 		const bool isRefMatch = current.isRef && filterOption == FilterOption::RefLights;
 		const bool isAttachedMatch = current.isAttached && filterOption == FilterOption::AttachedLights;
@@ -207,13 +210,12 @@ void LightEditor::GatherLights()
 
 		if (current.isRef) {
 			current.position = refr->GetPosition();
-		} else if (current.isAttached) {
+		} else if (niLight->parent) {
 			current.position = niLight->parent->world.translate;
 		}
 		if (current.isOther) {
 			current.ptr = reinterpret_cast<void*>(niLight);
 			current.name = niLight->name;
-			current.position = niLight->parent->world.translate;
 			current.index = 0;
 		}
 

--- a/src/Features/InverseSquareLighting/LightEditor.cpp
+++ b/src/Features/InverseSquareLighting/LightEditor.cpp
@@ -22,8 +22,15 @@ void LightEditor::DrawSettings()
 	ImGui::Checkbox("Disable Inverse Square Falloff Lights", &disableInvSqLights);
 
 	ImGui::Spacing();
+	ImGui::Text("Active Shadow Lights: %u", activeShadowLightCount);
+	ImGui::Spacing();
 	ImGui::Separator();
 	ImGui::Spacing();
+
+	ImGui::Checkbox("Shadows Only", &shadowsOnly);
+	if (auto _tt = Util::HoverTooltipWrapper()) {
+		ImGui::Text("Only show lights with HemiShadow or OmniShadow flags.");
+	}
 
 	int selectedFilter = static_cast<int>(filterOption);
 	if (ImGui::Combo("Filter By", &selectedFilter, FilterOptionLabels, static_cast<int>(FilterOption::Count))) {
@@ -183,6 +190,11 @@ void LightEditor::GatherLights()
 		if (ligh && ligh->data.flags.any(RE::TES_LIGHT_FLAGS::kSpotlight, RE::TES_LIGHT_FLAGS::kSpotShadow))
 			return;
 
+		if (shadowsOnly) {
+			if (!ligh || !ligh->data.flags.any(RE::TES_LIGHT_FLAGS::kHemiShadow, RE::TES_LIGHT_FLAGS::kOmniShadow))
+				return;
+		}
+
 		current.isOther = ligh == nullptr;
 		current.isAttached = refr && !current.isRef && !current.isOther;
 
@@ -229,6 +241,7 @@ void LightEditor::GatherLights()
 	}
 
 	const auto& activeShadowLights = shadowSceneNode->GetRuntimeData().activeShadowLights;
+	activeShadowLightCount = static_cast<uint32_t>(activeShadowLights.size());
 
 	for (auto& light : activeShadowLights) {
 		addLight(light);

--- a/src/Features/InverseSquareLighting/LightEditor.cpp
+++ b/src/Features/InverseSquareLighting/LightEditor.cpp
@@ -117,7 +117,7 @@ void LightEditor::DrawSettings()
 	ImGui::Spacing();
 	ImGui::Spacing();
 
-	if (!selected.isOther && current.data.lighFormId != 0) {
+	if (!selected.isOther && current.data.lighFormId != 0 && selected.hasPosition) {
 		ImGui::Text("X: %.2f, Y: %.2f, Z: %.2f", displayInfo.pos.x, displayInfo.pos.y, displayInfo.pos.z);
 		ImGui::Spacing();
 		ImGui::SliderFloat3("Position Offset", &current.pos.x, -500.f, 500.f, "%.0f");
@@ -188,11 +188,11 @@ void LightEditor::GatherLights()
 		}
 
 		current.isRef = ligh != nullptr;
-		current.isSpotlight = ligh && ligh->data.flags.any(RE::TES_LIGHT_FLAGS::kSpotlight, RE::TES_LIGHT_FLAGS::kSpotShadow);
 
 		if (!current.isRef && runtimeData->lighFormId != 0)
 			ligh = RE::TESForm::LookupByID(runtimeData->lighFormId)->As<RE::TESObjectLIGH>();
 
+		current.isSpotlight = ligh && ligh->data.flags.any(RE::TES_LIGHT_FLAGS::kSpotlight, RE::TES_LIGHT_FLAGS::kSpotShadow);
 		const bool isShadow = ligh && ligh->data.flags.any(RE::TES_LIGHT_FLAGS::kHemiShadow, RE::TES_LIGHT_FLAGS::kOmniShadow, RE::TES_LIGHT_FLAGS::kSpotShadow);
 
 		totalLightCount++;
@@ -299,16 +299,20 @@ void LightEditor::UpdateSelectedLight(RE::TESObjectREFR* refr, RE::TESObjectLIGH
 			waitFrames = 1;
 		}
 		displayInfo.pos = newPos;
-	} else if (selected.isAttached && niLight->parent) {
-		const auto currentPos = niLight->parent->local.translate;
-		const auto newPos = original.pos + current.pos;
-		if (currentPos != newPos) {
-			niLight->parent->local.translate = newPos;
-			RE::NiUpdateData updateData;
-			niLight->parent->Update(updateData);
-			waitFrames = 1;
+	} else if (selected.isAttached) {
+		if (niLight->parent) {
+			const auto currentPos = niLight->parent->local.translate;
+			const auto newPos = original.pos + current.pos;
+			if (currentPos != newPos) {
+				niLight->parent->local.translate = newPos;
+				RE::NiUpdateData updateData;
+				niLight->parent->Update(updateData);
+				waitFrames = 1;
+			}
+			displayInfo.pos = newPos;
+		} else {
+			displayInfo.pos = {};
 		}
-		displayInfo.pos = newPos;
 	}
 
 	if (!selected.isOther && refr && tesFlags && current.tesFlags.underlying() != tesFlags->underlying()) {

--- a/src/Features/InverseSquareLighting/LightEditor.cpp
+++ b/src/Features/InverseSquareLighting/LightEditor.cpp
@@ -91,8 +91,8 @@ void LightEditor::DrawSettings()
 		ImGui::TextDisabled("Spotlight: ISL light type flags not applicable");
 	ImGui::BeginDisabled(selected.isSpotlight);
 	ImGui::CheckboxFlags("Inverse Square Light", reinterpret_cast<uint32_t*>(&current.data.flags), static_cast<uint32_t>(LightLimitFix::LightFlags::InverseSquare));
-	ImGui::CheckboxFlags("Linear Light", reinterpret_cast<uint32_t*>(&current.data.flags), static_cast<uint32_t>(LightLimitFix::LightFlags::Linear));
 	ImGui::EndDisabled();
+	ImGui::CheckboxFlags("Linear Light", reinterpret_cast<uint32_t*>(&current.data.flags), static_cast<uint32_t>(LightLimitFix::LightFlags::Linear));
 
 	ImGui::Spacing();
 	ImGui::Spacing();
@@ -187,21 +187,23 @@ void LightEditor::GatherLights()
 		}
 
 		current.isRef = ligh != nullptr;
+		current.isSpotlight = ligh && ligh->data.flags.any(RE::TES_LIGHT_FLAGS::kSpotlight, RE::TES_LIGHT_FLAGS::kSpotShadow);
 
 		if (!current.isRef && runtimeData->lighFormId != 0)
 			ligh = RE::TESForm::LookupByID(runtimeData->lighFormId)->As<RE::TESObjectLIGH>();
 
-		current.isSpotlight = ligh && ligh->data.flags.any(RE::TES_LIGHT_FLAGS::kSpotlight, RE::TES_LIGHT_FLAGS::kSpotShadow);
 
 		if (shadowsOnly) {
-			if (!ligh || !ligh->data.flags.any(RE::TES_LIGHT_FLAGS::kHemiShadow, RE::TES_LIGHT_FLAGS::kOmniShadow))
+			if (!ligh || !ligh->data.flags.any(RE::TES_LIGHT_FLAGS::kHemiShadow, RE::TES_LIGHT_FLAGS::kOmniShadow, RE::TES_LIGHT_FLAGS::kSpotShadow))
 				return;
 		}
 
-		current.isAttached = !current.isRef && refr != nullptr;
-		current.isOther = !current.isRef && !current.isAttached;
 
-		const bool isRefMatch = current.isRef && filterOption == FilterOption::RefLights;
+		current.isAttached = !current.isRef && refr != nullptr;
+		current.isOther = (!current.isRef && !current.isAttached) || (current.isSpotlight);
+
+
+		const bool isRefMatch = (current.isRef&& !current.isSpotlight) && filterOption == FilterOption::RefLights;
 		const bool isAttachedMatch = current.isAttached && filterOption == FilterOption::AttachedLights;
 		const bool isOtherMatch = current.isOther && filterOption == FilterOption::OtherLights;
 
@@ -210,12 +212,15 @@ void LightEditor::GatherLights()
 
 		if (current.isRef) {
 			current.position = refr->GetPosition();
+			current.hasPosition = true;
 		} else if (niLight->parent) {
 			current.position = niLight->parent->world.translate;
+			current.hasPosition = true;
 		}
 		if (current.isOther) {
 			current.ptr = reinterpret_cast<void*>(niLight);
-			current.name = niLight->name;
+			if (current.name.empty())
+				current.name = niLight->name.c_str();
 			current.index = 0;
 		}
 
@@ -265,7 +270,7 @@ void LightEditor::UpdateSelectedLight(RE::TESObjectREFR* refr, RE::TESObjectLIGH
 	if (previous != selected) {
 		original.tesFlags = tesFlags ? static_cast<ISLCommon::TES_LIGHT_FLAGS_EXT>(tesFlags->underlying()) : static_cast<ISLCommon::TES_LIGHT_FLAGS_EXT>(0);
 		original.data = *runtimeData;
-		original.pos = selected.isRef ? refr->GetPosition() : niLight->parent->local.translate;
+		original.pos = selected.isRef ? refr->GetPosition() : (niLight->parent ? niLight->parent->local.translate : RE::NiPoint3{});
 		current = original;
 		current.pos = { 0, 0, 0 };
 		previous = selected;
@@ -339,6 +344,8 @@ void LightEditor::SortLights()
 		{
 			const auto playerPos = RE::PlayerCharacter::GetSingleton()->GetPosition();
 			std::ranges::sort(lights, [&](const LightInfo& a, const LightInfo& b) {
+				if (a.hasPosition != b.hasPosition)
+					return a.hasPosition;
 				return a.position.GetSquaredDistance(playerPos) < b.position.GetSquaredDistance(playerPos);
 			});
 			break;

--- a/src/Features/InverseSquareLighting/LightEditor.cpp
+++ b/src/Features/InverseSquareLighting/LightEditor.cpp
@@ -22,6 +22,7 @@ void LightEditor::DrawSettings()
 	ImGui::Checkbox("Disable Inverse Square Falloff Lights", &disableInvSqLights);
 
 	ImGui::Spacing();
+	ImGui::Text("Total Lights: %u", totalLightCount);
 	ImGui::Text("Active Shadow Lights: %u", activeShadowLightCount);
 	ImGui::Spacing();
 	ImGui::Separator();
@@ -192,10 +193,10 @@ void LightEditor::GatherLights()
 		if (!current.isRef && runtimeData->lighFormId != 0)
 			ligh = RE::TESForm::LookupByID(runtimeData->lighFormId)->As<RE::TESObjectLIGH>();
 
-
-		if (shadowsOnly) {
-			if (!ligh || !ligh->data.flags.any(RE::TES_LIGHT_FLAGS::kHemiShadow, RE::TES_LIGHT_FLAGS::kOmniShadow, RE::TES_LIGHT_FLAGS::kSpotShadow))
-				return;
+		const bool isShadow = ligh && ligh->data.flags.any(RE::TES_LIGHT_FLAGS::kHemiShadow, RE::TES_LIGHT_FLAGS::kOmniShadow, RE::TES_LIGHT_FLAGS::kSpotShadow);
+		
+		if ((shadowsOnly) && (!ligh || !isShadow)) {
+			return;
 		}
 
 
@@ -203,7 +204,11 @@ void LightEditor::GatherLights()
 		current.isOther = (!current.isRef && !current.isAttached) || (current.isSpotlight);
 
 
-		const bool isRefMatch = (current.isRef&& !current.isSpotlight) && filterOption == FilterOption::RefLights;
+		totalLightCount++;
+		if (isShadow)
+			activeShadowLightCount++;
+
+		const bool isRefMatch = (current.isRef && !current.isSpotlight) && filterOption == FilterOption::RefLights;
 		const bool isAttachedMatch = current.isAttached && filterOption == FilterOption::AttachedLights;
 		const bool isOtherMatch = current.isOther && filterOption == FilterOption::OtherLights;
 
@@ -237,7 +242,8 @@ void LightEditor::GatherLights()
 
 	lights.clear();
 	lightsAttached.clear();
-
+	totalLightCount = 0;
+	activeShadowLightCount = 0;
 	const auto smState = globals::game::smState;
 	const auto shadowSceneNode = smState->shadowSceneNode[0];
 
@@ -248,12 +254,11 @@ void LightEditor::GatherLights()
 	}
 
 	const auto& activeShadowLights = shadowSceneNode->GetRuntimeData().activeShadowLights;
-	activeShadowLightCount = static_cast<uint32_t>(activeShadowLights.size());
 
 	for (auto& light : activeShadowLights) {
 		addLight(light);
 	}
-
+	
 	if (!foundSelected) {
 		previous = selected;
 		selected = {};

--- a/src/Features/InverseSquareLighting/LightEditor.cpp
+++ b/src/Features/InverseSquareLighting/LightEditor.cpp
@@ -195,16 +195,16 @@ void LightEditor::GatherLights()
 
 		const bool isShadow = ligh && ligh->data.flags.any(RE::TES_LIGHT_FLAGS::kHemiShadow, RE::TES_LIGHT_FLAGS::kOmniShadow, RE::TES_LIGHT_FLAGS::kSpotShadow);
 
+		totalLightCount++;
+		if (isShadow)
+			activeShadowLightCount++;
+
 		if ((shadowsOnly) && (!ligh || !isShadow)) {
 			return;
 		}
 
 		current.isAttached = !current.isRef && refr != nullptr;
 		current.isOther = (!current.isRef && !current.isAttached) || (current.isSpotlight);
-
-		totalLightCount++;
-		if (isShadow)
-			activeShadowLightCount++;
 
 		const bool isRefMatch = (current.isRef && !current.isSpotlight) && filterOption == FilterOption::RefLights;
 		const bool isAttachedMatch = current.isAttached && filterOption == FilterOption::AttachedLights;
@@ -299,7 +299,7 @@ void LightEditor::UpdateSelectedLight(RE::TESObjectREFR* refr, RE::TESObjectLIGH
 			waitFrames = 1;
 		}
 		displayInfo.pos = newPos;
-	} else if (selected.isAttached) {
+	} else if (selected.isAttached && niLight->parent) {
 		const auto currentPos = niLight->parent->local.translate;
 		const auto newPos = original.pos + current.pos;
 		if (currentPos != newPos) {

--- a/src/Features/InverseSquareLighting/LightEditor.h
+++ b/src/Features/InverseSquareLighting/LightEditor.h
@@ -54,6 +54,7 @@ private:
 	bool showAttachedLights = false;
 	bool showEffectLights = false;
 	int32_t waitFrames = 0;
+	uint32_t totalLightCount = 0;
 	uint32_t activeShadowLightCount = 0;
 
 	enum class FilterOption

--- a/src/Features/InverseSquareLighting/LightEditor.h
+++ b/src/Features/InverseSquareLighting/LightEditor.h
@@ -22,7 +22,7 @@ private:
 		bool isRef;
 		bool isAttached;
 		bool isOther;
-		bool isSpotlight;
+		bool isSpotlight = false;
 		bool hasPosition = false;
 		RE::NiPoint3 position;
 

--- a/src/Features/InverseSquareLighting/LightEditor.h
+++ b/src/Features/InverseSquareLighting/LightEditor.h
@@ -23,6 +23,7 @@ private:
 		bool isAttached;
 		bool isOther;
 		bool isSpotlight;
+		bool hasPosition = false;
 		RE::NiPoint3 position;
 
 		bool operator==(const LightInfo& other) const noexcept

--- a/src/Features/InverseSquareLighting/LightEditor.h
+++ b/src/Features/InverseSquareLighting/LightEditor.h
@@ -6,6 +6,7 @@ struct LightEditor
 	bool enabled;
 	bool disableInvSqLights;
 	bool disableRegularLights;
+	bool shadowsOnly = false;
 
 	void DrawSettings();
 	void GatherLights();
@@ -51,6 +52,7 @@ private:
 	bool showAttachedLights = false;
 	bool showEffectLights = false;
 	int32_t waitFrames = 0;
+	uint32_t activeShadowLightCount = 0;
 
 	enum class FilterOption
 	{

--- a/src/Features/InverseSquareLighting/LightEditor.h
+++ b/src/Features/InverseSquareLighting/LightEditor.h
@@ -22,6 +22,7 @@ private:
 		bool isRef;
 		bool isAttached;
 		bool isOther;
+		bool isSpotlight;
 		RE::NiPoint3 position;
 
 		bool operator==(const LightInfo& other) const noexcept


### PR DESCRIPTION
Small rework of the ISL editor, added the counting of shadowcasters and normal lights.
Changed some sorting logic to ensure no lights are skipped and added guards for spotlights so they can be viewed but not edited.
Gives more transparency to the lighting mod authors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Displays total light and active shadow-casting light counters; adds a "Shadows only" checkbox filter with hover tooltip; hiding non-shadow lights when enabled.

* **Improvements**
  * Refined light-type filtering so spot/spot-shadow lights are handled separately and excluded from certain lists.
  * More reliable position handling and guarded updates to avoid missing-parent issues.
  * Distance sorting now prioritizes lights with valid positions.
  * Inverse-square control is disabled when a spotlight is selected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->