### PR TITLE
fix(UI): add dummy call after SetCursorScreenPos

### DIFF
--- a/src/Utils/UI.cpp
+++ b/src/Utils/UI.cpp
@@ -842,6 +842,7 @@ namespace Util
 
 			// Move cursor to next line
 			ImGui::SetCursorScreenPos(ImVec2(pos.x, pos.y + textSize.y + 8.0f));
+			ImGui::Dummy(ImVec2(availableWidth, 0.0f));
 		}
 
 		return stateChanged;

--- a/src/Utils/UI.cpp
+++ b/src/Utils/UI.cpp
@@ -778,6 +778,7 @@ namespace Util
 
 		// Move cursor to next line
 		ImGui::SetCursorScreenPos(ImVec2(pos.x, pos.y + textSize.y + 8.0f));
+		ImGui::Dummy(ImVec2(availableWidth, 0.0f));
 		return clicked;
 	}
 


### PR DESCRIPTION
Due to imgui version bump this is needed to prevent imgui from complaining.
I tried to look for other spots where this may be needed but couldn't find anything.
<img width="1483" height="289" alt="afbeelding" src="https://github.com/user-attachments/assets/b36ee51e-0e70-4e96-a6e2-8905b9a1cd0d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved header spacing and alignment across the UI: category and section headers now reserve consistent horizontal space after rendering to ensure more predictable layout advancement, reducing misalignment and visual jitter for a cleaner, more consistent interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->