### PR TITLE
refactor(weather-editor): use existing functions for lock retarget

### DIFF
--- a/src/Features/WeatherEditor.cpp
+++ b/src/Features/WeatherEditor.cpp
@@ -685,11 +685,9 @@ void WeatherEditor::RenderWeatherControls(RE::Sky* sky)
 				else
 					sky->SetWeather(selectedWeather, true, false);
 
-				// If the lock is active, retarget it to the newly chosen weather so
-				// Prepass() enforces the new choice instead of reverting it.
-				if (editorWindow->IsWeatherLocked()) {
-					editorWindow->lockedWeather = selectedWeather;
-				}
+				// Retarget the lock so Prepass() enforces the new choice instead of reverting it.
+				if (editorWindow->IsWeatherLocked())
+					editorWindow->LockWeather(selectedWeather);
 
 				Util::ClearComboSearch(kWeatherSearchId);
 				logger::info("[WeatherEditor] Changed weather to: {}", Util::FormatWeather(selectedWeather));


### PR DESCRIPTION
In the previous PR I missed that I could reuse a function I made earlier.
No changed functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal improvements to the weather editor code organization and maintainability through refactored method usage patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->