### PR TITLE
fix(weather-picker): lock weathers enforcement

### DIFF
--- a/src/Features/WeatherEditor.cpp
+++ b/src/Features/WeatherEditor.cpp
@@ -685,6 +685,12 @@ void WeatherEditor::RenderWeatherControls(RE::Sky* sky)
 				else
 					sky->SetWeather(selectedWeather, true, false);
 
+				// If the lock is active, retarget it to the newly chosen weather so
+				// Prepass() enforces the new choice instead of reverting it.
+				if (editorWindow->IsWeatherLocked()) {
+					editorWindow->lockedWeather = selectedWeather;
+				}
+
 				Util::ClearComboSearch(kWeatherSearchId);
 				logger::info("[WeatherEditor] Changed weather to: {}", Util::FormatWeather(selectedWeather));
 				break;


### PR DESCRIPTION
This PR allows the user to swap to a different weather using the weather picker, while a lock is active.
Previously the lock would prevent this. The lock is there purely to prevent the game from transitioning to a different weather.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed weather selection behavior when the weather lock feature is active. The editor now properly updates the locked weather to match the newly selected option, preventing it from reverting to the previous locked weather.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->