### PR TITLE
fix(volumetric-shadows): Change SharedShadowMap register back from t80 to t18

### DIFF
--- a/package/Shaders/Common/ShadowSampling.hlsli
+++ b/package/Shaders/Common/ShadowSampling.hlsli
@@ -18,10 +18,11 @@
 #	include "IBL/IBL.hlsli"
 #endif
 
-// Only declared when volumetric shadows are active; avoids register(t80) conflict with
-// TRUE_PBR LANDSCAPE TexLandDisplacement0Sampler in Lighting.hlsl.
+// Only declared when volumetric shadows are active; the #if guard already prevents
+// any conflict with TRUE_PBR LANDSCAPE shaders since VOLUMETRIC_SHADOWS is never
+// defined in Lighting.hlsl permutations.
 #if defined(VOLUMETRIC_SHADOWS)
-Texture2D<float2> SharedShadowMap : register(t80);
+Texture2D<float2> SharedShadowMap : register(t18);
 #endif
 
 // Directional (sun) shadow data: cascade split distances and projection matrices.

--- a/package/Shaders/Common/ShadowSampling.hlsli
+++ b/package/Shaders/Common/ShadowSampling.hlsli
@@ -163,7 +163,7 @@ namespace ShadowSampling
 		uint onePlusLayerIndex = 1.0 + primaryCascade;
 		float layerIndexRcp = rcp(onePlusLayerIndex);
 
-		float ShadowSampleParamZ = 0.001; // // fPoissonRadiusScale / iShadowMapResolution in z and w
+		float ShadowSampleParamZ = 0.001;  // // fPoissonRadiusScale / iShadowMapResolution in z and w
 
 		float visibility = 0;
 
@@ -174,7 +174,7 @@ namespace ShadowSampling
 		}
 
 		visibility /= 16.0;
-	
+
 		// Blend with secondary cascade if needed
 		[branch] if (needsBlending)
 		{
@@ -187,7 +187,7 @@ namespace ShadowSampling
 			positionLS.z -= Constants::ShadowBiasConst;
 
 			float visibilityBlend = 0.0;
-			
+
 			for (int i = 0; i < 16; i++) {
 				float2 sampleOffset = mul(Random::PoissonSampleOffsets16[i], rotationMatrix);
 				float2 sampleUV = positionLS.xy + layerIndexRcp * sampleOffset * ShadowSampleParamZ;

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -2432,8 +2432,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	float2x2 rotationMatrix = float2x2(rotation.x, rotation.y, -rotation.y, rotation.x);
 
 	// Sample directional shadow directly (VSM when VolumetricShadows loaded, PCF otherwise).
-	if (inWorld && !inReflection && !SharedData::InInterior)
-	{
+	if (inWorld && !inReflection && !SharedData::InInterior) {
 		dirDetailedShadow = ShadowSampling::GetDirectionalShadow(input.WorldPosition.xyz, rotationMatrix, eyeIndex);
 		dirSoftShadow = dirDetailedShadow;
 	}

--- a/package/Shaders/RunGrass.hlsl
+++ b/package/Shaders/RunGrass.hlsl
@@ -599,7 +599,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 	sincos(Math::TAU * screenNoise, rotation.y, rotation.x);
 	float2x2 rotationMatrix = float2x2(rotation.x, rotation.y, -rotation.y, rotation.x);
 
-	if (!SharedData::InInterior){
+	if (!SharedData::InInterior) {
 		dirDetailedShadow = ShadowSampling::GetDirectionalShadow(input.WorldPosition.xyz, rotationMatrix, eyeIndex);
 		dirSoftShadow = dirDetailedShadow;
 	}
@@ -886,7 +886,7 @@ PS_OUTPUT main(PS_INPUT input)
 	sincos(Math::TAU * screenNoise, rotation.y, rotation.x);
 	float2x2 rotationMatrix = float2x2(rotation.x, rotation.y, -rotation.y, rotation.x);
 
-	if (!SharedData::InInterior){
+	if (!SharedData::InInterior) {
 		dirDetailedShadow = ShadowSampling::GetDirectionalShadow(input.WorldPosition.xyz, rotationMatrix, eyeIndex);
 		dirSoftShadow = dirDetailedShadow;
 	}


### PR DESCRIPTION
caused wrong volumetric shadows shadowmap in exteriors when using PBR materials. The existing #if defined guard is suffcient to prevent conflicting with "TRUE_PBR LANDSCAPE TexLandDisplacement0Sampler"