### PR TITLE
fix(weather-editor): slider behaviour for the Lens Flare widget

### DIFF
--- a/src/WeatherEditor/Weather/LensFlareWidget.cpp
+++ b/src/WeatherEditor/Weather/LensFlareWidget.cpp
@@ -12,7 +12,7 @@ void LensFlareWidget::DrawWidget()
 		bool changed = false;
 
 		ImGui::SeparatorText("Fade Distance");
-		if (ImGui::SliderFloat("Fade Dist Radius Scale", &settings.fadeDistRadiusScale, 0.0f, 10.0f))
+		if (ImGui::SliderFloat("Fade Dist Radius Scale", &settings.fadeDistRadiusScale, 0.0f, 1.0f))
 			changed = true;
 
 		ImGui::SeparatorText("Color");


### PR DESCRIPTION
set fade Dist Radius Scale to 0-1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the lens flare fade distance radius scale slider range to provide more precise control over the effect intensity, now constrained within a tighter parameter range for improved usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->