### PR TITLE
chore(weather-widget): remove unused code

### DIFF
--- a/src/WeatherEditor/Weather/WeatherWidget.cpp
+++ b/src/WeatherEditor/Weather/WeatherWidget.cpp
@@ -16,22 +16,6 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(WeatherWidget::DirectionalColor, max, min)
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(WeatherWidget::DALC, specular, fresnelPower, directional)
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(WeatherWidget::Cloud, cloudLayerSpeedY, cloudLayerSpeedX, color, cloudAlpha, enabled, texturePath)
 
-NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(WeatherWidget::ImageSpaceSettings,
-	hdrEyeAdaptSpeed,
-	hdrBloomBlurRadius,
-	hdrBloomThreshold,
-	hdrBloomScale,
-	hdrSunlightScale,
-	hdrSkyScale,
-	cinematicSaturation,
-	cinematicBrightness,
-	cinematicContrast,
-	tintColor,
-	tintAmount,
-	dofStrength,
-	dofDistance,
-	dofRange)
-
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(WeatherWidget::Settings,
 	parent,
 	inheritFlags,
@@ -41,7 +25,6 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(WeatherWidget::Settings,
 	atmosphereColors,
 	dalc,
 	clouds,
-	imageSpaces,
 	featureSettings)
 
 WeatherWidget::~WeatherWidget()
@@ -1660,7 +1643,6 @@ bool WeatherWidget::Settings::operator==(const Settings& o) const
 	       std::equal(std::begin(atmosphereColors), std::end(atmosphereColors), std::begin(o.atmosphereColors)) &&
 	       std::equal(std::begin(dalc), std::end(dalc), std::begin(o.dalc)) &&
 	       std::equal(std::begin(clouds), std::end(clouds), std::begin(o.clouds)) &&
-	       std::equal(std::begin(imageSpaces), std::end(imageSpaces), std::begin(o.imageSpaces)) &&
 	       featureSettings == o.featureSettings;
 }
 

--- a/src/WeatherEditor/Weather/WeatherWidget.cpp
+++ b/src/WeatherEditor/Weather/WeatherWidget.cpp
@@ -16,6 +16,22 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(WeatherWidget::DirectionalColor, max, min)
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(WeatherWidget::DALC, specular, fresnelPower, directional)
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(WeatherWidget::Cloud, cloudLayerSpeedY, cloudLayerSpeedX, color, cloudAlpha, enabled, texturePath)
 
+NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(WeatherWidget::ImageSpaceSettings,
+	hdrEyeAdaptSpeed,
+	hdrBloomBlurRadius,
+	hdrBloomThreshold,
+	hdrBloomScale,
+	hdrSunlightScale,
+	hdrSkyScale,
+	cinematicSaturation,
+	cinematicBrightness,
+	cinematicContrast,
+	tintColor,
+	tintAmount,
+	dofStrength,
+	dofDistance,
+	dofRange)
+
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(WeatherWidget::Settings,
 	parent,
 	inheritFlags,
@@ -25,6 +41,7 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE(WeatherWidget::Settings,
 	atmosphereColors,
 	dalc,
 	clouds,
+	imageSpaces,
 	featureSettings)
 
 WeatherWidget::~WeatherWidget()
@@ -1643,6 +1660,7 @@ bool WeatherWidget::Settings::operator==(const Settings& o) const
 	       std::equal(std::begin(atmosphereColors), std::end(atmosphereColors), std::begin(o.atmosphereColors)) &&
 	       std::equal(std::begin(dalc), std::end(dalc), std::begin(o.dalc)) &&
 	       std::equal(std::begin(clouds), std::end(clouds), std::begin(o.clouds)) &&
+	       std::equal(std::begin(imageSpaces), std::end(imageSpaces), std::begin(o.imageSpaces)) &&
 	       featureSettings == o.featureSettings;
 }
 

--- a/src/WeatherEditor/Weather/WeatherWidget.h
+++ b/src/WeatherEditor/Weather/WeatherWidget.h
@@ -67,6 +67,33 @@ public:
 		}
 	};
 
+	struct ImageSpaceSettings
+	{
+		// HDR Settings
+		float hdrEyeAdaptSpeed = 0.0f;
+		float hdrBloomBlurRadius = 0.0f;
+		float hdrBloomThreshold = 0.0f;
+		float hdrBloomScale = 0.0f;
+		float hdrSunlightScale = 0.0f;
+		float hdrSkyScale = 0.0f;
+
+		// Cinematic Settings
+		float cinematicSaturation = 0.0f;
+		float cinematicBrightness = 0.0f;
+		float cinematicContrast = 0.0f;
+
+		// Tint Colors
+		float3 tintColor = { 1.0f, 1.0f, 1.0f };
+		float tintAmount = 0.0f;
+
+		// Depth of Field
+		float dofStrength = 0.0f;
+		float dofDistance = 0.0f;
+		float dofRange = 0.0f;
+
+		bool operator==(const ImageSpaceSettings&) const = default;
+	};
+
 	struct Settings
 	{
 		std::string parent = "None";
@@ -80,11 +107,8 @@ public:
 		DALC dalc[ColorTimes::kTotal];
 		Cloud clouds[TESWeather::kTotalLayers];
 
-		// Record form references
-		RE::TESImageSpace* imageSpaceRefs[ColorTimes::kTotal] = {};
-		RE::BGSVolumetricLighting* volumetricLightingRefs[ColorTimes::kTotal] = {};
-		RE::BGSShaderParticleGeometryData* precipitationData = nullptr;
-		RE::BGSReferenceEffect* referenceEffect = nullptr;
+		// ImageSpace settings for each time of day
+		ImageSpaceSettings imageSpaces[ColorTimes::kTotal];
 
 		// Per-feature settings storage
 		std::map<std::string, json> featureSettings;

--- a/src/WeatherEditor/Weather/WeatherWidget.h
+++ b/src/WeatherEditor/Weather/WeatherWidget.h
@@ -80,12 +80,6 @@ public:
 		DALC dalc[ColorTimes::kTotal];
 		Cloud clouds[TESWeather::kTotalLayers];
 
-		// Record form references
-		RE::TESImageSpace* imageSpaceRefs[ColorTimes::kTotal] = {};
-		RE::BGSVolumetricLighting* volumetricLightingRefs[ColorTimes::kTotal] = {};
-		RE::BGSShaderParticleGeometryData* precipitationData = nullptr;
-		RE::BGSReferenceEffect* referenceEffect = nullptr;
-
 		// Per-feature settings storage
 		std::map<std::string, json> featureSettings;
 

--- a/src/WeatherEditor/Weather/WeatherWidget.h
+++ b/src/WeatherEditor/Weather/WeatherWidget.h
@@ -67,33 +67,6 @@ public:
 		}
 	};
 
-	struct ImageSpaceSettings
-	{
-		// HDR Settings
-		float hdrEyeAdaptSpeed = 0.0f;
-		float hdrBloomBlurRadius = 0.0f;
-		float hdrBloomThreshold = 0.0f;
-		float hdrBloomScale = 0.0f;
-		float hdrSunlightScale = 0.0f;
-		float hdrSkyScale = 0.0f;
-
-		// Cinematic Settings
-		float cinematicSaturation = 0.0f;
-		float cinematicBrightness = 0.0f;
-		float cinematicContrast = 0.0f;
-
-		// Tint Colors
-		float3 tintColor = { 1.0f, 1.0f, 1.0f };
-		float tintAmount = 0.0f;
-
-		// Depth of Field
-		float dofStrength = 0.0f;
-		float dofDistance = 0.0f;
-		float dofRange = 0.0f;
-
-		bool operator==(const ImageSpaceSettings&) const = default;
-	};
-
 	struct Settings
 	{
 		std::string parent = "None";
@@ -107,8 +80,11 @@ public:
 		DALC dalc[ColorTimes::kTotal];
 		Cloud clouds[TESWeather::kTotalLayers];
 
-		// ImageSpace settings for each time of day
-		ImageSpaceSettings imageSpaces[ColorTimes::kTotal];
+		// Record form references
+		RE::TESImageSpace* imageSpaceRefs[ColorTimes::kTotal] = {};
+		RE::BGSVolumetricLighting* volumetricLightingRefs[ColorTimes::kTotal] = {};
+		RE::BGSShaderParticleGeometryData* precipitationData = nullptr;
+		RE::BGSReferenceEffect* referenceEffect = nullptr;
 
 		// Per-feature settings storage
 		std::map<std::string, json> featureSettings;


### PR DESCRIPTION
removed leftover code that was never removed since the design stage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified weather settings structure by removing per-time-of-day image-space parameters (HDR, cinematic, tint, and depth-of-field settings) from the weather widget configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->