### PR TITLE
fix(weather-editor): remove time of day for lighting templates

### DIFF
--- a/src/WeatherEditor/Weather/LightingTemplateWidget.cpp
+++ b/src/WeatherEditor/Weather/LightingTemplateWidget.cpp
@@ -166,17 +166,17 @@ void LightingTemplateWidget::DrawDALCSettings()
 		changed = true;
 
 	ImGui::SeparatorText("Directional Colors");
-	if (MatchesSearch("X+ (Right)") && WeatherUtils::DrawColorEdit("X+ (Right)", settings.dalc.directional[0].max))
+	if ((MatchesSearch("Directional") || MatchesSearch("X+ (Right)")) && WeatherUtils::DrawColorEdit("X+ (Right)", settings.dalc.directional[0].max))
 		changed = true;
-	if (MatchesSearch("X- (Left)") && WeatherUtils::DrawColorEdit("X- (Left)", settings.dalc.directional[0].min))
+	if ((MatchesSearch("Directional") || MatchesSearch("X- (Left)")) && WeatherUtils::DrawColorEdit("X- (Left)", settings.dalc.directional[0].min))
 		changed = true;
-	if (MatchesSearch("Y+ (Front)") && WeatherUtils::DrawColorEdit("Y+ (Front)", settings.dalc.directional[1].max))
+	if ((MatchesSearch("Directional") || MatchesSearch("Y+ (Front)")) && WeatherUtils::DrawColorEdit("Y+ (Front)", settings.dalc.directional[1].max))
 		changed = true;
-	if (MatchesSearch("Y- (Back)") && WeatherUtils::DrawColorEdit("Y- (Back)", settings.dalc.directional[1].min))
+	if ((MatchesSearch("Directional") || MatchesSearch("Y- (Back)")) && WeatherUtils::DrawColorEdit("Y- (Back)", settings.dalc.directional[1].min))
 		changed = true;
-	if (MatchesSearch("Z+ (Up)") && WeatherUtils::DrawColorEdit("Z+ (Up)", settings.dalc.directional[2].max))
+	if ((MatchesSearch("Directional") || MatchesSearch("Z+ (Up)")) && WeatherUtils::DrawColorEdit("Z+ (Up)", settings.dalc.directional[2].max))
 		changed = true;
-	if (MatchesSearch("Z- (Down)") && WeatherUtils::DrawColorEdit("Z- (Down)", settings.dalc.directional[2].min))
+	if ((MatchesSearch("Directional") || MatchesSearch("Z- (Down)")) && WeatherUtils::DrawColorEdit("Z- (Down)", settings.dalc.directional[2].min))
 		changed = true;
 
 	if (changed && EditorWindow::GetSingleton()->settings.autoApplyChanges) {

--- a/src/WeatherEditor/Weather/LightingTemplateWidget.cpp
+++ b/src/WeatherEditor/Weather/LightingTemplateWidget.cpp
@@ -160,9 +160,9 @@ void LightingTemplateWidget::DrawDALCSettings()
 	bool changed = false;
 
 	ImGui::SeparatorText("Directional Ambient Lighting (DALC)");
-	if (WeatherUtils::DrawColorEdit("Specular", settings.dalc.specular))
+	if (MatchesSearch("Specular") && WeatherUtils::DrawColorEdit("Specular", settings.dalc.specular))
 		changed = true;
-	if (WeatherUtils::DrawSliderFloat("Fresnel Power", settings.dalc.fresnelPower))
+	if (MatchesSearch("Fresnel Power") && WeatherUtils::DrawSliderFloat("Fresnel Power", settings.dalc.fresnelPower))
 		changed = true;
 
 	ImGui::SeparatorText("Directional Colors");

--- a/src/WeatherEditor/Weather/LightingTemplateWidget.cpp
+++ b/src/WeatherEditor/Weather/LightingTemplateWidget.cpp
@@ -159,59 +159,25 @@ void LightingTemplateWidget::DrawDALCSettings()
 {
 	bool changed = false;
 
-	if (ImGui::CollapsingHeader("Basic DALC", ImGuiTreeNodeFlags_DefaultOpen)) {
-		ImGui::Spacing();
-		if (WeatherUtils::DrawColorEdit("Specular", settings.dalc.specular))
-			changed = true;
-		ImGui::Spacing();
-		if (WeatherUtils::DrawSliderFloat("Fresnel Power", settings.dalc.fresnelPower))
-			changed = true;
-		ImGui::Spacing();
-	}
+	ImGui::SeparatorText("Directional Ambient Lighting (DALC)");
+	if (WeatherUtils::DrawColorEdit("Specular", settings.dalc.specular))
+		changed = true;
+	if (WeatherUtils::DrawSliderFloat("Fresnel Power", settings.dalc.fresnelPower))
+		changed = true;
 
-	if (ImGui::CollapsingHeader("Directional Colors (Time of Day)", ImGuiTreeNodeFlags_DefaultOpen)) {
-		// Note: The game engine uses X, Y, Z to represent time periods
-		// We map them to: X=Sunrise/Day, Y=Sunset, Z=Night for TOD display
-
-		if (TOD::BeginTODTable("DALCDirectionalTable")) {
-			TOD::RenderTODHeader();
-			TOD::DrawTODSeparator();
-
-			// Prepare arrays for TOD rendering (map X,Y,Z to Sunrise,Day,Sunset,Night)
-			float3 maxColors[4];
-			float3 minColors[4];
-
-			// Map X (index 0) to Sunrise and Day
-			maxColors[TOD::Sunrise] = settings.dalc.directional[0].max;
-			maxColors[TOD::Day] = settings.dalc.directional[0].max;
-			minColors[TOD::Sunrise] = settings.dalc.directional[0].min;
-			minColors[TOD::Day] = settings.dalc.directional[0].min;
-
-			// Map Y (index 1) to Sunset
-			maxColors[TOD::Sunset] = settings.dalc.directional[1].max;
-			minColors[TOD::Sunset] = settings.dalc.directional[1].min;
-
-			// Map Z (index 2) to Night
-			maxColors[TOD::Night] = settings.dalc.directional[2].max;
-			minColors[TOD::Night] = settings.dalc.directional[2].min;
-
-			if (TOD::DrawTODColorRow("Positive Direction (+)", maxColors)) {
-				settings.dalc.directional[0].max = maxColors[TOD::Sunrise];  // X from Sunrise
-				settings.dalc.directional[1].max = maxColors[TOD::Sunset];   // Y from Sunset
-				settings.dalc.directional[2].max = maxColors[TOD::Night];    // Z from Night
-				changed = true;
-			}
-
-			if (TOD::DrawTODColorRow("Negative Direction (-)", minColors)) {
-				settings.dalc.directional[0].min = minColors[TOD::Sunrise];  // X from Sunrise
-				settings.dalc.directional[1].min = minColors[TOD::Sunset];   // Y from Sunset
-				settings.dalc.directional[2].min = minColors[TOD::Night];    // Z from Night
-				changed = true;
-			}
-
-			TOD::EndTODTable();
-		}
-	}
+	ImGui::SeparatorText("Directional Colors");
+	if (MatchesSearch("X+ (Right)") && WeatherUtils::DrawColorEdit("X+ (Right)", settings.dalc.directional[0].max))
+		changed = true;
+	if (MatchesSearch("X- (Left)") && WeatherUtils::DrawColorEdit("X- (Left)", settings.dalc.directional[0].min))
+		changed = true;
+	if (MatchesSearch("Y+ (Front)") && WeatherUtils::DrawColorEdit("Y+ (Front)", settings.dalc.directional[1].max))
+		changed = true;
+	if (MatchesSearch("Y- (Back)") && WeatherUtils::DrawColorEdit("Y- (Back)", settings.dalc.directional[1].min))
+		changed = true;
+	if (MatchesSearch("Z+ (Up)") && WeatherUtils::DrawColorEdit("Z+ (Up)", settings.dalc.directional[2].max))
+		changed = true;
+	if (MatchesSearch("Z- (Down)") && WeatherUtils::DrawColorEdit("Z- (Down)", settings.dalc.directional[2].min))
+		changed = true;
 
 	if (changed && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
 		ApplyChanges();


### PR DESCRIPTION
Lighting templates for interiors do not have time of day. Matches cell lighting format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Lighting editor layout updated: section headers are now always visible; Specular and Fresnel Power controls appear only when matched by the search filter.
  * Directional color editor replaced: time‑of‑day table removed and replaced with direct per‑axis color controls (X+/X-/Y+/Y-/Z+/Z-) for min/max directional colors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->