### PR TITLE
fix(weather-editor): corrected slider behaviour for the lighting template widget

### DIFF
--- a/src/WeatherEditor/Weather/CellLightingWidget.cpp
+++ b/src/WeatherEditor/Weather/CellLightingWidget.cpp
@@ -41,9 +41,9 @@ void CellLightingWidget::DrawWidget()
 			if (ImGui::BeginTabItem("Fog")) {
 				BeginScrollableContent("##FogScroll");
 				ImGui::SeparatorText("Fog Distance");
-				if (WeatherUtils::DrawSliderFloat("Fog Near", settings.fogNear, 0.0f, 10000.0f))
+				if (WeatherUtils::DrawSliderFloat("Fog Near", settings.fogNear, 0.0f, 163840.0f))
 					changed = true;
-				if (WeatherUtils::DrawSliderFloat("Fog Far", settings.fogFar, 0.0f, 50000.0f))
+				if (WeatherUtils::DrawSliderFloat("Fog Far", settings.fogFar, 0.0f, 163840.0f))
 					changed = true;
 
 				ImGui::SeparatorText("Fog Properties");
@@ -84,11 +84,11 @@ void CellLightingWidget::DrawWidget()
 			if (ImGui::BeginTabItem("Advanced")) {
 				BeginScrollableContent("##AdvancedScroll");
 				ImGui::SeparatorText("Light Fade Distances");
-				if (WeatherUtils::DrawSliderFloat("Light Fade Start", settings.lightFadeStart, 0.0f, 10000.0f))
+				if (WeatherUtils::DrawSliderFloat("Light Fade Start", settings.lightFadeStart, 0.0f, 163840.0f))
 					changed = true;
-				if (WeatherUtils::DrawSliderFloat("Light Fade End", settings.lightFadeEnd, 0.0f, 20000.0f))
+				if (WeatherUtils::DrawSliderFloat("Light Fade End", settings.lightFadeEnd, 0.0f, 163840.0f))
 					changed = true;
-				if (WeatherUtils::DrawSliderFloat("Clip Distance", settings.clipDist, 0.0f, 50000.0f))
+				if (WeatherUtils::DrawSliderFloat("Clip Distance", settings.clipDist, 0.0f, 163840.0f))
 					changed = true;
 
 				ImGui::SeparatorText("Directional Rotation");

--- a/src/WeatherEditor/Weather/LightingTemplateWidget.cpp
+++ b/src/WeatherEditor/Weather/LightingTemplateWidget.cpp
@@ -77,15 +77,15 @@ void LightingTemplateWidget::DrawBasicSettings()
 
 	if (ImGui::CollapsingHeader("Directional Settings", ImGuiTreeNodeFlags_DefaultOpen)) {
 		ImGui::Spacing();
-		if (MatchesSearch("Directional XY") && WeatherUtils::DrawSliderFloat("Directional XY", settings.directionalXY))
+		if (MatchesSearch("Directional XY") && WeatherUtils::DrawSliderFloat("Directional XY", settings.directionalXY, 0.0f, 360.0f))
 			changed = true;
 		if (MatchesSearch("Directional XY"))
 			ImGui::Spacing();
-		if (MatchesSearch("Directional Z") && WeatherUtils::DrawSliderFloat("Directional Z", settings.directionalZ))
+		if (MatchesSearch("Directional Z") && WeatherUtils::DrawSliderFloat("Directional Z", settings.directionalZ, 0.0f, 360.0f))
 			changed = true;
 		if (MatchesSearch("Directional Z"))
 			ImGui::Spacing();
-		if (MatchesSearch("Directional Fade") && WeatherUtils::DrawSliderFloat("Directional Fade", settings.directionalFade))
+		if (MatchesSearch("Directional Fade") && WeatherUtils::DrawSliderFloat("Directional Fade", settings.directionalFade, 0.0f, 10.0f))
 			changed = true;
 		if (MatchesSearch("Directional Fade"))
 			ImGui::Spacing();
@@ -93,11 +93,11 @@ void LightingTemplateWidget::DrawBasicSettings()
 
 	if (ImGui::CollapsingHeader("Light Fade", ImGuiTreeNodeFlags_DefaultOpen)) {
 		ImGui::Spacing();
-		if (MatchesSearch("Light Fade Start") && WeatherUtils::DrawSliderFloat("Light Fade Start", settings.lightFadeStart))
+		if (MatchesSearch("Light Fade Start") && WeatherUtils::DrawSliderFloat("Light Fade Start", settings.lightFadeStart, 0.0f, 16384.0f))
 			changed = true;
 		if (MatchesSearch("Light Fade Start"))
 			ImGui::Spacing();
-		if (MatchesSearch("Light Fade End") && WeatherUtils::DrawSliderFloat("Light Fade End", settings.lightFadeEnd))
+		if (MatchesSearch("Light Fade End") && WeatherUtils::DrawSliderFloat("Light Fade End", settings.lightFadeEnd, 0.0f, 16384.0f))
 			changed = true;
 		if (MatchesSearch("Light Fade End"))
 			ImGui::Spacing();
@@ -105,7 +105,7 @@ void LightingTemplateWidget::DrawBasicSettings()
 
 	if (ImGui::CollapsingHeader("Other", ImGuiTreeNodeFlags_DefaultOpen)) {
 		ImGui::Spacing();
-		if (MatchesSearch("Clip Distance") && WeatherUtils::DrawSliderFloat("Clip Distance", settings.clipDist))
+		if (MatchesSearch("Clip Distance") && WeatherUtils::DrawSliderFloat("Clip Distance", settings.clipDist, 0.0f, 16384.0f))
 			changed = true;
 		if (MatchesSearch("Clip Distance"))
 			ImGui::Spacing();
@@ -131,21 +131,21 @@ void LightingTemplateWidget::DrawFogSettings()
 		ImGui::Spacing();
 
 	ImGui::Spacing();
-	if (MatchesSearch("Fog Near") && WeatherUtils::DrawSliderFloat("Fog Near", settings.fogNear))
+	if (MatchesSearch("Fog Near") && WeatherUtils::DrawSliderFloat("Fog Near", settings.fogNear, 0.0f, 16384.0f))
 		changed = true;
 	if (MatchesSearch("Fog Near"))
 		ImGui::Spacing();
-	if (MatchesSearch("Fog Far") && WeatherUtils::DrawSliderFloat("Fog Far", settings.fogFar))
+	if (MatchesSearch("Fog Far") && WeatherUtils::DrawSliderFloat("Fog Far", settings.fogFar, 0.0f, 16384.0f))
 		changed = true;
 	if (MatchesSearch("Fog Far"))
 		ImGui::Spacing();
 
 	ImGui::Spacing();
-	if (MatchesSearch("Fog Power") && WeatherUtils::DrawSliderFloat("Fog Power", settings.fogPower))
+	if (MatchesSearch("Fog Power") && WeatherUtils::DrawSliderFloat("Fog Power", settings.fogPower, 0.0f, 10.0f))
 		changed = true;
 	if (MatchesSearch("Fog Power"))
 		ImGui::Spacing();
-	if (MatchesSearch("Fog Clamp") && WeatherUtils::DrawSliderFloat("Fog Clamp", settings.fogClamp))
+	if (MatchesSearch("Fog Clamp") && WeatherUtils::DrawSliderFloat("Fog Clamp", settings.fogClamp, 0.0f, 1.0f))
 		changed = true;
 	if (MatchesSearch("Fog Clamp"))
 		ImGui::Spacing();
@@ -162,7 +162,7 @@ void LightingTemplateWidget::DrawDALCSettings()
 	ImGui::SeparatorText("Directional Ambient Lighting (DALC)");
 	if (MatchesSearch("Specular") && WeatherUtils::DrawColorEdit("Specular", settings.dalc.specular))
 		changed = true;
-	if (MatchesSearch("Fresnel Power") && WeatherUtils::DrawSliderFloat("Fresnel Power", settings.dalc.fresnelPower))
+	if (MatchesSearch("Fresnel Power") && WeatherUtils::DrawSliderFloat("Fresnel Power", settings.dalc.fresnelPower, 0.0f, 10.0f))
 		changed = true;
 
 	ImGui::SeparatorText("Directional Colors");

--- a/src/WeatherEditor/Weather/LightingTemplateWidget.cpp
+++ b/src/WeatherEditor/Weather/LightingTemplateWidget.cpp
@@ -93,11 +93,11 @@ void LightingTemplateWidget::DrawBasicSettings()
 
 	if (ImGui::CollapsingHeader("Light Fade", ImGuiTreeNodeFlags_DefaultOpen)) {
 		ImGui::Spacing();
-		if (MatchesSearch("Light Fade Start") && WeatherUtils::DrawSliderFloat("Light Fade Start", settings.lightFadeStart, 0.0f, 16384.0f))
+		if (MatchesSearch("Light Fade Start") && WeatherUtils::DrawSliderFloat("Light Fade Start", settings.lightFadeStart, 0.0f, 163840.0f))
 			changed = true;
 		if (MatchesSearch("Light Fade Start"))
 			ImGui::Spacing();
-		if (MatchesSearch("Light Fade End") && WeatherUtils::DrawSliderFloat("Light Fade End", settings.lightFadeEnd, 0.0f, 16384.0f))
+		if (MatchesSearch("Light Fade End") && WeatherUtils::DrawSliderFloat("Light Fade End", settings.lightFadeEnd, 0.0f, 163840.0f))
 			changed = true;
 		if (MatchesSearch("Light Fade End"))
 			ImGui::Spacing();
@@ -105,7 +105,7 @@ void LightingTemplateWidget::DrawBasicSettings()
 
 	if (ImGui::CollapsingHeader("Other", ImGuiTreeNodeFlags_DefaultOpen)) {
 		ImGui::Spacing();
-		if (MatchesSearch("Clip Distance") && WeatherUtils::DrawSliderFloat("Clip Distance", settings.clipDist, 0.0f, 16384.0f))
+		if (MatchesSearch("Clip Distance") && WeatherUtils::DrawSliderFloat("Clip Distance", settings.clipDist, 0.0f, 163840.0f))
 			changed = true;
 		if (MatchesSearch("Clip Distance"))
 			ImGui::Spacing();
@@ -131,11 +131,11 @@ void LightingTemplateWidget::DrawFogSettings()
 		ImGui::Spacing();
 
 	ImGui::Spacing();
-	if (MatchesSearch("Fog Near") && WeatherUtils::DrawSliderFloat("Fog Near", settings.fogNear, 0.0f, 16384.0f))
+	if (MatchesSearch("Fog Near") && WeatherUtils::DrawSliderFloat("Fog Near", settings.fogNear, 0.0f, 163840.0f))
 		changed = true;
 	if (MatchesSearch("Fog Near"))
 		ImGui::Spacing();
-	if (MatchesSearch("Fog Far") && WeatherUtils::DrawSliderFloat("Fog Far", settings.fogFar, 0.0f, 16384.0f))
+	if (MatchesSearch("Fog Far") && WeatherUtils::DrawSliderFloat("Fog Far", settings.fogFar, 0.0f, 163840.0f))
 		changed = true;
 	if (MatchesSearch("Fog Far"))
 		ImGui::Spacing();


### PR DESCRIPTION
added proper bounds to sliders, now should match what xedit allows or what kreate allows. based on feedback from lamin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined slider ranges in the weather & lighting editors to enforce sensible limits: directional angles and fade, light fade start/end and clip distance, expanded fog distances and fog power/clamp, and DALC Fresnel power—preventing out-of-range values and improving control precision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->