### PR TITLE
fix(UI): set window size of new widgets

### DIFF
--- a/src/WeatherEditor/EditorWindow.cpp
+++ b/src/WeatherEditor/EditorWindow.cpp
@@ -857,6 +857,8 @@ void EditorWindow::ShowWidgetWindow()
 
 	// Draw current cell lighting widget if open
 	if (currentCellLightingWidget && currentCellLightingWidget->IsOpen()) {
+		const float scale = Util::GetUIScale();
+		ImGui::SetNextWindowSize(ImVec2(600.0f * scale, 600.0f * scale), ImGuiCond_FirstUseEver);
 		currentCellLightingWidget->DrawWidget();
 		if (ImGui::IsWindowFocused(ImGuiFocusedFlags_RootAndChildWindows))
 			lastFocusedWidget = currentCellLightingWidget.get();

--- a/src/WeatherEditor/WeatherUtils.h
+++ b/src/WeatherEditor/WeatherUtils.h
@@ -188,8 +188,10 @@ namespace WidgetFactory
 	template <typename Container>
 	void DrawOpenWidgets(Container& widgets, Widget*& lastFocusedWidget)
 	{
+		const float scale = Util::GetUIScale();
 		for (auto& widget : widgets) {
 			if (widget->IsOpen()) {
+				ImGui::SetNextWindowSize(ImVec2(600.0f * scale, 600.0f * scale), ImGuiCond_FirstUseEver);
 				widget->DrawWidget();
 				if (ImGui::IsWindowFocused(ImGuiFocusedFlags_RootAndChildWindows)) {
 					lastFocusedWidget = widget.get();


### PR DESCRIPTION
minor fix to prevent weather editor widgets from opening in the smallest possible window.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed editor widget UI scaling to properly adjust window sizes based on system display settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->