### PR TITLE
fix(weather-editor): corrected slider behaviour for the imagespace widget

### DIFF
--- a/src/WeatherEditor/Weather/ImageSpaceWidget.cpp
+++ b/src/WeatherEditor/Weather/ImageSpaceWidget.cpp
@@ -43,7 +43,7 @@ void ImageSpaceWidget::DrawWidget()
 			const char* search = searchBuffer[0] ? searchBuffer : nullptr;
 
 			// HDR Settings
-			changed |= PropertyDrawer::DrawFloat("Eye Adapt Speed", settings.hdrEyeAdaptSpeed, 0.0f, 10.0f, search);
+			changed |= PropertyDrawer::DrawFloat("Eye Adapt Speed", settings.hdrEyeAdaptSpeed, 0.0f, 100.0f, search);
 			changed |= PropertyDrawer::DrawFloat("Bloom Blur Radius", settings.hdrBloomBlurRadius, 0.0f, 10.0f, search);
 			changed |= PropertyDrawer::DrawFloat("Bloom Threshold", settings.hdrBloomThreshold, 0.0f, 10.0f, search);
 			changed |= PropertyDrawer::DrawFloat("Bloom Scale", settings.hdrBloomScale, 0.0f, 10.0f, search);
@@ -72,8 +72,8 @@ void ImageSpaceWidget::DrawWidget()
 
 			// Depth of Field
 			changed |= PropertyDrawer::DrawFloat("DOF Strength", settings.dofStrength, 0.0f, 10.0f, search);
-			changed |= PropertyDrawer::DrawFloat("DOF Distance", settings.dofDistance, 0.0f, 10000.0f, search, "%.1f");
-			changed |= PropertyDrawer::DrawFloat("DOF Range", settings.dofRange, 0.0f, 10000.0f, search, "%.1f");
+			changed |= PropertyDrawer::DrawFloat("DOF Distance", settings.dofDistance, 0.0f, 50000.0f, search, "%.1f");
+			changed |= PropertyDrawer::DrawFloat("DOF Range", settings.dofRange, 0.0f, 50000.0f, search, "%.1f");
 
 			PropertyDrawer::EndTable();
 


### PR DESCRIPTION
expanded some limits because they were arbitrarily limiting, now should match what xedit allows or what kreate allows. based on feedback from lamin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Extended the maximum adjustable range for Eye Adapt Speed parameter, allowing values up to 100.0 (previously capped at 10.0).
  * Increased the maximum range for DOF Distance and DOF Range parameters to 50000.0 (previously capped at 10000.0), providing greater control over depth-of-field adjustments in the weather editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->