### PR TITLE
fix(weather-editor): shader texture application

### DIFF
--- a/src/WeatherEditor/Weather/PrecipitationWidget.cpp
+++ b/src/WeatherEditor/Weather/PrecipitationWidget.cpp
@@ -166,10 +166,13 @@ void PrecipitationWidget::LoadSettings()
 					logger::warn("Precipitation {}: particleTexture is not a string, skipping", GetEditorID());
 				} else {
 					auto texPath = js["particleTexture"].get<std::string>();
-					if (IsValidTexturePath(texPath))
+					if (!HasValidTextureFormat(texPath)) {
+						logger::warn("Precipitation {}: ignoring malformed texture path '{}'", GetEditorID(), texPath);
+					} else {
 						settings.particleTexture = texPath;
-					else
-						logger::warn("Precipitation {}: ignoring invalid saved texture path '{}'", GetEditorID(), texPath);
+						if (!IsValidTexturePath(texPath))
+							logger::warn("Precipitation {}: saved texture path '{}' not found on disk", GetEditorID(), texPath);
+					}
 				}
 			}
 		} catch (const std::exception& e) {
@@ -264,8 +267,9 @@ void PrecipitationWidget::ApplyLiveParticleTexture(const std::string& path)
 	if (!sky || !sky->precip)
 		return;
 
-	auto* currentPrecip = sky->precip->currentPrecip.get();
-	if (path == lastAppliedTexture && currentPrecip == lastAppliedPrecip)
+	if (path == lastAppliedTexture &&
+		sky->precip->currentPrecip == lastAppliedPrecip &&
+		sky->precip->lastPrecip == lastAppliedPrecip)
 		return;
 
 	RE::NiPointer<RE::NiTexture> tex;
@@ -277,7 +281,7 @@ void PrecipitationWidget::ApplyLiveParticleTexture(const std::string& path)
 	if (!sourceTex->rendererTexture || !sourceTex->rendererTexture->texture)
 		return;
 
-	RE::BSGeometry* precipObjects[] = { currentPrecip, sky->precip->lastPrecip.get() };
+	RE::BSGeometry* precipObjects[] = { sky->precip->currentPrecip.get(), sky->precip->lastPrecip.get() };
 	for (auto* precipObject : precipObjects) {
 		if (!precipObject)
 			continue;
@@ -286,13 +290,15 @@ void PrecipitationWidget::ApplyLiveParticleTexture(const std::string& path)
 	}
 
 	lastAppliedTexture = path;
-	lastAppliedPrecip = currentPrecip;
+	lastAppliedPrecip = sky->precip->currentPrecip;
 }
 
 void PrecipitationWidget::RevertChanges()
 {
 	settings = vanillaSettings;
 	strncpy_s(textureBuffer, sizeof(textureBuffer), settings.particleTexture.c_str(), _TRUNCATE);
+	lastAppliedTexture.clear();
+	lastAppliedPrecip.reset();
 	ApplyChanges();
 }
 

--- a/src/WeatherEditor/Weather/PrecipitationWidget.cpp
+++ b/src/WeatherEditor/Weather/PrecipitationWidget.cpp
@@ -1,6 +1,9 @@
 #include "PrecipitationWidget.h"
 #include "../EditorWindow.h"
 #include "../WeatherUtils.h"
+#include "RE/B/BSShaderManager.h"
+#include "RE/N/NiSourceTexture.h"
+#include "Globals.h"
 
 void PrecipitationWidget::DrawWidget()
 {
@@ -72,10 +75,12 @@ void PrecipitationWidget::DrawWidget()
 				}
 
 				ImGui::SeparatorText("Texture Path");
-				if (ImGui::InputText("Particle Texture", textureBuffer, sizeof(textureBuffer))) {
+				if (ImGui::InputText("Particle Texture", textureBuffer, sizeof(textureBuffer), ImGuiInputTextFlags_EnterReturnsTrue)) {
 					settings.particleTexture = textureBuffer;
 					changed = true;
 				}
+				if (settings.particleTexture != textureBuffer)
+					ImGui::TextColored(globals::menu->GetTheme().StatusPalette.Warning, "Press Enter to apply texture change.");
 
 				EndScrollableContent();
 				ImGui::EndTabItem();
@@ -198,6 +203,29 @@ void PrecipitationWidget::ApplyChanges()
 	runtime.data[(uint32_t)RE::BGSShaderParticleGeometryData::DataID::kBoxSize].f = settings.boxSize;
 	runtime.data[(uint32_t)RE::BGSShaderParticleGeometryData::DataID::kParticleDensity].f = settings.particleDensity;
 	runtime.particleTexture.textureName = settings.particleTexture.c_str();
+	ApplyLiveParticleTexture(settings.particleTexture);
+}
+
+void PrecipitationWidget::ApplyLiveParticleTexture(const std::string& path)
+{
+	if (path.empty())
+		return;
+
+	RE::NiPointer<RE::NiTexture> tex;
+	RE::BSShaderManager::GetTexture(path.c_str(), true, tex, false);
+	if (!tex || tex->GetRTTI() != globals::rtti::NiSourceTextureRTTI.get())
+		return;
+
+	auto* sky = globals::game::sky;
+	if (!sky || !sky->precip)
+		return;
+
+	auto precipObject = sky->precip->currentPrecip ? sky->precip->currentPrecip : sky->precip->lastPrecip;
+	if (!precipObject)
+		return;
+
+	if (auto* shaderProp = netimmerse_cast<RE::BSParticleShaderProperty*>(precipObject->GetGeometryRuntimeData().shaderProperty.get()))
+		shaderProp->particleShaderTexture = RE::NiPointer(static_cast<RE::NiSourceTexture*>(tex.get()));
 }
 
 void PrecipitationWidget::RevertChanges()

--- a/src/WeatherEditor/Weather/PrecipitationWidget.cpp
+++ b/src/WeatherEditor/Weather/PrecipitationWidget.cpp
@@ -1,9 +1,9 @@
 #include "PrecipitationWidget.h"
 #include "../EditorWindow.h"
 #include "../WeatherUtils.h"
+#include "Globals.h"
 #include "RE/B/BSShaderManager.h"
 #include "RE/N/NiSourceTexture.h"
-#include "Globals.h"
 
 void PrecipitationWidget::DrawWidget()
 {

--- a/src/WeatherEditor/Weather/PrecipitationWidget.cpp
+++ b/src/WeatherEditor/Weather/PrecipitationWidget.cpp
@@ -99,6 +99,8 @@ void PrecipitationWidget::DrawWidget()
 				if (std::string_view buf(textureBuffer); settings.particleTexture != buf) {
 					if (!buf.empty() && !HasValidTextureFormat(buf))
 						ImGui::TextColored(globals::menu->GetTheme().StatusPalette.Error, "Path must start with 'textures\\' and end with '.dds'");
+					else if (!buf.empty() && HasValidTextureFormat(buf) && !IsValidTexturePath(std::string(buf)))
+						ImGui::TextColored(globals::menu->GetTheme().StatusPalette.Error, "Texture file not found under Data/.");
 					else
 						ImGui::TextColored(globals::menu->GetTheme().StatusPalette.Warning, "Press Enter to apply texture change.");
 				}
@@ -150,11 +152,15 @@ void PrecipitationWidget::LoadSettings()
 			if (js.contains("particleDensity"))
 				settings.particleDensity = js["particleDensity"];
 			if (js.contains("particleTexture")) {
-				auto texPath = js["particleTexture"].get<std::string>();
-				if (IsValidTexturePath(texPath))
-					settings.particleTexture = texPath;
-				else
-					logger::warn("Precipitation {}: ignoring invalid saved texture path '{}'", GetEditorID(), texPath);
+				if (!js["particleTexture"].is_string()) {
+					logger::warn("Precipitation {}: particleTexture is not a string, skipping", GetEditorID());
+				} else {
+					auto texPath = js["particleTexture"].get<std::string>();
+					if (IsValidTexturePath(texPath))
+						settings.particleTexture = texPath;
+					else
+						logger::warn("Precipitation {}: ignoring invalid saved texture path '{}'", GetEditorID(), texPath);
+				}
 			}
 		} catch (const std::exception& e) {
 			logger::error("Precipitation {}: Failed to load from JSON: {}", GetEditorID(), e.what());

--- a/src/WeatherEditor/Weather/PrecipitationWidget.cpp
+++ b/src/WeatherEditor/Weather/PrecipitationWidget.cpp
@@ -4,30 +4,6 @@
 #include "Globals.h"
 #include "RE/B/BSShaderManager.h"
 #include "RE/N/NiSourceTexture.h"
-#include "Utils/FileSystem.h"
-
-static std::string ToLowerBackslash(std::string_view path)
-{
-	std::string result(path);
-	std::transform(result.begin(), result.end(), result.begin(), [](unsigned char c) { return std::tolower(c); });
-	std::replace(result.begin(), result.end(), '/', '\\');
-	return result;
-}
-
-static bool HasValidTextureFormat(std::string_view path)
-{
-	return ToLowerBackslash(path).ends_with(".dds");
-}
-
-static bool IsValidTexturePath(const std::string& path)
-{
-	const std::string lower = ToLowerBackslash(path);
-	if (!lower.ends_with(".dds"))
-		return false;
-	auto fullPath = lower.starts_with("textures\\") ? Util::PathHelpers::GetDataPath() / path : Util::PathHelpers::GetDataPath() / "textures" / path;
-	std::error_code ec;
-	return std::filesystem::exists(fullPath, ec) && !ec;
-}
 
 void PrecipitationWidget::DrawWidget()
 {
@@ -102,7 +78,7 @@ void PrecipitationWidget::DrawWidget()
 				if (ImGui::InputText("Particle Texture", textureBuffer, sizeof(textureBuffer))) {
 					std::string_view buf(textureBuffer);
 					if (buf != lastCheckedBuffer) {
-						lastCheckedExists = IsValidTexturePath(std::string(buf));
+						lastCheckedExists = WeatherUtils::TexturePath::ExistsOnDisk(buf);
 						lastCheckedBuffer = std::string(buf);
 					}
 					if (lastCheckedExists) {
@@ -111,11 +87,11 @@ void PrecipitationWidget::DrawWidget()
 					}
 				}
 				if (std::string_view buf(textureBuffer); settings.particleTexture != buf) {
-					if (!buf.empty() && !HasValidTextureFormat(buf))
+					if (!buf.empty() && !WeatherUtils::TexturePath::HasDdsExtension(buf))
 						ImGui::TextColored(globals::menu->GetTheme().StatusPalette.Error, "Path must end with '.dds'");
 					else if (!buf.empty()) {
 						if (buf != lastCheckedBuffer) {
-							lastCheckedExists = IsValidTexturePath(std::string(buf));
+							lastCheckedExists = WeatherUtils::TexturePath::ExistsOnDisk(buf);
 							lastCheckedBuffer = std::string(buf);
 						}
 						if (!lastCheckedExists)
@@ -174,11 +150,11 @@ void PrecipitationWidget::LoadSettings()
 					logger::warn("Precipitation {}: particleTexture is not a string, skipping", GetEditorID());
 				} else {
 					auto texPath = js["particleTexture"].get<std::string>();
-					if (!HasValidTextureFormat(texPath)) {
+					if (!WeatherUtils::TexturePath::HasDdsExtension(texPath)) {
 						logger::warn("Precipitation {}: ignoring malformed texture path '{}'", GetEditorID(), texPath);
 					} else {
 						settings.particleTexture = texPath;
-						if (!IsValidTexturePath(texPath))
+						if (!WeatherUtils::TexturePath::ExistsOnDisk(texPath))
 							logger::warn("Precipitation {}: saved texture path '{}' not found on disk", GetEditorID(), texPath);
 					}
 				}
@@ -263,7 +239,7 @@ void PrecipitationWidget::ApplyLiveParticleTexture(const std::string& path)
 {
 	if (path.empty())
 		return;
-	if (!IsValidTexturePath(path)) {
+	if (!WeatherUtils::TexturePath::ExistsOnDisk(path)) {
 		if (path != lastInvalidTexture) {
 			logger::warn("Precipitation {}: invalid texture path '{}', must end with '.dds'", GetEditorID(), path);
 			lastInvalidTexture = path;

--- a/src/WeatherEditor/Weather/PrecipitationWidget.cpp
+++ b/src/WeatherEditor/Weather/PrecipitationWidget.cpp
@@ -6,21 +6,27 @@
 #include "RE/N/NiSourceTexture.h"
 #include "Utils/FileSystem.h"
 
+static std::string ToLowerBackslash(std::string_view path)
+{
+	std::string result(path);
+	std::transform(result.begin(), result.end(), result.begin(), [](unsigned char c) { return std::tolower(c); });
+	std::replace(result.begin(), result.end(), '/', '\\');
+	return result;
+}
+
 static bool HasValidTextureFormat(std::string_view path)
 {
-	std::string lower(path);
-	std::transform(lower.begin(), lower.end(), lower.begin(), [](unsigned char c) { return std::tolower(c); });
-	return lower.ends_with(".dds");
+	return ToLowerBackslash(path).ends_with(".dds");
 }
 
 static bool IsValidTexturePath(const std::string& path)
 {
-	if (!HasValidTextureFormat(path))
+	const std::string lower = ToLowerBackslash(path);
+	if (!lower.ends_with(".dds"))
 		return false;
-	std::string lower(path);
-	std::transform(lower.begin(), lower.end(), lower.begin(), [](unsigned char c) { return std::tolower(c); });
-	std::replace(lower.begin(), lower.end(), '/', '\\');
-	auto fullPath = lower.starts_with("textures\\") ? Util::PathHelpers::GetDataPath() / path : Util::PathHelpers::GetDataPath() / "textures" / path;
+	auto fullPath = lower.starts_with("textures\\")
+	                    ? Util::PathHelpers::GetDataPath() / path
+	                    : Util::PathHelpers::GetDataPath() / "textures" / path;
 	std::error_code ec;
 	return std::filesystem::exists(fullPath, ec) && !ec;
 }

--- a/src/WeatherEditor/Weather/PrecipitationWidget.cpp
+++ b/src/WeatherEditor/Weather/PrecipitationWidget.cpp
@@ -20,9 +20,7 @@ static bool IsValidTexturePath(const std::string& path)
 	std::string lower(path);
 	std::transform(lower.begin(), lower.end(), lower.begin(), [](unsigned char c) { return std::tolower(c); });
 	std::replace(lower.begin(), lower.end(), '/', '\\');
-	auto fullPath = lower.starts_with("textures\\")
-	                    ? Util::PathHelpers::GetDataPath() / path
-	                    : Util::PathHelpers::GetDataPath() / "textures" / path;
+	auto fullPath = lower.starts_with("textures\\") ? Util::PathHelpers::GetDataPath() / path : Util::PathHelpers::GetDataPath() / "textures" / path;
 	std::error_code ec;
 	return std::filesystem::exists(fullPath, ec) && !ec;
 }

--- a/src/WeatherEditor/Weather/PrecipitationWidget.cpp
+++ b/src/WeatherEditor/Weather/PrecipitationWidget.cpp
@@ -4,14 +4,20 @@
 #include "Globals.h"
 #include "RE/B/BSShaderManager.h"
 #include "RE/N/NiSourceTexture.h"
+#include "Utils/FileSystem.h"
+
+static bool HasValidTextureFormat(std::string_view path)
+{
+	std::string lower(path);
+	std::transform(lower.begin(), lower.end(), lower.begin(), [](unsigned char c) { return std::tolower(c); });
+	return lower.starts_with("textures\\") && lower.ends_with(".dds");
+}
 
 static bool IsValidTexturePath(const std::string& path)
 {
-	std::string lower = path;
-	std::transform(lower.begin(), lower.end(), lower.begin(), [](unsigned char c) { return std::tolower(c); });
-	if (!lower.starts_with("textures\\") || !lower.ends_with(".dds"))
+	if (!HasValidTextureFormat(path))
 		return false;
-	return std::filesystem::exists(std::filesystem::path("Data") / path);
+	return std::filesystem::exists(Util::PathHelpers::GetDataPath() / path);
 }
 
 void PrecipitationWidget::DrawWidget()
@@ -90,8 +96,8 @@ void PrecipitationWidget::DrawWidget()
 						changed = true;
 					}
 				}
-				if (std::string buf(textureBuffer); settings.particleTexture != buf) {
-					if (!buf.empty() && !IsValidTexturePath(buf))
+				if (std::string_view buf(textureBuffer); settings.particleTexture != buf) {
+					if (!buf.empty() && !HasValidTextureFormat(buf))
 						ImGui::TextColored(globals::menu->GetTheme().StatusPalette.Error, "Path must start with 'textures\\' and end with '.dds'");
 					else
 						ImGui::TextColored(globals::menu->GetTheme().StatusPalette.Warning, "Press Enter to apply texture change.");

--- a/src/WeatherEditor/Weather/PrecipitationWidget.cpp
+++ b/src/WeatherEditor/Weather/PrecipitationWidget.cpp
@@ -24,9 +24,7 @@ static bool IsValidTexturePath(const std::string& path)
 	const std::string lower = ToLowerBackslash(path);
 	if (!lower.ends_with(".dds"))
 		return false;
-	auto fullPath = lower.starts_with("textures\\")
-	                    ? Util::PathHelpers::GetDataPath() / path
-	                    : Util::PathHelpers::GetDataPath() / "textures" / path;
+	auto fullPath = lower.starts_with("textures\\") ? Util::PathHelpers::GetDataPath() / path : Util::PathHelpers::GetDataPath() / "textures" / path;
 	std::error_code ec;
 	return std::filesystem::exists(fullPath, ec) && !ec;
 }

--- a/src/WeatherEditor/Weather/PrecipitationWidget.cpp
+++ b/src/WeatherEditor/Weather/PrecipitationWidget.cpp
@@ -85,8 +85,10 @@ void PrecipitationWidget::DrawWidget()
 
 				ImGui::SeparatorText("Texture Path");
 				if (ImGui::InputText("Particle Texture", textureBuffer, sizeof(textureBuffer), ImGuiInputTextFlags_EnterReturnsTrue)) {
-					settings.particleTexture = textureBuffer;
-					changed = true;
+					if (IsValidTexturePath(textureBuffer)) {
+						settings.particleTexture = textureBuffer;
+						changed = true;
+					}
 				}
 				if (std::string buf(textureBuffer); settings.particleTexture != buf) {
 					if (!buf.empty() && !IsValidTexturePath(buf))
@@ -141,8 +143,13 @@ void PrecipitationWidget::LoadSettings()
 				settings.boxSize = js["boxSize"];
 			if (js.contains("particleDensity"))
 				settings.particleDensity = js["particleDensity"];
-			if (js.contains("particleTexture"))
-				settings.particleTexture = js["particleTexture"].get<std::string>();
+			if (js.contains("particleTexture")) {
+				auto texPath = js["particleTexture"].get<std::string>();
+				if (IsValidTexturePath(texPath))
+					settings.particleTexture = texPath;
+				else
+					logger::warn("Precipitation {}: ignoring invalid saved texture path '{}'", GetEditorID(), texPath);
+			}
 		} catch (const std::exception& e) {
 			logger::error("Precipitation {}: Failed to load from JSON: {}", GetEditorID(), e.what());
 			settings = vanillaSettings;

--- a/src/WeatherEditor/Weather/PrecipitationWidget.cpp
+++ b/src/WeatherEditor/Weather/PrecipitationWidget.cpp
@@ -5,6 +5,15 @@
 #include "RE/B/BSShaderManager.h"
 #include "RE/N/NiSourceTexture.h"
 
+static bool IsValidTexturePath(const std::string& path)
+{
+	std::string lower = path;
+	std::transform(lower.begin(), lower.end(), lower.begin(), [](unsigned char c) { return std::tolower(c); });
+	if (!lower.starts_with("textures\\") || !lower.ends_with(".dds"))
+		return false;
+	return std::filesystem::exists(std::filesystem::path("Data") / path);
+}
+
 void PrecipitationWidget::DrawWidget()
 {
 	WeatherUtils::SetCurrentWidget(this);
@@ -208,15 +217,6 @@ void PrecipitationWidget::ApplyChanges()
 	runtime.data[(uint32_t)RE::BGSShaderParticleGeometryData::DataID::kParticleDensity].f = settings.particleDensity;
 	runtime.particleTexture.textureName = settings.particleTexture.c_str();
 	ApplyLiveParticleTexture(settings.particleTexture);
-}
-
-static bool IsValidTexturePath(const std::string& path)
-{
-	std::string lower = path;
-	std::transform(lower.begin(), lower.end(), lower.begin(), [](unsigned char c) { return std::tolower(c); });
-	if (!lower.starts_with("textures\\") || !lower.ends_with(".dds"))
-		return false;
-	return std::filesystem::exists(std::filesystem::path("Data") / path);
 }
 
 void PrecipitationWidget::ApplyLiveParticleTexture(const std::string& path)

--- a/src/WeatherEditor/Weather/PrecipitationWidget.cpp
+++ b/src/WeatherEditor/Weather/PrecipitationWidget.cpp
@@ -10,14 +10,15 @@ static bool HasValidTextureFormat(std::string_view path)
 {
 	std::string lower(path);
 	std::transform(lower.begin(), lower.end(), lower.begin(), [](unsigned char c) { return std::tolower(c); });
-	return lower.starts_with("textures\\") && lower.ends_with(".dds");
+	return lower.ends_with(".dds");
 }
 
 static bool IsValidTexturePath(const std::string& path)
 {
 	if (!HasValidTextureFormat(path))
 		return false;
-	return std::filesystem::exists(Util::PathHelpers::GetDataPath() / path);
+	std::error_code ec;
+	return std::filesystem::exists(Util::PathHelpers::GetDataPath() / "textures" / path, ec) && !ec;
 }
 
 void PrecipitationWidget::DrawWidget()
@@ -90,19 +91,28 @@ void PrecipitationWidget::DrawWidget()
 				}
 
 				ImGui::SeparatorText("Texture Path");
-				if (ImGui::InputText("Particle Texture", textureBuffer, sizeof(textureBuffer), ImGuiInputTextFlags_EnterReturnsTrue)) {
-					if (IsValidTexturePath(textureBuffer)) {
-						settings.particleTexture = textureBuffer;
+				if (ImGui::InputText("Particle Texture", textureBuffer, sizeof(textureBuffer))) {
+					std::string_view buf(textureBuffer);
+					if (buf != lastCheckedBuffer) {
+						lastCheckedExists = IsValidTexturePath(std::string(buf));
+						lastCheckedBuffer = std::string(buf);
+					}
+					if (lastCheckedExists) {
+						settings.particleTexture = lastCheckedBuffer;
 						changed = true;
 					}
 				}
 				if (std::string_view buf(textureBuffer); settings.particleTexture != buf) {
 					if (!buf.empty() && !HasValidTextureFormat(buf))
-						ImGui::TextColored(globals::menu->GetTheme().StatusPalette.Error, "Path must start with 'textures\\' and end with '.dds'");
-					else if (!buf.empty() && HasValidTextureFormat(buf) && !IsValidTexturePath(std::string(buf)))
-						ImGui::TextColored(globals::menu->GetTheme().StatusPalette.Error, "Texture file not found under Data/.");
-					else
-						ImGui::TextColored(globals::menu->GetTheme().StatusPalette.Warning, "Press Enter to apply texture change.");
+						ImGui::TextColored(globals::menu->GetTheme().StatusPalette.Error, "Path must end with '.dds'");
+					else if (!buf.empty()) {
+						if (buf != lastCheckedBuffer) {
+							lastCheckedExists = IsValidTexturePath(std::string(buf));
+							lastCheckedBuffer = std::string(buf);
+						}
+						if (!lastCheckedExists)
+							ImGui::TextColored(globals::menu->GetTheme().StatusPalette.Error, "Texture file not found under Data/textures/.");
+					}
 				}
 
 				EndScrollableContent();
@@ -240,15 +250,22 @@ void PrecipitationWidget::ApplyChanges()
 
 void PrecipitationWidget::ApplyLiveParticleTexture(const std::string& path)
 {
-	if (path.empty()) {
-		logger::warn("Precipitation {}: empty texture path, live texture not updated", GetEditorID());
+	if (path.empty())
 		return;
-	}
 	if (!IsValidTexturePath(path)) {
-		logger::warn("Precipitation {}: invalid texture path '{}', must start with 'textures\\' and end with '.dds'", GetEditorID(), path);
+		if (path != lastInvalidTexture) {
+			logger::warn("Precipitation {}: invalid texture path '{}', must end with '.dds'", GetEditorID(), path);
+			lastInvalidTexture = path;
+		}
 		return;
 	}
-	if (path == lastAppliedTexture)
+
+	auto* sky = globals::game::sky;
+	if (!sky || !sky->precip)
+		return;
+
+	auto* currentPrecip = sky->precip->currentPrecip.get();
+	if (path == lastAppliedTexture && currentPrecip == lastAppliedPrecip)
 		return;
 
 	RE::NiPointer<RE::NiTexture> tex;
@@ -260,11 +277,7 @@ void PrecipitationWidget::ApplyLiveParticleTexture(const std::string& path)
 	if (!sourceTex->rendererTexture || !sourceTex->rendererTexture->texture)
 		return;
 
-	auto* sky = globals::game::sky;
-	if (!sky || !sky->precip)
-		return;
-
-	RE::BSGeometry* precipObjects[] = { sky->precip->currentPrecip.get(), sky->precip->lastPrecip.get() };
+	RE::BSGeometry* precipObjects[] = { currentPrecip, sky->precip->lastPrecip.get() };
 	for (auto* precipObject : precipObjects) {
 		if (!precipObject)
 			continue;
@@ -273,6 +286,7 @@ void PrecipitationWidget::ApplyLiveParticleTexture(const std::string& path)
 	}
 
 	lastAppliedTexture = path;
+	lastAppliedPrecip = currentPrecip;
 }
 
 void PrecipitationWidget::RevertChanges()

--- a/src/WeatherEditor/Weather/PrecipitationWidget.cpp
+++ b/src/WeatherEditor/Weather/PrecipitationWidget.cpp
@@ -79,8 +79,12 @@ void PrecipitationWidget::DrawWidget()
 					settings.particleTexture = textureBuffer;
 					changed = true;
 				}
-				if (settings.particleTexture != textureBuffer)
-					ImGui::TextColored(globals::menu->GetTheme().StatusPalette.Warning, "Press Enter to apply texture change.");
+				if (std::string buf(textureBuffer); settings.particleTexture != buf) {
+					if (!buf.empty() && !IsValidTexturePath(buf))
+						ImGui::TextColored(globals::menu->GetTheme().StatusPalette.Error, "Path must start with 'textures\\' and end with '.dds'");
+					else
+						ImGui::TextColored(globals::menu->GetTheme().StatusPalette.Warning, "Press Enter to apply texture change.");
+				}
 
 				EndScrollableContent();
 				ImGui::EndTabItem();
@@ -206,9 +210,26 @@ void PrecipitationWidget::ApplyChanges()
 	ApplyLiveParticleTexture(settings.particleTexture);
 }
 
+static bool IsValidTexturePath(const std::string& path)
+{
+	std::string lower = path;
+	std::transform(lower.begin(), lower.end(), lower.begin(), [](unsigned char c) { return std::tolower(c); });
+	if (!lower.starts_with("textures\\") || !lower.ends_with(".dds"))
+		return false;
+	return std::filesystem::exists(std::filesystem::path("Data") / path);
+}
+
 void PrecipitationWidget::ApplyLiveParticleTexture(const std::string& path)
 {
-	if (path.empty())
+	if (path.empty()) {
+		logger::warn("Precipitation {}: empty texture path, live texture not updated", GetEditorID());
+		return;
+	}
+	if (!IsValidTexturePath(path)) {
+		logger::warn("Precipitation {}: invalid texture path '{}', must start with 'textures\\' and end with '.dds'", GetEditorID(), path);
+		return;
+	}
+	if (path == lastAppliedTexture)
 		return;
 
 	RE::NiPointer<RE::NiTexture> tex;
@@ -216,16 +237,23 @@ void PrecipitationWidget::ApplyLiveParticleTexture(const std::string& path)
 	if (!tex || tex->GetRTTI() != globals::rtti::NiSourceTextureRTTI.get())
 		return;
 
+	auto* sourceTex = static_cast<RE::NiSourceTexture*>(tex.get());
+	if (!sourceTex->rendererTexture || !sourceTex->rendererTexture->texture)
+		return;
+
 	auto* sky = globals::game::sky;
 	if (!sky || !sky->precip)
 		return;
 
-	auto precipObject = sky->precip->currentPrecip ? sky->precip->currentPrecip : sky->precip->lastPrecip;
-	if (!precipObject)
-		return;
+	RE::BSGeometry* precipObjects[] = { sky->precip->currentPrecip.get(), sky->precip->lastPrecip.get() };
+	for (auto* precipObject : precipObjects) {
+		if (!precipObject)
+			continue;
+		if (auto* shaderProp = netimmerse_cast<RE::BSParticleShaderProperty*>(precipObject->GetGeometryRuntimeData().shaderProperty.get()))
+			shaderProp->particleShaderTexture = RE::NiPointer(sourceTex);
+	}
 
-	if (auto* shaderProp = netimmerse_cast<RE::BSParticleShaderProperty*>(precipObject->GetGeometryRuntimeData().shaderProperty.get()))
-		shaderProp->particleShaderTexture = RE::NiPointer(static_cast<RE::NiSourceTexture*>(tex.get()));
+	lastAppliedTexture = path;
 }
 
 void PrecipitationWidget::RevertChanges()

--- a/src/WeatherEditor/Weather/PrecipitationWidget.cpp
+++ b/src/WeatherEditor/Weather/PrecipitationWidget.cpp
@@ -17,8 +17,14 @@ static bool IsValidTexturePath(const std::string& path)
 {
 	if (!HasValidTextureFormat(path))
 		return false;
+	std::string lower(path);
+	std::transform(lower.begin(), lower.end(), lower.begin(), [](unsigned char c) { return std::tolower(c); });
+	std::replace(lower.begin(), lower.end(), '/', '\\');
+	auto fullPath = lower.starts_with("textures\\")
+	                    ? Util::PathHelpers::GetDataPath() / path
+	                    : Util::PathHelpers::GetDataPath() / "textures" / path;
 	std::error_code ec;
-	return std::filesystem::exists(Util::PathHelpers::GetDataPath() / "textures" / path, ec) && !ec;
+	return std::filesystem::exists(fullPath, ec) && !ec;
 }
 
 void PrecipitationWidget::DrawWidget()
@@ -299,6 +305,9 @@ void PrecipitationWidget::RevertChanges()
 	strncpy_s(textureBuffer, sizeof(textureBuffer), settings.particleTexture.c_str(), _TRUNCATE);
 	lastAppliedTexture.clear();
 	lastAppliedPrecip.reset();
+	lastInvalidTexture.clear();
+	lastCheckedBuffer.clear();
+	lastCheckedExists = false;
 	ApplyChanges();
 }
 

--- a/src/WeatherEditor/Weather/PrecipitationWidget.h
+++ b/src/WeatherEditor/Weather/PrecipitationWidget.h
@@ -60,7 +60,7 @@ private:
 	char textureBuffer[256] = {};
 	std::string lastAppliedTexture;
 	std::string lastInvalidTexture;
-	RE::BSGeometry* lastAppliedPrecip = nullptr;
+	RE::NiPointer<RE::BSGeometry> lastAppliedPrecip;
 	std::string lastCheckedBuffer;
 	bool lastCheckedExists = false;
 };

--- a/src/WeatherEditor/Weather/PrecipitationWidget.h
+++ b/src/WeatherEditor/Weather/PrecipitationWidget.h
@@ -59,4 +59,8 @@ private:
 	Settings originalSettings;
 	char textureBuffer[256] = {};
 	std::string lastAppliedTexture;
+	std::string lastInvalidTexture;
+	RE::BSGeometry* lastAppliedPrecip = nullptr;
+	std::string lastCheckedBuffer;
+	bool lastCheckedExists = false;
 };

--- a/src/WeatherEditor/Weather/PrecipitationWidget.h
+++ b/src/WeatherEditor/Weather/PrecipitationWidget.h
@@ -32,6 +32,10 @@ public:
 private:
 	void LoadFromGameSettings();
 
+	// Swaps the live precipitation particle texture (Sky → precip → BSParticleShaderProperty::particleShaderTexture).
+	// Needed because updating BGSShaderParticleGeometryData::particleTexture.textureName alone doesn't reload the GPU texture.
+	static void ApplyLiveParticleTexture(const std::string& path);
+
 	struct Settings
 	{
 		float gravityVelocity = 0.0f;

--- a/src/WeatherEditor/Weather/PrecipitationWidget.h
+++ b/src/WeatherEditor/Weather/PrecipitationWidget.h
@@ -34,7 +34,7 @@ private:
 
 	// Swaps the live precipitation particle texture (Sky → precip → BSParticleShaderProperty::particleShaderTexture).
 	// Needed because updating BGSShaderParticleGeometryData::particleTexture.textureName alone doesn't reload the GPU texture.
-	static void ApplyLiveParticleTexture(const std::string& path);
+	void ApplyLiveParticleTexture(const std::string& path);
 
 	struct Settings
 	{
@@ -58,4 +58,5 @@ private:
 	Settings vanillaSettings;
 	Settings originalSettings;
 	char textureBuffer[256] = {};
+	std::string lastAppliedTexture;
 };

--- a/src/WeatherEditor/Weather/WeatherWidget.cpp
+++ b/src/WeatherEditor/Weather/WeatherWidget.cpp
@@ -2030,14 +2030,7 @@ ID3D11ShaderResourceView* WeatherWidget::GetCloudTexture(int layerIndex)
 		return nullptr;
 	}
 
-	// Build resource path for BSA loading: Textures\path (relative to Data folder)
-	// Note: Skyrim texture paths don't include .dds extension, so we add it
-	std::string resourcePath = std::string("Textures\\") + texturePath;
-
-	// Add .dds extension if not present
-	if (resourcePath.size() < 4 || resourcePath.substr(resourcePath.size() - 4) != ".dds") {
-		resourcePath += ".dds";
-	}
+	std::string resourcePath = WeatherUtils::TexturePath::BuildResourcePath(texturePath);
 
 	ID3D11ShaderResourceView* srv = nullptr;
 	ImVec2 textureSize;

--- a/src/WeatherEditor/WeatherUtils.cpp
+++ b/src/WeatherEditor/WeatherUtils.cpp
@@ -1,7 +1,46 @@
 #include "WeatherUtils.h"
 #include "EditorWindow.h"
 #include "PaletteWindow.h"
+#include "Utils/FileSystem.h"
 #include "Utils/UI.h"
+
+namespace WeatherUtils::TexturePath
+{
+	std::string Normalize(std::string_view path)
+	{
+		std::string result(path);
+		std::transform(result.begin(), result.end(), result.begin(),
+			[](unsigned char c) { return std::tolower(c); });
+		std::replace(result.begin(), result.end(), '/', '\\');
+		return result;
+	}
+
+	bool HasDdsExtension(std::string_view path)
+	{
+		return Normalize(path).ends_with(".dds");
+	}
+
+	bool ExistsOnDisk(std::string_view path)
+	{
+		const std::string lower = Normalize(path);
+		if (!lower.ends_with(".dds"))
+			return false;
+		auto fullPath = lower.starts_with("textures\\") ?
+		                    Util::PathHelpers::GetDataPath() / path :
+		                    Util::PathHelpers::GetDataPath() / "textures" / path;
+		std::error_code ec;
+		return std::filesystem::exists(fullPath, ec) && !ec;
+	}
+
+	std::string BuildResourcePath(std::string_view path)
+	{
+		std::string result = "Textures\\";
+		result.append(path);
+		if (!Normalize(result).ends_with(".dds"))
+			result += ".dds";
+		return result;
+	}
+}
 
 // Global widget context for undo tracking
 static Widget* g_currentWidget = nullptr;

--- a/src/WeatherEditor/WeatherUtils.cpp
+++ b/src/WeatherEditor/WeatherUtils.cpp
@@ -25,9 +25,22 @@ namespace WeatherUtils::TexturePath
 		const std::string lower = Normalize(path);
 		if (!lower.ends_with(".dds"))
 			return false;
-		auto fullPath = lower.starts_with("textures\\") ?
-		                    Util::PathHelpers::GetDataPath() / path :
-		                    Util::PathHelpers::GetDataPath() / "textures" / path;
+
+		// Reject absolute paths
+		const std::filesystem::path fsPath(lower);
+		if (fsPath.is_absolute())
+			return false;
+
+		// Reject any ".." component
+		for (const auto& part : fsPath)
+			if (part == "..")
+				return false;
+
+		const std::filesystem::path dataPath = Util::PathHelpers::GetDataPath();
+		const std::filesystem::path fullPath = lower.starts_with("textures\\") ?
+		                                           dataPath / lower :
+		                                           dataPath / "textures" / lower;
+
 		std::error_code ec;
 		return std::filesystem::exists(fullPath, ec) && !ec;
 	}

--- a/src/WeatherEditor/WeatherUtils.h
+++ b/src/WeatherEditor/WeatherUtils.h
@@ -354,6 +354,22 @@ void EndWidgetSearchBar();
 
 namespace WeatherUtils
 {
+	// Texture path helpers shared by precipitation and cloud layer widgets.
+	namespace TexturePath
+	{
+		// Lowercase + convert forward slashes to backslashes.
+		std::string Normalize(std::string_view path);
+
+		// True if the normalized path ends with ".dds".
+		bool HasDdsExtension(std::string_view path);
+
+		// True if the file exists under Data/textures/ (accepts paths with or without the leading "textures\").
+		bool ExistsOnDisk(std::string_view path);
+
+		// Build a BSA-style resource path ("Textures\\<path>" with .dds appended if missing).
+		std::string BuildResourcePath(std::string_view path);
+	}
+
 	// Set the current widget for undo tracking (should be called at start of widget Draw())
 	void SetCurrentWidget(Widget* widget);
 


### PR DESCRIPTION
Previously the particle effect texture was not being applied when changing it in the editor. This PR addresses this by applying the texture live. Also changed the input to only apply when focus is lost or a valid texture is detected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Live apply of particle textures to precipitation immediately after confirming edits, with redundant updates avoided.

* **Bug Fixes**
  * Validates texture inputs (requires .dds, case-insensitive) and verifies files exist before updating settings; ignores non-string or malformed JSON values.
  * Revert now clears live-application caches to avoid stale textures.

* **Chores**
  * Added shared texture path utilities and unified resource-path construction for cloud/particle textures.

* **UX**
  * Inline error/warning messages indicate invalid or missing texture files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->