### PR TITLE
fix(reflex): add old reflex dll to incompatible list

### DIFF
--- a/src/XSEPlugin.cpp
+++ b/src/XSEPlugin.cpp
@@ -183,7 +183,8 @@ bool Load()
 		L"Data/SKSE/Plugins/AELAS.dll",
 		L"Data/SKSE/Plugins/SSEReShadeHelper.dll",
 		L"Data/SKSE/Plugins/trainwreck.dll",
-		L"Data/SKSE/Plugins/TAASharpen.dll"
+		L"Data/SKSE/Plugins/TAASharpen.dll",
+		L"Data/SKSE/Plugins/NVIDIA_Reflex.dll"
 	};
 
 	for (const auto dll : incompatibleDLLs) {


### PR DESCRIPTION
fixes: https://github.com/doodlum/skyrim-community-shaders/issues/2167

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added detection for NVIDIA_Reflex plugin incompatibility. Users will now receive notification if this incompatible component is detected during plugin initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->