### PR TITLE
fix(UI): stuck keys

### DIFF
--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -1028,7 +1028,13 @@ void Menu::ProcessInputEventQueue()
 						std::function<void()> action;
 					};
 					KeyAction keyActions[] = {
-						{ settings.ToggleKey, [this]() { if (!HomePageRenderer::ShouldShowFirstTimeSetup()) IsEnabled = !IsEnabled; } },
+						{ settings.ToggleKey, [this]() {
+							if (!HomePageRenderer::ShouldShowFirstTimeSetup()) {
+								IsEnabled = !IsEnabled;
+								if (IsEnabled)
+									ImGui::GetIO().ClearInputKeys();  // Prevent toggle key from remaining "held" in ImGui after open.
+							}
+						} },
 						{ settings.SkipCompilationKey, [this, shaderCache]() { if (!ShouldSwallowInput() && shaderCache->IsCompiling()) shaderCache->backgroundCompilation = true; } },
 						{ settings.EffectToggleKey, [shaderCache]() { shaderCache->SetEnabled(!shaderCache->IsEnabled()); } },
 						{ settings.ShaderBlockPrevKey, [this, shaderCache]() { if (settings.EnableShaderBlocking) shaderCache->IterateShaderBlock(); } },

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -1086,7 +1086,9 @@ void Menu::ProcessInputEventQueue()
 			bool isHotkey = ShouldSwallowInput() && std::any_of(std::begin(hotkeys), std::end(hotkeys),
 														[key](const auto* combo) { return InputCombo::MatchesKeyboardCombo(*combo, key); });
 
-			if (!isHotkey) {
+			// Swallow hotkey key-down events to avoid UI side effects, but always forward
+			// key-up events so ImGui state cannot get stuck in a held-key state.
+			if (!isHotkey || !event.IsPressed()) {
 				// DirectInput loses key-up events after alt-tab; validate against OS state.
 				bool pressed = event.IsPressed() && (GetAsyncKeyState(key) & Constants::KEY_PRESSED_MASK);
 				io.AddKeyEvent(Util::Input::VirtualKeyToImGuiKey(key), pressed);

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -957,7 +957,7 @@ void Menu::ProcessInputEventQueue()
 
 			const bool wasCapturingHotkey = IsCapturingHotkeyInput();
 			const bool allowSetupCloseKey = wasCapturingHotkey && HomePageRenderer::ShouldShowFirstTimeSetup() &&
-				(key == VK_RETURN || key == VK_ESCAPE);
+			                                (key == VK_RETURN || key == VK_ESCAPE);
 			if (!event.IsPressed()) {
 				// Skip key release if it was used to close the first-time setup dialog
 				if (HomePageRenderer::ShouldSkipKeyRelease(key)) {
@@ -1033,12 +1033,12 @@ void Menu::ProcessInputEventQueue()
 					};
 					KeyAction keyActions[] = {
 						{ settings.ToggleKey, [this]() {
-							if (!HomePageRenderer::ShouldShowFirstTimeSetup()) {
-								IsEnabled = !IsEnabled;
-								if (IsEnabled)
-									ImGui::GetIO().ClearInputKeys();  // Prevent toggle key from remaining "held" in ImGui after open.
-							}
-						} },
+							 if (!HomePageRenderer::ShouldShowFirstTimeSetup()) {
+								 IsEnabled = !IsEnabled;
+								 if (IsEnabled)
+									 ImGui::GetIO().ClearInputKeys();  // Prevent toggle key from remaining "held" in ImGui after open.
+							 }
+						 } },
 						{ settings.SkipCompilationKey, [this, shaderCache]() { if (!ShouldSwallowInput() && shaderCache->IsCompiling()) shaderCache->backgroundCompilation = true; } },
 						{ settings.EffectToggleKey, [shaderCache]() { shaderCache->SetEnabled(!shaderCache->IsEnabled()); } },
 						{ settings.ShaderBlockPrevKey, [this, shaderCache]() { if (settings.EnableShaderBlocking) shaderCache->IterateShaderBlock(); } },
@@ -1115,7 +1115,7 @@ void Menu::ProcessInputEventQueue()
 bool Menu::IsCapturingHotkeyInput() const
 {
 	return settingToggleKey || settingSkipCompilationKey || settingsEffectsToggle ||
-		settingOverlayToggleKey || settingShaderBlockPrevKey || settingShaderBlockNextKey || settingWeatherEditorToggleKey;
+	       settingOverlayToggleKey || settingShaderBlockPrevKey || settingShaderBlockNextKey || settingWeatherEditorToggleKey;
 }
 
 void Menu::addToEventQueue(KeyEvent e)

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -1090,13 +1090,13 @@ void Menu::ProcessInputEventQueue()
 			bool isHotkey = ShouldSwallowInput() && std::any_of(std::begin(hotkeys), std::end(hotkeys),
 														[key](const auto* combo) { return InputCombo::MatchesKeyboardCombo(*combo, key); });
 
-			// Swallow hotkey key-down events to avoid UI side effects, but always forward
-			// key-up events so ImGui state cannot get stuck in a held-key state.
-			// While recording a new hotkey, suppress keyboard forwarding so capture input
-			// does not trigger menu navigation; first-time setup Enter/Escape is allowed.
-			if ((!isHotkey || !event.IsPressed()) && (!wasCapturingHotkey || allowSetupCloseKey)) {
+			// Always forward key-up events. Suppress key-down during active hotkeys,
+			// and during hotkey capture except setup close keys (Enter/Escape).
+			const bool isKeyDown = event.IsPressed();
+			const bool suppressForwarding = isKeyDown && (isHotkey || (wasCapturingHotkey && !allowSetupCloseKey));
+			if (!suppressForwarding) {
 				// DirectInput loses key-up events after alt-tab; validate against OS state.
-				bool pressed = event.IsPressed() && (GetAsyncKeyState(key) & Constants::KEY_PRESSED_MASK);
+				bool pressed = isKeyDown && (GetAsyncKeyState(key) & Constants::KEY_PRESSED_MASK);
 				io.AddKeyEvent(Util::Input::VirtualKeyToImGuiKey(key), pressed);
 
 				if (key == VK_LCONTROL || key == VK_RCONTROL)

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -954,6 +954,10 @@ void Menu::ProcessInputEventQueue()
 			logger::trace("Detected key code {} ({})", event.keyCode, key);
 			if (key == event.keyCode)
 				key = MapVirtualKeyEx(event.keyCode, MAPVK_VSC_TO_VK_EX, GetKeyboardLayout(0));
+
+			const bool wasCapturingHotkey = IsCapturingHotkeyInput();
+			const bool allowSetupCloseKey = wasCapturingHotkey && HomePageRenderer::ShouldShowFirstTimeSetup() &&
+				(key == VK_RETURN || key == VK_ESCAPE);
 			if (!event.IsPressed()) {
 				// Skip key release if it was used to close the first-time setup dialog
 				if (HomePageRenderer::ShouldSkipKeyRelease(key)) {
@@ -1088,7 +1092,9 @@ void Menu::ProcessInputEventQueue()
 
 			// Swallow hotkey key-down events to avoid UI side effects, but always forward
 			// key-up events so ImGui state cannot get stuck in a held-key state.
-			if (!isHotkey || !event.IsPressed()) {
+			// While recording a new hotkey, suppress keyboard forwarding so capture input
+			// does not trigger menu navigation; first-time setup Enter/Escape is allowed.
+			if ((!isHotkey || !event.IsPressed()) && (!wasCapturingHotkey || allowSetupCloseKey)) {
 				// DirectInput loses key-up events after alt-tab; validate against OS state.
 				bool pressed = event.IsPressed() && (GetAsyncKeyState(key) & Constants::KEY_PRESSED_MASK);
 				io.AddKeyEvent(Util::Input::VirtualKeyToImGuiKey(key), pressed);
@@ -1104,6 +1110,12 @@ void Menu::ProcessInputEventQueue()
 	}
 
 	_keyEventQueue.clear();
+}
+
+bool Menu::IsCapturingHotkeyInput() const
+{
+	return settingToggleKey || settingSkipCompilationKey || settingsEffectsToggle ||
+		settingOverlayToggleKey || settingShaderBlockPrevKey || settingShaderBlockNextKey || settingWeatherEditorToggleKey;
 }
 
 void Menu::addToEventQueue(KeyEvent e)

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -501,5 +501,6 @@ private:
 
 	void addToEventQueue(KeyEvent e);
 	void ProcessInputEventQueue();
+	bool IsCapturingHotkeyInput() const;
 	winrt::com_ptr<IDXGIAdapter3> dxgiAdapter3;
 };


### PR DESCRIPTION
fixes multiple cases of stuck keys:
- When the menu is opened the release action was swallowed
- When a new hotkey was assigned, the release action was also swallowed
- When a new hotkey was assigned, it still registered the UI input related to that newly assigned key.

Closes: https://github.com/doodlum/skyrim-community-shaders/issues/2099
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Improved hotkey capture and input handling to prevent keys from becoming stuck in the UI.
* Fixed Enter/Escape behavior during initial setup so these keys work reliably.
* Ensured toggling the menu clears lingering key states to avoid accidental repeated input.
* Refined key event forwarding to reduce unintended UI side effects and more predictable hotkey behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->