### PR TITLE
refactor(weather-editor): remove duplicate code

### DIFF
--- a/src/WeatherEditor/Weather/PrecipitationWidget.cpp
+++ b/src/WeatherEditor/Weather/PrecipitationWidget.cpp
@@ -76,22 +76,20 @@ void PrecipitationWidget::DrawWidget()
 
 				ImGui::SeparatorText("Texture Path");
 				const bool inputChanged = ImGui::InputText("Particle Texture", textureBuffer, sizeof(textureBuffer));
-				{
-					std::string_view buf(textureBuffer);
-					if (buf != lastCheckedBuffer) {
-						lastCheckedBuffer = std::string(buf);
-						lastCheckedExists = WeatherUtils::TexturePath::ExistsOnDisk(buf);
-					}
-					if (inputChanged && lastCheckedExists) {
-						settings.particleTexture = lastCheckedBuffer;
-						changed = true;
-					}
-					if (settings.particleTexture != buf && !buf.empty()) {
-						if (!WeatherUtils::TexturePath::HasDdsExtension(buf))
-							ImGui::TextColored(globals::menu->GetTheme().StatusPalette.Error, "Path must end with '.dds'");
-						else if (!lastCheckedExists)
-							ImGui::TextColored(globals::menu->GetTheme().StatusPalette.Error, "Texture file not found under Data/textures/.");
-					}
+				std::string_view buf(textureBuffer);
+				if (buf != lastCheckedBuffer) {
+					lastCheckedBuffer = std::string(buf);
+					lastCheckedExists = WeatherUtils::TexturePath::ExistsOnDisk(buf);
+				}
+				if (inputChanged && lastCheckedExists) {
+					settings.particleTexture = lastCheckedBuffer;
+					changed = true;
+				}
+				if (settings.particleTexture != buf && !buf.empty()) {
+					if (!WeatherUtils::TexturePath::HasDdsExtension(buf))
+						ImGui::TextColored(globals::menu->GetTheme().StatusPalette.Error, "Path must end with '.dds'");
+					else if (!lastCheckedExists)
+						ImGui::TextColored(globals::menu->GetTheme().StatusPalette.Error, "Texture file not found under Data/textures/.");
 				}
 
 				EndScrollableContent();

--- a/src/WeatherEditor/Weather/PrecipitationWidget.cpp
+++ b/src/WeatherEditor/Weather/PrecipitationWidget.cpp
@@ -75,26 +75,21 @@ void PrecipitationWidget::DrawWidget()
 				}
 
 				ImGui::SeparatorText("Texture Path");
-				if (ImGui::InputText("Particle Texture", textureBuffer, sizeof(textureBuffer))) {
+				const bool inputChanged = ImGui::InputText("Particle Texture", textureBuffer, sizeof(textureBuffer));
+				{
 					std::string_view buf(textureBuffer);
 					if (buf != lastCheckedBuffer) {
-						lastCheckedExists = WeatherUtils::TexturePath::ExistsOnDisk(buf);
 						lastCheckedBuffer = std::string(buf);
+						lastCheckedExists = WeatherUtils::TexturePath::ExistsOnDisk(buf);
 					}
-					if (lastCheckedExists) {
+					if (inputChanged && lastCheckedExists) {
 						settings.particleTexture = lastCheckedBuffer;
 						changed = true;
 					}
-				}
-				if (std::string_view buf(textureBuffer); settings.particleTexture != buf) {
-					if (!buf.empty() && !WeatherUtils::TexturePath::HasDdsExtension(buf))
-						ImGui::TextColored(globals::menu->GetTheme().StatusPalette.Error, "Path must end with '.dds'");
-					else if (!buf.empty()) {
-						if (buf != lastCheckedBuffer) {
-							lastCheckedExists = WeatherUtils::TexturePath::ExistsOnDisk(buf);
-							lastCheckedBuffer = std::string(buf);
-						}
-						if (!lastCheckedExists)
+					if (settings.particleTexture != buf && !buf.empty()) {
+						if (!WeatherUtils::TexturePath::HasDdsExtension(buf))
+							ImGui::TextColored(globals::menu->GetTheme().StatusPalette.Error, "Path must end with '.dds'");
+						else if (!lastCheckedExists)
 							ImGui::TextColored(globals::menu->GetTheme().StatusPalette.Error, "Texture file not found under Data/textures/.");
 					}
 				}


### PR DESCRIPTION
After revisiting my recent PR I noticed that I had a duplicated HasDdsExtension() call.
This PR cleans up this code so that there is only 1 filesystem read instead of 2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved particle texture input flow in the editor: validation is more reliable, unnecessary disk checks during rendering are reduced, and texture changes are only applied once the file is confirmed present.
  * Clarified error display: fewer false "file not found" warnings and more consistent ".dds" validation messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->