### PR TITLE
fix(weather-editor): Records tab serialization and tracking

### DIFF
--- a/src/WeatherEditor/Weather/WeatherWidget.cpp
+++ b/src/WeatherEditor/Weather/WeatherWidget.cpp
@@ -260,8 +260,10 @@ void WeatherWidget::DrawWidget()
 						bool& inheritFlag = settings.inheritFlags[inheritKey];
 						ImGui::Checkbox(("##inherit_" + inheritKey).c_str(), &inheritFlag);
 						if (inheritFlag && parentWidget) {
-							settings.imageSpaceRefs[i] = parentWidget->settings.imageSpaceRefs[i];
-							recordChanged = true;
+							if (settings.imageSpaceRefs[i] != parentWidget->settings.imageSpaceRefs[i]) {
+								settings.imageSpaceRefs[i] = parentWidget->settings.imageSpaceRefs[i];
+								recordChanged = true;
+							}
 						}
 						if (ImGui::IsItemHovered()) {
 							ImGui::SetTooltip(inheritFlag ? "Inheriting from parent" : "Inherit from parent");
@@ -306,8 +308,10 @@ void WeatherWidget::DrawWidget()
 						bool& inheritFlag = settings.inheritFlags[inheritKey];
 						ImGui::Checkbox(("##inherit_" + inheritKey).c_str(), &inheritFlag);
 						if (inheritFlag && parentWidget) {
-							settings.volumetricLightingRefs[i] = parentWidget->settings.volumetricLightingRefs[i];
-							recordChanged = true;
+							if (settings.volumetricLightingRefs[i] != parentWidget->settings.volumetricLightingRefs[i]) {
+								settings.volumetricLightingRefs[i] = parentWidget->settings.volumetricLightingRefs[i];
+								recordChanged = true;
+							}
 						}
 						if (ImGui::IsItemHovered()) {
 							ImGui::SetTooltip(inheritFlag ? "Inheriting from parent" : "Inherit from parent");
@@ -347,8 +351,10 @@ void WeatherWidget::DrawWidget()
 					bool& inheritFlag = settings.inheritFlags["Precipitation"];
 					ImGui::Checkbox("##inherit_Precipitation", &inheritFlag);
 					if (inheritFlag && parentWidget) {
-						settings.precipitationData = parentWidget->settings.precipitationData;
-						recordChanged = true;
+						if (settings.precipitationData != parentWidget->settings.precipitationData) {
+							settings.precipitationData = parentWidget->settings.precipitationData;
+							recordChanged = true;
+						}
 					}
 					if (ImGui::IsItemHovered()) {
 						ImGui::SetTooltip(inheritFlag ? "Inheriting from parent" : "Inherit from parent");
@@ -386,8 +392,10 @@ void WeatherWidget::DrawWidget()
 					bool& inheritFlag = settings.inheritFlags["ReferenceEffect"];
 					ImGui::Checkbox("##inherit_ReferenceEffect", &inheritFlag);
 					if (inheritFlag && parentWidget) {
-						settings.referenceEffect = parentWidget->settings.referenceEffect;
-						recordChanged = true;
+						if (settings.referenceEffect != parentWidget->settings.referenceEffect) {
+							settings.referenceEffect = parentWidget->settings.referenceEffect;
+							recordChanged = true;
+						}
 					}
 					if (ImGui::IsItemHovered()) {
 						ImGui::SetTooltip(inheritFlag ? "Inheriting from parent" : "Inherit from parent");
@@ -477,7 +485,7 @@ void WeatherWidget::LoadSettings()
 				if (id.empty())
 					return nullptr;
 				auto* f = WeatherUtils::FindFormByEditorID(id, widgets);
-				return f ? static_cast<T*>(f) : nullptr;
+				return f ? static_cast<T*>(f) : vanillaValue;
 			};
 			for (size_t i = 0; i < ColorTimes::kTotal; i++) {
 				settings.imageSpaceRefs[i] = loadRef(std::format("imageSpaceRef_{}", i), editorWindow->imageSpaceWidgets, vanillaSettings.imageSpaceRefs[i]);

--- a/src/WeatherEditor/Weather/WeatherWidget.cpp
+++ b/src/WeatherEditor/Weather/WeatherWidget.cpp
@@ -479,7 +479,7 @@ void WeatherWidget::LoadSettings()
 
 			// Record form references (resolved by matching widget EditorID)
 			auto* editorWindow = EditorWindow::GetSingleton();
-			auto findFormByEditorID = [](const std::string& editorID, const WidgetVec& widgets) -> RE::TESForm* {
+			auto findFormByEditorID = [](const std::string& editorID, const EditorWindow::WidgetVec& widgets) -> RE::TESForm* {
 				if (editorID.empty())
 					return nullptr;
 				for (const auto& w : widgets)
@@ -487,21 +487,19 @@ void WeatherWidget::LoadSettings()
 						return w->form;
 				return nullptr;
 			};
-			auto loadFormRef = [&](const std::string& key, auto*& ptr, const WidgetVec& widgets, auto* fallback) {
-				using T = std::remove_pointer_t<std::remove_reference_t<decltype(ptr)>>;
-				if (js.contains(key)) {
-					std::string editorID = js[key].get<std::string>();
-					ptr = static_cast<T*>(findFormByEditorID(editorID, widgets));
-				} else {
-					ptr = fallback;
-				}
+			auto loadEditorID = [&](const std::string& key) -> std::string {
+				return js.contains(key) ? js[key].get<std::string>() : "";
 			};
 			for (int i = 0; i < ColorTimes::kTotal; i++) {
-				loadFormRef(std::format("imageSpaceRef_{}", i), settings.imageSpaceRefs[i], editorWindow->imageSpaceWidgets, vanillaSettings.imageSpaceRefs[i]);
-				loadFormRef(std::format("volumetricLightingRef_{}", i), settings.volumetricLightingRefs[i], editorWindow->volumetricLightingWidgets, vanillaSettings.volumetricLightingRefs[i]);
+				auto* f = findFormByEditorID(loadEditorID(std::format("imageSpaceRef_{}", i)), editorWindow->imageSpaceWidgets);
+				settings.imageSpaceRefs[i] = f ? static_cast<RE::TESImageSpace*>(f) : vanillaSettings.imageSpaceRefs[i];
+				auto* vl = findFormByEditorID(loadEditorID(std::format("volumetricLightingRef_{}", i)), editorWindow->volumetricLightingWidgets);
+				settings.volumetricLightingRefs[i] = vl ? static_cast<RE::BGSVolumetricLighting*>(vl) : vanillaSettings.volumetricLightingRefs[i];
 			}
-			loadFormRef("precipitationDataRef", settings.precipitationData, editorWindow->precipitationWidgets, vanillaSettings.precipitationData);
-			loadFormRef("referenceEffectRef", settings.referenceEffect, editorWindow->referenceEffectWidgets, vanillaSettings.referenceEffect);
+			auto* precip = findFormByEditorID(loadEditorID("precipitationDataRef"), editorWindow->precipitationWidgets);
+			settings.precipitationData = precip ? static_cast<RE::BGSShaderParticleGeometryData*>(precip) : vanillaSettings.precipitationData;
+			auto* refEffect = findFormByEditorID(loadEditorID("referenceEffectRef"), editorWindow->referenceEffectWidgets);
+			settings.referenceEffect = refEffect ? static_cast<RE::BGSReferenceEffect*>(refEffect) : vanillaSettings.referenceEffect;
 
 		} catch (const nlohmann::json::exception& e) {
 			logger::error("Weather {}: Failed to deserialize settings from JSON: {}", GetEditorID(), e.what());
@@ -533,7 +531,7 @@ void WeatherWidget::SaveSettings()
 
 		// Record form references (serialized as widget EditorIDs for load-order independence)
 		auto* editorWindow = EditorWindow::GetSingleton();
-		auto findWidgetEditorID = [](RE::TESForm* form, const WidgetVec& widgets) -> std::string {
+		auto findWidgetEditorID = [](RE::TESForm* form, const EditorWindow::WidgetVec& widgets) -> std::string {
 			if (!form)
 				return "";
 			for (const auto& w : widgets)

--- a/src/WeatherEditor/Weather/WeatherWidget.cpp
+++ b/src/WeatherEditor/Weather/WeatherWidget.cpp
@@ -477,6 +477,23 @@ void WeatherWidget::LoadSettings()
 					settings.fogProperties.size());
 			}
 
+			// Record form references (stored as EditorIDs for load-order independence)
+			auto loadFormRef = [&](const std::string& key, auto*& ptr, auto* fallback) {
+				using T = std::remove_pointer_t<std::remove_reference_t<decltype(ptr)>>;
+				if (js.contains(key)) {
+					std::string editorID = js[key].get<std::string>();
+					ptr = editorID.empty() ? nullptr : RE::TESForm::LookupByEditorID<T>(editorID);
+				} else {
+					ptr = fallback;
+				}
+			};
+			for (int i = 0; i < ColorTimes::kTotal; i++) {
+				loadFormRef(std::format("imageSpaceRef_{}", i), settings.imageSpaceRefs[i], vanillaSettings.imageSpaceRefs[i]);
+				loadFormRef(std::format("volumetricLightingRef_{}", i), settings.volumetricLightingRefs[i], vanillaSettings.volumetricLightingRefs[i]);
+			}
+			loadFormRef("precipitationDataRef", settings.precipitationData, vanillaSettings.precipitationData);
+			loadFormRef("referenceEffectRef", settings.referenceEffect, vanillaSettings.referenceEffect);
+
 		} catch (const nlohmann::json::exception& e) {
 			logger::error("Weather {}: Failed to deserialize settings from JSON: {}", GetEditorID(), e.what());
 			// Fallback to vanilla/game values on exception
@@ -504,6 +521,14 @@ void WeatherWidget::SaveSettings()
 
 	try {
 		js = settings;
+
+		// Record form references (serialized as EditorIDs for load-order independence)
+		for (int i = 0; i < ColorTimes::kTotal; i++) {
+			js[std::format("imageSpaceRef_{}", i)] = settings.imageSpaceRefs[i] ? settings.imageSpaceRefs[i]->GetFormEditorID() : "";
+			js[std::format("volumetricLightingRef_{}", i)] = settings.volumetricLightingRefs[i] ? settings.volumetricLightingRefs[i]->GetFormEditorID() : "";
+		}
+		js["precipitationDataRef"] = settings.precipitationData ? settings.precipitationData->GetFormEditorID() : "";
+		js["referenceEffectRef"] = settings.referenceEffect ? settings.referenceEffect->GetFormEditorID() : "";
 
 		if (js.is_null()) {
 			logger::error("Weather {}: Serialization produced null JSON!", GetEditorID());

--- a/src/WeatherEditor/Weather/WeatherWidget.cpp
+++ b/src/WeatherEditor/Weather/WeatherWidget.cpp
@@ -260,8 +260,7 @@ void WeatherWidget::DrawWidget()
 						bool& inheritFlag = settings.inheritFlags[inheritKey];
 						ImGui::Checkbox(("##inherit_" + inheritKey).c_str(), &inheritFlag);
 						if (inheritFlag && parentWidget) {
-							weather->imageSpaces[i] = parentWidget->weather->imageSpaces[i];
-							settings.imageSpaceRefs[i] = weather->imageSpaces[i];
+							settings.imageSpaceRefs[i] = parentWidget->settings.imageSpaceRefs[i];
 							recordChanged = true;
 						}
 						if (ImGui::IsItemHovered()) {
@@ -272,15 +271,14 @@ void WeatherWidget::DrawWidget()
 
 					ImGui::Text("%s:", label.c_str());
 					ImGui::SameLine(todLabelOffset);
-					if (WeatherUtils::DrawFormPickerCached("##ImageSpace", weather->imageSpaces[i], editorWindow->imageSpaceWidgets, false, true, pickerWidth)) {
-						settings.imageSpaceRefs[i] = weather->imageSpaces[i];
+					if (WeatherUtils::DrawFormPickerCached("##ImageSpace", settings.imageSpaceRefs[i], editorWindow->imageSpaceWidgets, false, true, pickerWidth)) {
 						recordChanged = true;
 					}  // Add "Open" button
-					if (weather->imageSpaces[i]) {
+					if (settings.imageSpaceRefs[i]) {
 						ImGui::SameLine();
 						if (ImGui::SmallButton(std::format("Open##{}", i).c_str())) {
 							for (auto& widget : editorWindow->imageSpaceWidgets) {
-								if (widget->form == weather->imageSpaces[i]) {
+								if (widget->form == settings.imageSpaceRefs[i]) {
 									widget->SetOpen(true);
 									break;
 								}
@@ -308,8 +306,7 @@ void WeatherWidget::DrawWidget()
 						bool& inheritFlag = settings.inheritFlags[inheritKey];
 						ImGui::Checkbox(("##inherit_" + inheritKey).c_str(), &inheritFlag);
 						if (inheritFlag && parentWidget) {
-							weather->volumetricLighting[i] = parentWidget->weather->volumetricLighting[i];
-							settings.volumetricLightingRefs[i] = weather->volumetricLighting[i];
+							settings.volumetricLightingRefs[i] = parentWidget->settings.volumetricLightingRefs[i];
 							recordChanged = true;
 						}
 						if (ImGui::IsItemHovered()) {
@@ -320,15 +317,14 @@ void WeatherWidget::DrawWidget()
 
 					ImGui::Text("%s:", label.c_str());
 					ImGui::SameLine(todLabelOffset);
-					if (WeatherUtils::DrawFormPickerCached("##VolumetricLighting", weather->volumetricLighting[i], editorWindow->volumetricLightingWidgets, false, true, pickerWidth)) {
-						settings.volumetricLightingRefs[i] = weather->volumetricLighting[i];
+					if (WeatherUtils::DrawFormPickerCached("##VolumetricLighting", settings.volumetricLightingRefs[i], editorWindow->volumetricLightingWidgets, false, true, pickerWidth)) {
 						recordChanged = true;
 					}  // Add "Open" button
-					if (weather->volumetricLighting[i]) {
+					if (settings.volumetricLightingRefs[i]) {
 						ImGui::SameLine();
 						if (ImGui::SmallButton(std::format("Open##{}", i).c_str())) {
 							for (auto& widget : editorWindow->volumetricLightingWidgets) {
-								if (widget->form == weather->volumetricLighting[i]) {
+								if (widget->form == settings.volumetricLightingRefs[i]) {
 									widget->SetOpen(true);
 									break;
 								}
@@ -351,8 +347,7 @@ void WeatherWidget::DrawWidget()
 					bool& inheritFlag = settings.inheritFlags["Precipitation"];
 					ImGui::Checkbox("##inherit_Precipitation", &inheritFlag);
 					if (inheritFlag && parentWidget) {
-						weather->precipitationData = parentWidget->weather->precipitationData;
-						settings.precipitationData = weather->precipitationData;
+						settings.precipitationData = parentWidget->settings.precipitationData;
 						recordChanged = true;
 					}
 					if (ImGui::IsItemHovered()) {
@@ -363,15 +358,14 @@ void WeatherWidget::DrawWidget()
 
 				ImGui::Text("Particle Shader:");
 				ImGui::SameLine(formLabelOffset);
-				if (WeatherUtils::DrawFormPickerCached("##Precipitation", weather->precipitationData, editorWindow->precipitationWidgets, false, true, pickerWidth)) {
-					settings.precipitationData = weather->precipitationData;
+				if (WeatherUtils::DrawFormPickerCached("##Precipitation", settings.precipitationData, editorWindow->precipitationWidgets, false, true, pickerWidth)) {
 					recordChanged = true;
 				}  // Add "Open" button
-				if (weather->precipitationData) {
+				if (settings.precipitationData) {
 					ImGui::SameLine();
 					if (ImGui::SmallButton("Open##Precip")) {
 						for (auto& widget : editorWindow->precipitationWidgets) {
-							if (widget->form == weather->precipitationData) {
+							if (widget->form == settings.precipitationData) {
 								widget->SetOpen(true);
 								break;
 							}
@@ -392,8 +386,7 @@ void WeatherWidget::DrawWidget()
 					bool& inheritFlag = settings.inheritFlags["ReferenceEffect"];
 					ImGui::Checkbox("##inherit_ReferenceEffect", &inheritFlag);
 					if (inheritFlag && parentWidget) {
-						weather->referenceEffect = parentWidget->weather->referenceEffect;
-						settings.referenceEffect = weather->referenceEffect;
+						settings.referenceEffect = parentWidget->settings.referenceEffect;
 						recordChanged = true;
 					}
 					if (ImGui::IsItemHovered()) {
@@ -404,15 +397,14 @@ void WeatherWidget::DrawWidget()
 
 				ImGui::Text("Reference Effect:");
 				ImGui::SameLine(formLabelOffset);
-				if (WeatherUtils::DrawFormPickerCached("##ReferenceEffect", weather->referenceEffect, editorWindow->referenceEffectWidgets, false, true, pickerWidth)) {
-					settings.referenceEffect = weather->referenceEffect;
+				if (WeatherUtils::DrawFormPickerCached("##ReferenceEffect", settings.referenceEffect, editorWindow->referenceEffectWidgets, false, true, pickerWidth)) {
 					recordChanged = true;
 				}  // Add "Open" button
-				if (weather->referenceEffect) {
+				if (settings.referenceEffect) {
 					ImGui::SameLine();
 					if (ImGui::SmallButton("Open##RefEffect")) {
 						for (auto& widget : editorWindow->referenceEffectWidgets) {
-							if (widget->form == weather->referenceEffect) {
+							if (widget->form == settings.referenceEffect) {
 								widget->SetOpen(true);
 								break;
 							}
@@ -476,20 +468,23 @@ void WeatherWidget::LoadSettings()
 			}
 
 			// Record form references (resolved by matching widget EditorID)
+			// Three cases: key missing -> vanilla, key present with "" -> explicit None (nullptr), key present with id -> lookup form
 			auto* editorWindow = EditorWindow::GetSingleton();
-			auto loadEditorID = [&](const std::string& key) -> std::string {
-				return (js.contains(key) && js[key].is_string()) ? js[key].get<std::string>() : "";
+			auto loadRef = [&]<typename T>(const std::string& key, const std::vector<std::unique_ptr<Widget>>& widgets, T* vanillaValue) -> T* {
+				if (!js.contains(key) || !js[key].is_string())
+					return vanillaValue;
+				const std::string id = js[key].get<std::string>();
+				if (id.empty())
+					return nullptr;
+				auto* f = WeatherUtils::FindFormByEditorID(id, widgets);
+				return f ? static_cast<T*>(f) : nullptr;
 			};
 			for (size_t i = 0; i < ColorTimes::kTotal; i++) {
-				auto* f = WeatherUtils::FindFormByEditorID(loadEditorID(std::format("imageSpaceRef_{}", i)), editorWindow->imageSpaceWidgets);
-				settings.imageSpaceRefs[i] = f ? static_cast<RE::TESImageSpace*>(f) : vanillaSettings.imageSpaceRefs[i];
-				auto* vl = WeatherUtils::FindFormByEditorID(loadEditorID(std::format("volumetricLightingRef_{}", i)), editorWindow->volumetricLightingWidgets);
-				settings.volumetricLightingRefs[i] = vl ? static_cast<RE::BGSVolumetricLighting*>(vl) : vanillaSettings.volumetricLightingRefs[i];
+				settings.imageSpaceRefs[i] = loadRef(std::format("imageSpaceRef_{}", i), editorWindow->imageSpaceWidgets, vanillaSettings.imageSpaceRefs[i]);
+				settings.volumetricLightingRefs[i] = loadRef(std::format("volumetricLightingRef_{}", i), editorWindow->volumetricLightingWidgets, vanillaSettings.volumetricLightingRefs[i]);
 			}
-			auto* precip = WeatherUtils::FindFormByEditorID(loadEditorID("precipitationDataRef"), editorWindow->precipitationWidgets);
-			settings.precipitationData = precip ? static_cast<RE::BGSShaderParticleGeometryData*>(precip) : vanillaSettings.precipitationData;
-			auto* refEffect = WeatherUtils::FindFormByEditorID(loadEditorID("referenceEffectRef"), editorWindow->referenceEffectWidgets);
-			settings.referenceEffect = refEffect ? static_cast<RE::BGSReferenceEffect*>(refEffect) : vanillaSettings.referenceEffect;
+			settings.precipitationData = loadRef("precipitationDataRef", editorWindow->precipitationWidgets, vanillaSettings.precipitationData);
+			settings.referenceEffect = loadRef("referenceEffectRef", editorWindow->referenceEffectWidgets, vanillaSettings.referenceEffect);
 
 		} catch (const nlohmann::json::exception& e) {
 			logger::error("Weather {}: Failed to deserialize settings from JSON: {}", GetEditorID(), e.what());

--- a/src/WeatherEditor/Weather/WeatherWidget.cpp
+++ b/src/WeatherEditor/Weather/WeatherWidget.cpp
@@ -632,6 +632,14 @@ void WeatherWidget::SetWeatherValues()
 	}
 	weather->cloudLayerDisabledBits = disabledBits;
 
+	// Record form references
+	for (size_t i = 0; i < ColorTimes::kTotal; i++) {
+		weather->imageSpaces[i] = settings.imageSpaceRefs[i];
+		weather->volumetricLighting[i] = settings.volumetricLightingRefs[i];
+	}
+	weather->precipitationData = settings.precipitationData;
+	weather->referenceEffect = settings.referenceEffect;
+
 	// If this weather is currently active, immediately apply feature settings to game memory
 	auto* weatherManager = WeatherManager::GetSingleton();
 	if (weatherManager->GetCurrentWeathers().currentWeather == weather) {

--- a/src/WeatherEditor/Weather/WeatherWidget.cpp
+++ b/src/WeatherEditor/Weather/WeatherWidget.cpp
@@ -477,22 +477,31 @@ void WeatherWidget::LoadSettings()
 					settings.fogProperties.size());
 			}
 
-			// Record form references (stored as EditorIDs for load-order independence)
-			auto loadFormRef = [&](const std::string& key, auto*& ptr, auto* fallback) {
+			// Record form references (resolved by matching widget EditorID)
+			auto* editorWindow = EditorWindow::GetSingleton();
+			auto findFormByEditorID = [](const std::string& editorID, const WidgetVec& widgets) -> RE::TESForm* {
+				if (editorID.empty())
+					return nullptr;
+				for (const auto& w : widgets)
+					if (w->GetEditorID() == editorID)
+						return w->form;
+				return nullptr;
+			};
+			auto loadFormRef = [&](const std::string& key, auto*& ptr, const WidgetVec& widgets, auto* fallback) {
 				using T = std::remove_pointer_t<std::remove_reference_t<decltype(ptr)>>;
 				if (js.contains(key)) {
 					std::string editorID = js[key].get<std::string>();
-					ptr = editorID.empty() ? nullptr : RE::TESForm::LookupByEditorID<T>(editorID);
+					ptr = static_cast<T*>(findFormByEditorID(editorID, widgets));
 				} else {
 					ptr = fallback;
 				}
 			};
 			for (int i = 0; i < ColorTimes::kTotal; i++) {
-				loadFormRef(std::format("imageSpaceRef_{}", i), settings.imageSpaceRefs[i], vanillaSettings.imageSpaceRefs[i]);
-				loadFormRef(std::format("volumetricLightingRef_{}", i), settings.volumetricLightingRefs[i], vanillaSettings.volumetricLightingRefs[i]);
+				loadFormRef(std::format("imageSpaceRef_{}", i), settings.imageSpaceRefs[i], editorWindow->imageSpaceWidgets, vanillaSettings.imageSpaceRefs[i]);
+				loadFormRef(std::format("volumetricLightingRef_{}", i), settings.volumetricLightingRefs[i], editorWindow->volumetricLightingWidgets, vanillaSettings.volumetricLightingRefs[i]);
 			}
-			loadFormRef("precipitationDataRef", settings.precipitationData, vanillaSettings.precipitationData);
-			loadFormRef("referenceEffectRef", settings.referenceEffect, vanillaSettings.referenceEffect);
+			loadFormRef("precipitationDataRef", settings.precipitationData, editorWindow->precipitationWidgets, vanillaSettings.precipitationData);
+			loadFormRef("referenceEffectRef", settings.referenceEffect, editorWindow->referenceEffectWidgets, vanillaSettings.referenceEffect);
 
 		} catch (const nlohmann::json::exception& e) {
 			logger::error("Weather {}: Failed to deserialize settings from JSON: {}", GetEditorID(), e.what());
@@ -522,13 +531,22 @@ void WeatherWidget::SaveSettings()
 	try {
 		js = settings;
 
-		// Record form references (serialized as EditorIDs for load-order independence)
+		// Record form references (serialized as widget EditorIDs for load-order independence)
+		auto* editorWindow = EditorWindow::GetSingleton();
+		auto findWidgetEditorID = [](RE::TESForm* form, const WidgetVec& widgets) -> std::string {
+			if (!form)
+				return "";
+			for (const auto& w : widgets)
+				if (w->form == form)
+					return w->GetEditorID();
+			return "";
+		};
 		for (int i = 0; i < ColorTimes::kTotal; i++) {
-			js[std::format("imageSpaceRef_{}", i)] = settings.imageSpaceRefs[i] ? settings.imageSpaceRefs[i]->GetFormEditorID() : "";
-			js[std::format("volumetricLightingRef_{}", i)] = settings.volumetricLightingRefs[i] ? settings.volumetricLightingRefs[i]->GetFormEditorID() : "";
+			js[std::format("imageSpaceRef_{}", i)] = findWidgetEditorID(settings.imageSpaceRefs[i], editorWindow->imageSpaceWidgets);
+			js[std::format("volumetricLightingRef_{}", i)] = findWidgetEditorID(settings.volumetricLightingRefs[i], editorWindow->volumetricLightingWidgets);
 		}
-		js["precipitationDataRef"] = settings.precipitationData ? settings.precipitationData->GetFormEditorID() : "";
-		js["referenceEffectRef"] = settings.referenceEffect ? settings.referenceEffect->GetFormEditorID() : "";
+		js["precipitationDataRef"] = findWidgetEditorID(settings.precipitationData, editorWindow->precipitationWidgets);
+		js["referenceEffectRef"] = findWidgetEditorID(settings.referenceEffect, editorWindow->referenceEffectWidgets);
 
 		if (js.is_null()) {
 			logger::error("Weather {}: Serialization produced null JSON!", GetEditorID());

--- a/src/WeatherEditor/Weather/WeatherWidget.cpp
+++ b/src/WeatherEditor/Weather/WeatherWidget.cpp
@@ -258,12 +258,11 @@ void WeatherWidget::DrawWidget()
 					// Inherit checkbox
 					if (hasParent) {
 						bool& inheritFlag = settings.inheritFlags[inheritKey];
-						if (ImGui::Checkbox(("##inherit_" + inheritKey).c_str(), &inheritFlag)) {
-							if (inheritFlag && parentWidget) {
-								weather->imageSpaces[i] = parentWidget->weather->imageSpaces[i];
-								settings.imageSpaceRefs[i] = weather->imageSpaces[i];
-								recordChanged = true;
-							}
+						ImGui::Checkbox(("##inherit_" + inheritKey).c_str(), &inheritFlag);
+						if (inheritFlag && parentWidget) {
+							weather->imageSpaces[i] = parentWidget->weather->imageSpaces[i];
+							settings.imageSpaceRefs[i] = weather->imageSpaces[i];
+							recordChanged = true;
 						}
 						if (ImGui::IsItemHovered()) {
 							ImGui::SetTooltip(inheritFlag ? "Inheriting from parent" : "Inherit from parent");
@@ -307,12 +306,11 @@ void WeatherWidget::DrawWidget()
 					// Inherit checkbox
 					if (hasParent) {
 						bool& inheritFlag = settings.inheritFlags[inheritKey];
-						if (ImGui::Checkbox(("##inherit_" + inheritKey).c_str(), &inheritFlag)) {
-							if (inheritFlag && parentWidget) {
-								weather->volumetricLighting[i] = parentWidget->weather->volumetricLighting[i];
-								settings.volumetricLightingRefs[i] = weather->volumetricLighting[i];
-								recordChanged = true;
-							}
+						ImGui::Checkbox(("##inherit_" + inheritKey).c_str(), &inheritFlag);
+						if (inheritFlag && parentWidget) {
+							weather->volumetricLighting[i] = parentWidget->weather->volumetricLighting[i];
+							settings.volumetricLightingRefs[i] = weather->volumetricLighting[i];
+							recordChanged = true;
 						}
 						if (ImGui::IsItemHovered()) {
 							ImGui::SetTooltip(inheritFlag ? "Inheriting from parent" : "Inherit from parent");
@@ -351,12 +349,11 @@ void WeatherWidget::DrawWidget()
 				// Inherit checkbox
 				if (hasParent) {
 					bool& inheritFlag = settings.inheritFlags["Precipitation"];
-					if (ImGui::Checkbox("##inherit_Precipitation", &inheritFlag)) {
-						if (inheritFlag && parentWidget) {
-							weather->precipitationData = parentWidget->weather->precipitationData;
-							settings.precipitationData = weather->precipitationData;
-							recordChanged = true;
-						}
+					ImGui::Checkbox("##inherit_Precipitation", &inheritFlag);
+					if (inheritFlag && parentWidget) {
+						weather->precipitationData = parentWidget->weather->precipitationData;
+						settings.precipitationData = weather->precipitationData;
+						recordChanged = true;
 					}
 					if (ImGui::IsItemHovered()) {
 						ImGui::SetTooltip(inheritFlag ? "Inheriting from parent" : "Inherit from parent");
@@ -393,12 +390,11 @@ void WeatherWidget::DrawWidget()
 				// Inherit checkbox
 				if (hasParent) {
 					bool& inheritFlag = settings.inheritFlags["ReferenceEffect"];
-					if (ImGui::Checkbox("##inherit_ReferenceEffect", &inheritFlag)) {
-						if (inheritFlag && parentWidget) {
-							weather->referenceEffect = parentWidget->weather->referenceEffect;
-							settings.referenceEffect = weather->referenceEffect;
-							recordChanged = true;
-						}
+					ImGui::Checkbox("##inherit_ReferenceEffect", &inheritFlag);
+					if (inheritFlag && parentWidget) {
+						weather->referenceEffect = parentWidget->weather->referenceEffect;
+						settings.referenceEffect = weather->referenceEffect;
+						recordChanged = true;
 					}
 					if (ImGui::IsItemHovered()) {
 						ImGui::SetTooltip(inheritFlag ? "Inheriting from parent" : "Inherit from parent");
@@ -1508,6 +1504,14 @@ void WeatherWidget::InheritAllFromParent()
 		settings.clouds[i] = parentWidget->settings.clouds[i];
 	}
 
+	// Copy records (form references)
+	for (size_t i = 0; i < ColorTimes::kTotal; i++) {
+		settings.imageSpaceRefs[i] = parentWidget->settings.imageSpaceRefs[i];
+		settings.volumetricLightingRefs[i] = parentWidget->settings.volumetricLightingRefs[i];
+	}
+	settings.precipitationData = parentWidget->settings.precipitationData;
+	settings.referenceEffect = parentWidget->settings.referenceEffect;
+
 	// Set all inherit flags to true
 	settings.inheritFlags["DALC_Specular"] = true;
 	settings.inheritFlags["DALC_Fresnel"] = true;
@@ -1536,6 +1540,14 @@ void WeatherWidget::InheritAllFromParent()
 		settings.inheritFlags[std::format("Cloud{}_Color", i)] = true;
 		settings.inheritFlags[std::format("Cloud{}_Alpha", i)] = true;
 	}
+
+	// Records
+	for (size_t i = 0; i < ColorTimes::kTotal; i++) {
+		settings.inheritFlags["ImageSpace_" + std::to_string(i)] = true;
+		settings.inheritFlags["VolumetricLighting_" + std::to_string(i)] = true;
+	}
+	settings.inheritFlags["Precipitation"] = true;
+	settings.inheritFlags["ReferenceEffect"] = true;
 
 	// Apply the changes
 	if (EditorWindow::GetSingleton()->settings.autoApplyChanges) {

--- a/src/WeatherEditor/Weather/WeatherWidget.cpp
+++ b/src/WeatherEditor/Weather/WeatherWidget.cpp
@@ -481,26 +481,18 @@ void WeatherWidget::LoadSettings()
 
 			// Record form references (resolved by matching widget EditorID)
 			auto* editorWindow = EditorWindow::GetSingleton();
-			auto findFormByEditorID = [](const std::string& editorID, const EditorWindow::WidgetVec& widgets) -> RE::TESForm* {
-				if (editorID.empty())
-					return nullptr;
-				for (const auto& w : widgets)
-					if (w->GetEditorID() == editorID)
-						return w->form;
-				return nullptr;
-			};
 			auto loadEditorID = [&](const std::string& key) -> std::string {
-				return js.contains(key) ? js[key].get<std::string>() : "";
+				return (js.contains(key) && js[key].is_string()) ? js[key].get<std::string>() : "";
 			};
-			for (int i = 0; i < ColorTimes::kTotal; i++) {
-				auto* f = findFormByEditorID(loadEditorID(std::format("imageSpaceRef_{}", i)), editorWindow->imageSpaceWidgets);
+			for (size_t i = 0; i < ColorTimes::kTotal; i++) {
+				auto* f = WeatherUtils::FindFormByEditorID(loadEditorID(std::format("imageSpaceRef_{}", i)), editorWindow->imageSpaceWidgets);
 				settings.imageSpaceRefs[i] = f ? static_cast<RE::TESImageSpace*>(f) : vanillaSettings.imageSpaceRefs[i];
-				auto* vl = findFormByEditorID(loadEditorID(std::format("volumetricLightingRef_{}", i)), editorWindow->volumetricLightingWidgets);
+				auto* vl = WeatherUtils::FindFormByEditorID(loadEditorID(std::format("volumetricLightingRef_{}", i)), editorWindow->volumetricLightingWidgets);
 				settings.volumetricLightingRefs[i] = vl ? static_cast<RE::BGSVolumetricLighting*>(vl) : vanillaSettings.volumetricLightingRefs[i];
 			}
-			auto* precip = findFormByEditorID(loadEditorID("precipitationDataRef"), editorWindow->precipitationWidgets);
+			auto* precip = WeatherUtils::FindFormByEditorID(loadEditorID("precipitationDataRef"), editorWindow->precipitationWidgets);
 			settings.precipitationData = precip ? static_cast<RE::BGSShaderParticleGeometryData*>(precip) : vanillaSettings.precipitationData;
-			auto* refEffect = findFormByEditorID(loadEditorID("referenceEffectRef"), editorWindow->referenceEffectWidgets);
+			auto* refEffect = WeatherUtils::FindFormByEditorID(loadEditorID("referenceEffectRef"), editorWindow->referenceEffectWidgets);
 			settings.referenceEffect = refEffect ? static_cast<RE::BGSReferenceEffect*>(refEffect) : vanillaSettings.referenceEffect;
 
 		} catch (const nlohmann::json::exception& e) {
@@ -533,20 +525,12 @@ void WeatherWidget::SaveSettings()
 
 		// Record form references (serialized as widget EditorIDs for load-order independence)
 		auto* editorWindow = EditorWindow::GetSingleton();
-		auto findWidgetEditorID = [](RE::TESForm* targetForm, const EditorWindow::WidgetVec& widgets) -> std::string {
-			if (!targetForm)
-				return "";
-			for (const auto& w : widgets)
-				if (w->form == targetForm)
-					return w->GetEditorID();
-			return "";
-		};
-		for (int i = 0; i < ColorTimes::kTotal; i++) {
-			js[std::format("imageSpaceRef_{}", i)] = findWidgetEditorID(settings.imageSpaceRefs[i], editorWindow->imageSpaceWidgets);
-			js[std::format("volumetricLightingRef_{}", i)] = findWidgetEditorID(settings.volumetricLightingRefs[i], editorWindow->volumetricLightingWidgets);
+		for (size_t i = 0; i < ColorTimes::kTotal; i++) {
+			js[std::format("imageSpaceRef_{}", i)] = WeatherUtils::FindEditorIDByForm(settings.imageSpaceRefs[i], editorWindow->imageSpaceWidgets);
+			js[std::format("volumetricLightingRef_{}", i)] = WeatherUtils::FindEditorIDByForm(settings.volumetricLightingRefs[i], editorWindow->volumetricLightingWidgets);
 		}
-		js["precipitationDataRef"] = findWidgetEditorID(settings.precipitationData, editorWindow->precipitationWidgets);
-		js["referenceEffectRef"] = findWidgetEditorID(settings.referenceEffect, editorWindow->referenceEffectWidgets);
+		js["precipitationDataRef"] = WeatherUtils::FindEditorIDByForm(settings.precipitationData, editorWindow->precipitationWidgets);
+		js["referenceEffectRef"] = WeatherUtils::FindEditorIDByForm(settings.referenceEffect, editorWindow->referenceEffectWidgets);
 
 		if (js.is_null()) {
 			logger::error("Weather {}: Serialization produced null JSON!", GetEditorID());

--- a/src/WeatherEditor/Weather/WeatherWidget.cpp
+++ b/src/WeatherEditor/Weather/WeatherWidget.cpp
@@ -531,11 +531,11 @@ void WeatherWidget::SaveSettings()
 
 		// Record form references (serialized as widget EditorIDs for load-order independence)
 		auto* editorWindow = EditorWindow::GetSingleton();
-		auto findWidgetEditorID = [](RE::TESForm* form, const EditorWindow::WidgetVec& widgets) -> std::string {
-			if (!form)
+		auto findWidgetEditorID = [](RE::TESForm* targetForm, const EditorWindow::WidgetVec& widgets) -> std::string {
+			if (!targetForm)
 				return "";
 			for (const auto& w : widgets)
-				if (w->form == form)
+				if (w->form == targetForm)
 					return w->GetEditorID();
 			return "";
 		};

--- a/src/WeatherEditor/Weather/WeatherWidget.cpp
+++ b/src/WeatherEditor/Weather/WeatherWidget.cpp
@@ -259,6 +259,7 @@ void WeatherWidget::DrawWidget()
 						if (ImGui::Checkbox(("##inherit_" + inheritKey).c_str(), &inheritFlag)) {
 							if (inheritFlag && parentWidget) {
 								weather->imageSpaces[i] = parentWidget->weather->imageSpaces[i];
+								settings.imageSpaceRefs[i] = weather->imageSpaces[i];
 								recordChanged = true;
 							}
 						}
@@ -271,6 +272,7 @@ void WeatherWidget::DrawWidget()
 					ImGui::Text("%s:", label.c_str());
 					ImGui::SameLine(todLabelOffset);
 					if (WeatherUtils::DrawFormPickerCached("##ImageSpace", weather->imageSpaces[i], editorWindow->imageSpaceWidgets, false, true, pickerWidth)) {
+						settings.imageSpaceRefs[i] = weather->imageSpaces[i];
 						recordChanged = true;
 					}  // Add "Open" button
 					if (weather->imageSpaces[i]) {
@@ -306,6 +308,7 @@ void WeatherWidget::DrawWidget()
 						if (ImGui::Checkbox(("##inherit_" + inheritKey).c_str(), &inheritFlag)) {
 							if (inheritFlag && parentWidget) {
 								weather->volumetricLighting[i] = parentWidget->weather->volumetricLighting[i];
+								settings.volumetricLightingRefs[i] = weather->volumetricLighting[i];
 								recordChanged = true;
 							}
 						}
@@ -318,6 +321,7 @@ void WeatherWidget::DrawWidget()
 					ImGui::Text("%s:", label.c_str());
 					ImGui::SameLine(todLabelOffset);
 					if (WeatherUtils::DrawFormPickerCached("##VolumetricLighting", weather->volumetricLighting[i], editorWindow->volumetricLightingWidgets, false, true, pickerWidth)) {
+						settings.volumetricLightingRefs[i] = weather->volumetricLighting[i];
 						recordChanged = true;
 					}  // Add "Open" button
 					if (weather->volumetricLighting[i]) {
@@ -348,6 +352,7 @@ void WeatherWidget::DrawWidget()
 					if (ImGui::Checkbox("##inherit_Precipitation", &inheritFlag)) {
 						if (inheritFlag && parentWidget) {
 							weather->precipitationData = parentWidget->weather->precipitationData;
+							settings.precipitationData = weather->precipitationData;
 							recordChanged = true;
 						}
 					}
@@ -360,6 +365,7 @@ void WeatherWidget::DrawWidget()
 				ImGui::Text("Particle Shader:");
 				ImGui::SameLine(formLabelOffset);
 				if (WeatherUtils::DrawFormPickerCached("##Precipitation", weather->precipitationData, editorWindow->precipitationWidgets, false, true, pickerWidth)) {
+					settings.precipitationData = weather->precipitationData;
 					recordChanged = true;
 				}  // Add "Open" button
 				if (weather->precipitationData) {
@@ -388,6 +394,7 @@ void WeatherWidget::DrawWidget()
 					if (ImGui::Checkbox("##inherit_ReferenceEffect", &inheritFlag)) {
 						if (inheritFlag && parentWidget) {
 							weather->referenceEffect = parentWidget->weather->referenceEffect;
+							settings.referenceEffect = weather->referenceEffect;
 							recordChanged = true;
 						}
 					}
@@ -400,6 +407,7 @@ void WeatherWidget::DrawWidget()
 				ImGui::Text("Reference Effect:");
 				ImGui::SameLine(formLabelOffset);
 				if (WeatherUtils::DrawFormPickerCached("##ReferenceEffect", weather->referenceEffect, editorWindow->referenceEffectWidgets, false, true, pickerWidth)) {
+					settings.referenceEffect = weather->referenceEffect;
 					recordChanged = true;
 				}  // Add "Open" button
 				if (weather->referenceEffect) {
@@ -786,6 +794,14 @@ void WeatherWidget::LoadWeatherValues()
 			ColorToFloat3(cloudColors[j], settingsCloud.color[j]);
 		}
 	}
+
+	// Record form references
+	for (size_t i = 0; i < ColorTimes::kTotal; i++) {
+		settings.imageSpaceRefs[i] = weather->imageSpaces[i];
+		settings.volumetricLightingRefs[i] = weather->volumetricLighting[i];
+	}
+	settings.precipitationData = weather->precipitationData;
+	settings.referenceEffect = weather->referenceEffect;
 }
 
 void WeatherWidget::DrawDALCSettings()
@@ -1659,6 +1675,10 @@ bool WeatherWidget::Settings::operator==(const Settings& o) const
 	       std::equal(std::begin(dalc), std::end(dalc), std::begin(o.dalc)) &&
 	       std::equal(std::begin(clouds), std::end(clouds), std::begin(o.clouds)) &&
 	       std::equal(std::begin(imageSpaces), std::end(imageSpaces), std::begin(o.imageSpaces)) &&
+	       std::equal(std::begin(imageSpaceRefs), std::end(imageSpaceRefs), std::begin(o.imageSpaceRefs)) &&
+	       std::equal(std::begin(volumetricLightingRefs), std::end(volumetricLightingRefs), std::begin(o.volumetricLightingRefs)) &&
+	       precipitationData == o.precipitationData &&
+	       referenceEffect == o.referenceEffect &&
 	       featureSettings == o.featureSettings;
 }
 

--- a/src/WeatherEditor/Weather/WeatherWidget.h
+++ b/src/WeatherEditor/Weather/WeatherWidget.h
@@ -110,6 +110,12 @@ public:
 		// ImageSpace settings for each time of day
 		ImageSpaceSettings imageSpaces[ColorTimes::kTotal];
 
+		// Record form references
+		RE::TESImageSpace* imageSpaceRefs[ColorTimes::kTotal] = {};
+		RE::BGSVolumetricLighting* volumetricLightingRefs[ColorTimes::kTotal] = {};
+		RE::BGSShaderParticleGeometryData* precipitationData = nullptr;
+		RE::BGSReferenceEffect* referenceEffect = nullptr;
+
 		// Per-feature settings storage
 		std::map<std::string, json> featureSettings;
 

--- a/src/WeatherEditor/WeatherUtils.cpp
+++ b/src/WeatherEditor/WeatherUtils.cpp
@@ -17,29 +17,27 @@ namespace WeatherUtils::TexturePath
 
 	bool HasDdsExtension(std::string_view path)
 	{
-		return Normalize(path).ends_with(".dds");
+		return Normalize(path).ends_with(kDdsExtension);
 	}
 
 	bool ExistsOnDisk(std::string_view path)
 	{
 		const std::string lower = Normalize(path);
-		if (!lower.ends_with(".dds"))
+		if (!lower.ends_with(kDdsExtension))
 			return false;
 
-		// Reject absolute paths
+		// Reject absolute paths and ".." traversal
 		const std::filesystem::path fsPath(lower);
 		if (fsPath.is_absolute())
 			return false;
-
-		// Reject any ".." component
 		for (const auto& part : fsPath)
 			if (part == "..")
 				return false;
 
 		const std::filesystem::path dataPath = Util::PathHelpers::GetDataPath();
-		const std::filesystem::path fullPath = lower.starts_with("textures\\") ?
+		const std::filesystem::path fullPath = lower.starts_with(kTexturePrefix) ?
 		                                           dataPath / lower :
-		                                           dataPath / "textures" / lower;
+		                                           dataPath / kTexturePrefix / lower;
 
 		std::error_code ec;
 		return std::filesystem::exists(fullPath, ec) && !ec;
@@ -47,11 +45,34 @@ namespace WeatherUtils::TexturePath
 
 	std::string BuildResourcePath(std::string_view path)
 	{
-		std::string result = "Textures\\";
+		std::string result(kResourcePrefix);
 		result.append(path);
-		if (!Normalize(result).ends_with(".dds"))
-			result += ".dds";
+		if (!Normalize(result).ends_with(kDdsExtension))
+			result += kDdsExtension;
 		return result;
+	}
+}
+
+namespace WeatherUtils
+{
+	RE::TESForm* FindFormByEditorID(std::string_view editorID, const std::vector<std::unique_ptr<Widget>>& widgets)
+	{
+		if (editorID.empty())
+			return nullptr;
+		for (const auto& w : widgets)
+			if (w->GetEditorID() == editorID)
+				return w->form;
+		return nullptr;
+	}
+
+	std::string FindEditorIDByForm(const RE::TESForm* form, const std::vector<std::unique_ptr<Widget>>& widgets)
+	{
+		if (!form)
+			return "";
+		for (const auto& w : widgets)
+			if (w->form == form)
+				return w->GetEditorID();
+		return "";
 	}
 }
 

--- a/src/WeatherEditor/WeatherUtils.h
+++ b/src/WeatherEditor/WeatherUtils.h
@@ -357,6 +357,10 @@ namespace WeatherUtils
 	// Texture path helpers shared by precipitation and cloud layer widgets.
 	namespace TexturePath
 	{
+		inline constexpr std::string_view kTexturePrefix = "textures\\";
+		inline constexpr std::string_view kResourcePrefix = "Textures\\";
+		inline constexpr std::string_view kDdsExtension = ".dds";
+
 		// Lowercase + convert forward slashes to backslashes.
 		std::string Normalize(std::string_view path);
 
@@ -369,6 +373,10 @@ namespace WeatherUtils
 		// Build a BSA-style resource path ("Textures\\<path>" with .dds appended if missing).
 		std::string BuildResourcePath(std::string_view path);
 	}
+
+	// Lookup helpers for form↔widget ref serialization (load-order independent).
+	RE::TESForm* FindFormByEditorID(std::string_view editorID, const std::vector<std::unique_ptr<Widget>>& widgets);
+	std::string FindEditorIDByForm(const RE::TESForm* form, const std::vector<std::unique_ptr<Widget>>& widgets);
 
 	// Set the current widget for undo tracking (should be called at start of widget Draw())
 	void SetCurrentWidget(Widget* widget);


### PR DESCRIPTION
Currently the records tab allows the user to change records tied to a weather, but this isn't actually tracked at all, nor is it saved.
The user expectation and intended behaviour is that it should be tracking and saving these changes. Just like the other tabs in this widget. This PR corrects this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Weather editor now persistently tracks ImageSpace, Volumetric Lighting, Precipitation and Reference Effect selections and syncs them when picked or inherited.
  * Settings now serialize selections as EditorIDs for stable, load-order-independent persistence; loads tolerate missing or empty entries.
  * Added lookup helpers to map UI widgets to serialized settings.
  * Centralized texture path/extension constants and stricter disk-path validation (rejects absolute paths and ".." traversal).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->