### PR TITLE
fix(weather-editor): corrected slider behaviour for the weather widget

### DIFF
--- a/src/Features/WeatherEditor.cpp
+++ b/src/Features/WeatherEditor.cpp
@@ -141,7 +141,7 @@ void WeatherEditor::LerpWeather(RE::TESWeather* oldWeather, RE::TESWeather* newW
 	//// Lightning
 	newWeather->data.thunderLightningBeginFadeIn = LerpInt8_t(oldWeather->data.thunderLightningBeginFadeIn, newWeather->data.thunderLightningBeginFadeIn, currentWeatherPct);
 	newWeather->data.thunderLightningEndFadeOut = LerpInt8_t(oldWeather->data.thunderLightningEndFadeOut, newWeather->data.thunderLightningEndFadeOut, currentWeatherPct);
-	newWeather->data.thunderLightningFrequency = LerpInt8_t(oldWeather->data.thunderLightningFrequency, newWeather->data.thunderLightningFrequency, currentWeatherPct);
+	newWeather->data.thunderLightningFrequency = (int8_t)LerpUint8_t((uint8_t)oldWeather->data.thunderLightningFrequency, (uint8_t)newWeather->data.thunderLightningFrequency, currentWeatherPct);
 	LerpColor(oldWeather->data.lightningColor, newWeather->data.lightningColor, currentWeatherPct);
 
 	//// Trans delta
@@ -404,7 +404,7 @@ void WeatherEditor::DisplayPrecipitationInfo(RE::TESWeather* weather)
 
 void WeatherEditor::DisplayLightningInfo(RE::TESWeather* weather, bool showInteractiveElements)
 {
-	if (!weather || weather->data.thunderLightningFrequency <= 0)
+	if (!weather || (uint8_t)weather->data.thunderLightningFrequency == 0)
 		return;
 	const auto& theme = Menu::GetSingleton()->GetTheme();
 	uint8_t lightningR = weather->data.lightningColor.red;
@@ -427,57 +427,19 @@ void WeatherEditor::DisplayLightningInfo(RE::TESWeather* weather, bool showInter
 		weather->data.lightningColor.green = static_cast<std::uint8_t>(lightningColor[1] * 255.0f + 0.5f);
 		weather->data.lightningColor.blue = static_cast<std::uint8_t>(lightningColor[2] * 255.0f + 0.5f);
 	}
-	int8_t thunderFreqRaw = weather->data.thunderLightningFrequency;
-	ImGui::BulletText("Thunder Frequency: %d (signed 8-bit)", static_cast<int>(thunderFreqRaw));
-	ImGui::Indent();
-	if (thunderFreqRaw >= 76) {
-		if (thunderFreqRaw == 76) {
-			ImGui::BulletText("This matches ~75%% frequency in Creation Kit");
-		} else if (thunderFreqRaw > 76) {
-			ImGui::BulletText("High frequency range: Above 75%% (raw > 76)");
-		}
-	} else if (thunderFreqRaw >= 15) {
-		if (thunderFreqRaw == 15) {
-			ImGui::BulletText("This matches maximum observed frequency in Creation Kit");
-		} else {
-			ImGui::BulletText("High-medium frequency range: 75-100%% (raw 15-76)");
-		}
-	} else if (thunderFreqRaw >= 0) {
-		ImGui::BulletText("Medium frequency range: 25-75%% (raw 0-15)");
-	} else if (thunderFreqRaw >= -10) {
-		if (thunderFreqRaw == -1) {
-			ImGui::BulletText("This matches minimum frequency in Creation Kit (255 unsigned)");
-		} else if (thunderFreqRaw == -10) {
-			ImGui::BulletText("This matches ~5%% frequency in Creation Kit (246 unsigned)");
-		} else {
-			ImGui::BulletText("Low frequency range: 0-25%% (raw -10 to 0)");
-		}
-	} else if (thunderFreqRaw >= -53) {
-		if (thunderFreqRaw == -53) {
-			ImGui::BulletText("This matches ~20%% frequency in Creation Kit (203 unsigned)");
-		} else {
-			ImGui::BulletText("Low-medium frequency range: 5-20%% (raw -53 to -10)");
-		}
-	} else if (thunderFreqRaw >= -100) {
-		ImGui::BulletText("Very low frequency range: Near 0%% (raw -100 to -53)");
-	} else {
-		ImGui::BulletText("Extreme low frequency: Likely no thunder (raw < -100)");
-	}
-	ImGui::Unindent();
+	uint8_t thunderFreqRaw = (uint8_t)weather->data.thunderLightningFrequency;
+	ImGui::BulletText("Thunder Frequency: %u", static_cast<unsigned>(thunderFreqRaw));
 	if (auto _tt = Util::HoverTooltipWrapper()) {
-		Util::DrawMultiLineTooltip({ "Thunder frequency raw value with observed Creation Kit behavior:",
+		Util::DrawMultiLineTooltip({ "Thunder frequency raw value (0-255):",
 			"",
 			"Known data points from Creation Kit slider:",
 			"- Raw 15 = ~100% frequency (highest thunder)",
 			"- Raw 76 = ~75% frequency",
-			"- Raw -10 (246 unsigned) = ~5% frequency",
-			"- Raw -53 (203 unsigned) = ~20% frequency",
-			"- Raw -1 (255 unsigned) = ~0% frequency (lowest thunder)",
+			"- Raw 203 = ~20% frequency",
+			"- Raw 246 = ~5% frequency",
+			"- Raw 255 = ~0% frequency (lowest thunder)",
 			"",
-			"Pattern: Higher positive values = more frequent thunder",
-			"Lower/negative values = less frequent thunder",
-			"",
-			"Range: -128 to +127 (signed 8-bit integer)",
+			"Range: 0-255 (unsigned 8-bit integer)",
 			"Note: Creation Kit interprets this value non-linearly" });
 	}
 	uint8_t lightningBeginFadeIn = weather->data.thunderLightningBeginFadeIn;

--- a/src/Features/WeatherEditor.cpp
+++ b/src/Features/WeatherEditor.cpp
@@ -139,8 +139,8 @@ void WeatherEditor::LerpWeather(RE::TESWeather* oldWeather, RE::TESWeather* newW
 	newWeather->data.sunGlare = LerpInt8_t(oldWeather->data.sunGlare, newWeather->data.sunGlare, currentWeatherPct);
 
 	//// Lightning
-	newWeather->data.thunderLightningBeginFadeIn = LerpInt8_t(oldWeather->data.thunderLightningBeginFadeIn, newWeather->data.thunderLightningBeginFadeIn, currentWeatherPct);
-	newWeather->data.thunderLightningEndFadeOut = LerpInt8_t(oldWeather->data.thunderLightningEndFadeOut, newWeather->data.thunderLightningEndFadeOut, currentWeatherPct);
+	newWeather->data.thunderLightningBeginFadeIn = LerpUint8_t(oldWeather->data.thunderLightningBeginFadeIn, newWeather->data.thunderLightningBeginFadeIn, currentWeatherPct);
+	newWeather->data.thunderLightningEndFadeOut = LerpUint8_t(oldWeather->data.thunderLightningEndFadeOut, newWeather->data.thunderLightningEndFadeOut, currentWeatherPct);
 	newWeather->data.thunderLightningFrequency = (int8_t)LerpUint8_t((uint8_t)oldWeather->data.thunderLightningFrequency, (uint8_t)newWeather->data.thunderLightningFrequency, currentWeatherPct);
 	LerpColor(oldWeather->data.lightningColor, newWeather->data.lightningColor, currentWeatherPct);
 

--- a/src/Features/WeatherEditor.cpp
+++ b/src/Features/WeatherEditor.cpp
@@ -131,8 +131,8 @@ void WeatherEditor::LerpWeather(RE::TESWeather* oldWeather, RE::TESWeather* newW
 	}
 
 	//// Precipitation
-	newWeather->data.precipitationBeginFadeIn = LerpInt8_t(oldWeather->data.precipitationBeginFadeIn, newWeather->data.precipitationBeginFadeIn, currentWeatherPct);
-	newWeather->data.precipitationEndFadeOut = LerpInt8_t(oldWeather->data.precipitationEndFadeOut, newWeather->data.precipitationEndFadeOut, currentWeatherPct);
+	newWeather->data.precipitationBeginFadeIn = LerpUint8_t(oldWeather->data.precipitationBeginFadeIn, newWeather->data.precipitationBeginFadeIn, currentWeatherPct);
+	newWeather->data.precipitationEndFadeOut = LerpUint8_t(oldWeather->data.precipitationEndFadeOut, newWeather->data.precipitationEndFadeOut, currentWeatherPct);
 
 	//// Sun
 	newWeather->data.sunDamage = LerpInt8_t(oldWeather->data.sunDamage, newWeather->data.sunDamage, currentWeatherPct);

--- a/src/Features/WeatherEditor.cpp
+++ b/src/Features/WeatherEditor.cpp
@@ -145,11 +145,11 @@ void WeatherEditor::LerpWeather(RE::TESWeather* oldWeather, RE::TESWeather* newW
 	LerpColor(oldWeather->data.lightningColor, newWeather->data.lightningColor, currentWeatherPct);
 
 	//// Trans delta
-	newWeather->data.transDelta = LerpInt8_t(oldWeather->data.transDelta, newWeather->data.transDelta, currentWeatherPct);
+	newWeather->data.transDelta = LerpUint8_t(oldWeather->data.transDelta, newWeather->data.transDelta, currentWeatherPct);
 
 	//// Visual Effects
-	newWeather->data.visualEffectBegin = LerpInt8_t(oldWeather->data.visualEffectBegin, newWeather->data.visualEffectBegin, currentWeatherPct);
-	newWeather->data.visualEffectEnd = LerpInt8_t(oldWeather->data.visualEffectEnd, newWeather->data.visualEffectEnd, currentWeatherPct);
+	newWeather->data.visualEffectBegin = LerpUint8_t(oldWeather->data.visualEffectBegin, newWeather->data.visualEffectBegin, currentWeatherPct);
+	newWeather->data.visualEffectEnd = LerpUint8_t(oldWeather->data.visualEffectEnd, newWeather->data.visualEffectEnd, currentWeatherPct);
 
 	//// Wind
 	newWeather->data.windDirection = LerpInt8_t(oldWeather->data.windDirection, newWeather->data.windDirection, currentWeatherPct);

--- a/src/WeatherEditor/Weather/WeatherWidget.cpp
+++ b/src/WeatherEditor/Weather/WeatherWidget.cpp
@@ -188,7 +188,7 @@ void WeatherWidget::DrawWidget()
 			DrawProperties("Sun", { { "Sun Damage", INT8_SLIDER } });
 			DrawProperties("Wind", { { "Wind Speed", UINT8_SLIDER }, { "Wind Direction", INT8_SLIDER }, { "Wind Direction Range", INT8_SLIDER } });
 			DrawProperties("Precipitation", { { "Precipitation Begin Fade In", UINT8_SLIDER }, { "Precipitation End Fade Out", UINT8_SLIDER } });
-			DrawProperties("Lightning", { { "Thunder Lightning Begin Fade In", INT8_SLIDER }, { "Thunder Lightning End Fade Out", INT8_SLIDER },
+			DrawProperties("Lightning", { { "Thunder Lightning Begin Fade In", UINT8_SLIDER }, { "Thunder Lightning End Fade Out", UINT8_SLIDER },
 											{ "Thunder Lightning Frequency", UINT8_SLIDER }, { "Lightning Color", COLOR3_PICKER } });
 			DrawProperties("Visual Effects", { { "Visual Effect Begin", UINT8_SLIDER }, { "Visual Effect End", UINT8_SLIDER } });
 			DrawProperties("Weather Transition", { { "Trans Delta", UINT8_SLIDER } });
@@ -552,8 +552,8 @@ void WeatherWidget::SetWeatherValues()
 	data.precipitationEndFadeOut = (uint8_t)weatherProps["Precipitation End Fade Out"];
 
 	// Lightning
-	data.thunderLightningBeginFadeIn = (int8_t)weatherProps["Thunder Lightning Begin Fade In"];
-	data.thunderLightningEndFadeOut = (int8_t)weatherProps["Thunder Lightning End Fade Out"];
+	data.thunderLightningBeginFadeIn = (uint8_t)weatherProps["Thunder Lightning Begin Fade In"];
+	data.thunderLightningEndFadeOut = (uint8_t)weatherProps["Thunder Lightning End Fade Out"];
 	data.thunderLightningFrequency = (int8_t)weatherProps["Thunder Lightning Frequency"];
 	Float3ToColor(weatherColors["Lightning Color"], weather->data.lightningColor);
 

--- a/src/WeatherEditor/Weather/WeatherWidget.cpp
+++ b/src/WeatherEditor/Weather/WeatherWidget.cpp
@@ -187,7 +187,7 @@ void WeatherWidget::DrawWidget()
 			BeginScrollableContent("##BasicScroll");
 			DrawProperties("Sun", { { "Sun Damage", INT8_SLIDER } });
 			DrawProperties("Wind", { { "Wind Speed", UINT8_SLIDER }, { "Wind Direction", INT8_SLIDER }, { "Wind Direction Range", INT8_SLIDER } });
-			DrawProperties("Precipitation", { { "Precipitation Begin Fade In", INT8_SLIDER }, { "Precipitation End Fade Out", INT8_SLIDER } });
+			DrawProperties("Precipitation", { { "Precipitation Begin Fade In", UINT8_SLIDER }, { "Precipitation End Fade Out", UINT8_SLIDER } });
 			DrawProperties("Lightning", { { "Thunder Lightning Begin Fade In", INT8_SLIDER }, { "Thunder Lightning End Fade Out", INT8_SLIDER },
 											{ "Thunder Lightning Frequency", UINT8_SLIDER }, { "Lightning Color", COLOR3_PICKER } });
 			DrawProperties("Visual Effects", { { "Visual Effect Begin", UINT8_SLIDER }, { "Visual Effect End", UINT8_SLIDER } });
@@ -548,8 +548,8 @@ void WeatherWidget::SetWeatherValues()
 	data.sunDamage = (int8_t)weatherProps["Sun Damage"];
 
 	// Precipitation
-	data.precipitationBeginFadeIn = (int8_t)weatherProps["Precipitation Begin Fade In"];
-	data.precipitationEndFadeOut = (int8_t)weatherProps["Precipitation End Fade Out"];
+	data.precipitationBeginFadeIn = (uint8_t)weatherProps["Precipitation Begin Fade In"];
+	data.precipitationEndFadeOut = (uint8_t)weatherProps["Precipitation End Fade Out"];
 
 	// Lightning
 	data.thunderLightningBeginFadeIn = (int8_t)weatherProps["Thunder Lightning Begin Fade In"];

--- a/src/WeatherEditor/Weather/WeatherWidget.cpp
+++ b/src/WeatherEditor/Weather/WeatherWidget.cpp
@@ -189,9 +189,9 @@ void WeatherWidget::DrawWidget()
 			DrawProperties("Wind", { { "Wind Speed", UINT8_SLIDER }, { "Wind Direction", INT8_SLIDER }, { "Wind Direction Range", INT8_SLIDER } });
 			DrawProperties("Precipitation", { { "Precipitation Begin Fade In", INT8_SLIDER }, { "Precipitation End Fade Out", INT8_SLIDER } });
 			DrawProperties("Lightning", { { "Thunder Lightning Begin Fade In", INT8_SLIDER }, { "Thunder Lightning End Fade Out", INT8_SLIDER },
-											{ "Thunder Lightning Frequency", INT8_SLIDER }, { "Lightning Color", COLOR3_PICKER } });
-			DrawProperties("Visual Effects", { { "Visual Effect Begin", INT8_SLIDER }, { "Visual Effect End", INT8_SLIDER } });
-			DrawProperties("Weather Transition", { { "Trans Delta", INT8_SLIDER } });
+											{ "Thunder Lightning Frequency", UINT8_SLIDER }, { "Lightning Color", COLOR3_PICKER } });
+			DrawProperties("Visual Effects", { { "Visual Effect Begin", UINT8_SLIDER }, { "Visual Effect End", UINT8_SLIDER } });
+			DrawProperties("Weather Transition", { { "Trans Delta", UINT8_SLIDER } });
 			EndScrollableContent();
 			ImGui::EndTabItem();
 		}
@@ -541,7 +541,7 @@ void WeatherWidget::SetWeatherValues()
 	auto& colorData = weather->colorData;
 	auto& fogData = weather->fogData;
 
-	weather->data.transDelta = (int8_t)weatherProps["Trans Delta"];
+	weather->data.transDelta = (uint8_t)weatherProps["Trans Delta"];
 
 	// Sun
 	data.sunGlare = (int8_t)weatherProps["Sun Glare"];
@@ -558,8 +558,8 @@ void WeatherWidget::SetWeatherValues()
 	Float3ToColor(weatherColors["Lightning Color"], weather->data.lightningColor);
 
 	// Visual Effects
-	data.visualEffectBegin = (int8_t)weatherProps["Visual Effect Begin"];
-	data.visualEffectEnd = (int8_t)weatherProps["Visual Effect End"];
+	data.visualEffectBegin = (uint8_t)weatherProps["Visual Effect Begin"];
+	data.visualEffectEnd = (uint8_t)weatherProps["Visual Effect End"];
 
 	// Wind
 	data.windSpeed = (uint8_t)weatherProps["Wind Speed"];
@@ -721,7 +721,7 @@ void WeatherWidget::LoadWeatherValues()
 	// Lightning
 	weatherProps["Thunder Lightning Begin Fade In"] = data.thunderLightningBeginFadeIn;
 	weatherProps["Thunder Lightning End Fade Out"] = data.thunderLightningEndFadeOut;
-	weatherProps["Thunder Lightning Frequency"] = data.thunderLightningFrequency;
+	weatherProps["Thunder Lightning Frequency"] = (uint8_t)data.thunderLightningFrequency;
 	ColorToFloat3(data.lightningColor, weatherColors["Lightning Color"]);
 
 	// Visual Effects

--- a/src/WeatherEditor/WeatherUtils.cpp
+++ b/src/WeatherEditor/WeatherUtils.cpp
@@ -207,7 +207,7 @@ namespace WeatherUtils
 		const double debounceDelay = 2.0;
 		double currentTime = ImGui::GetTime();
 
-		bool changed = ImGui::SliderInt(label.c_str(), &property, -128, 127);
+		bool changed = ImGui::SliderInt(label.c_str(), &property, -127, 127);
 		bool isNowActive = ImGui::IsItemActive();
 
 		// Push undo state when slider becomes active
@@ -1025,7 +1025,7 @@ namespace TOD
 
 			ImGui::PushItemWidth(sliderWidth);
 			std::string id = std::string("##") + label + std::to_string(i);
-			if (ImGui::SliderInt(id.c_str(), &values[i], -128, 127))
+			if (ImGui::SliderInt(id.c_str(), &values[i], -127, 127))
 				changed = true;
 
 			if (ImGui::IsItemHovered())


### PR DESCRIPTION
This PR contains a set of corrections for expected values based on feedback from lamin and my own testing.
slider maxima and minima have been corrected, as well as some variable types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Weather precipitation, lightning, visual-effect, and transition parameters in the editor now use unsigned 0–255 ranges, updating interpolation and persistence.
* **UI**
  * Lightning frequency display, tooltip and slider now reflect 0–255 semantics and treat zero correctly.
  * Small adjustment to int8 slider lower bound to avoid an out-of-range value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->