### PR TITLE
fix(ui): save resolution based font in setting

### DIFF
--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -428,12 +428,6 @@ void Menu::Save(json& o_json)
 	InputCombo::ComboList::to_json(o_json["WeatherEditorToggleKey"], settings.WeatherEditorToggleKey);
 }
 
-void Menu::ApplyResolutionFontOverride()
-{
-	if (settings.UseResolutionFont)
-		settings.Theme.FontSize = 0.0f;
-}
-
 void Menu::LoadTheme(json& o_json)
 {
 	if (o_json["Theme"].is_object()) {
@@ -454,8 +448,6 @@ void Menu::LoadTheme(json& o_json)
 
 		// Apply background blur enabled state from theme
 		BackgroundBlur::SetEnabled(settings.Theme.BackgroundBlurEnabled);
-
-		ApplyResolutionFontOverride();
 	}
 }
 void Menu::SaveTheme(json& o_json)
@@ -528,8 +520,6 @@ bool Menu::LoadThemePreset(const std::string& themeName)
 
 			// Apply background blur enabled state from theme
 			BackgroundBlur::SetEnabled(settings.Theme.BackgroundBlurEnabled);
-
-			ApplyResolutionFontOverride();
 
 			logger::info("Applied theme preset: {}", themeName);
 			return true;

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -169,6 +169,7 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	AutoHideFeatureList,
 	SkipConstraintWarning,
 	RequireShiftToDock,
+	UseResolutionFont,
 	Theme,
 	SelectedThemePreset)
 
@@ -427,6 +428,12 @@ void Menu::Save(json& o_json)
 	InputCombo::ComboList::to_json(o_json["WeatherEditorToggleKey"], settings.WeatherEditorToggleKey);
 }
 
+void Menu::ApplyResolutionFontOverride()
+{
+	if (settings.UseResolutionFont)
+		settings.Theme.FontSize = 0.0f;
+}
+
 void Menu::LoadTheme(json& o_json)
 {
 	if (o_json["Theme"].is_object()) {
@@ -447,6 +454,8 @@ void Menu::LoadTheme(json& o_json)
 
 		// Apply background blur enabled state from theme
 		BackgroundBlur::SetEnabled(settings.Theme.BackgroundBlurEnabled);
+
+		ApplyResolutionFontOverride();
 	}
 }
 void Menu::SaveTheme(json& o_json)
@@ -519,6 +528,8 @@ bool Menu::LoadThemePreset(const std::string& themeName)
 
 			// Apply background blur enabled state from theme
 			BackgroundBlur::SetEnabled(settings.Theme.BackgroundBlurEnabled);
+
+			ApplyResolutionFontOverride();
 
 			logger::info("Applied theme preset: {}", themeName);
 			return true;

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -113,7 +113,6 @@ public:
 
 	void LoadTheme(json& o_json);
 	void SaveTheme(json& o_json);
-	void ApplyResolutionFontOverride();
 
 	// Multi-theme support
 	std::vector<std::string> DiscoverThemes();
@@ -418,6 +417,7 @@ public:
 	};
 	const ThemeSettings& GetTheme() const { return settings.Theme; }                // Provide read-only access to the Theme.
 	Settings& GetSettings() { return settings; }                                    // Provide access to settings for other components
+	const Settings& GetSettings() const { return settings; }
 	winrt::com_ptr<IDXGIAdapter3> GetDXGIAdapter3() const { return dxgiAdapter3; }  // Provide access to dxgiAdapter3
 	ThemeSettings::FontRoleSettings& GetFontRoleSettings(FontRole role) { return settings.Theme.FontRoles[static_cast<size_t>(role)]; }
 	const ThemeSettings::FontRoleSettings& GetFontRoleSettings(FontRole role) const { return settings.Theme.FontRoles[static_cast<size_t>(role)]; }

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -411,7 +411,7 @@ public:
 		bool AutoHideFeatureList = false;                                                   // Auto-hide left feature list panel, show on hover
 		bool SkipConstraintWarning = false;                                                 // Skip popup when a setting change creates new constraints
 		bool RequireShiftToDock = true;                                                     // Require holding Shift to dock windows
-		bool UseResolutionFont = true;                                                      // When true, font size scales with screen resolution (FontSize=0)
+		bool UseResolutionFont = true;                                                      // When true, runtime font size scales with screen resolution; when persisted to theme files, FontSize is zeroed for backward compatibility
 		ThemeSettings Theme;
 		std::string SelectedThemePreset = "";  // Currently selected theme preset (empty = custom/user theme)
 	};

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -113,6 +113,7 @@ public:
 
 	void LoadTheme(json& o_json);
 	void SaveTheme(json& o_json);
+	void ApplyResolutionFontOverride();
 
 	// Multi-theme support
 	std::vector<std::string> DiscoverThemes();
@@ -411,6 +412,7 @@ public:
 		bool AutoHideFeatureList = false;                                                   // Auto-hide left feature list panel, show on hover
 		bool SkipConstraintWarning = false;                                                 // Skip popup when a setting change creates new constraints
 		bool RequireShiftToDock = true;                                                     // Require holding Shift to dock windows
+		bool UseResolutionFont = true;                                                      // When true, font size scales with screen resolution (FontSize=0)
 		ThemeSettings Theme;
 		std::string SelectedThemePreset = "";  // Currently selected theme preset (empty = custom/user theme)
 	};

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -415,8 +415,8 @@ public:
 		ThemeSettings Theme;
 		std::string SelectedThemePreset = "";  // Currently selected theme preset (empty = custom/user theme)
 	};
-	const ThemeSettings& GetTheme() const { return settings.Theme; }                // Provide read-only access to the Theme.
-	Settings& GetSettings() { return settings; }                                    // Provide access to settings for other components
+	const ThemeSettings& GetTheme() const { return settings.Theme; }  // Provide read-only access to the Theme.
+	Settings& GetSettings() { return settings; }                      // Provide access to settings for other components
 	const Settings& GetSettings() const { return settings; }
 	winrt::com_ptr<IDXGIAdapter3> GetDXGIAdapter3() const { return dxgiAdapter3; }  // Provide access to dxgiAdapter3
 	ThemeSettings::FontRoleSettings& GetFontRoleSettings(FontRole role) { return settings.Theme.FontRoles[static_cast<size_t>(role)]; }

--- a/src/Menu/SettingsTabRenderer.cpp
+++ b/src/Menu/SettingsTabRenderer.cpp
@@ -856,7 +856,7 @@ void SettingsTabRenderer::RenderFontsTab()
 
 		SeparatorTextWithFont("Font", Menu::FontRole::Subheading);
 
-		bool useAutoFont = (themeSettings.FontSize <= 0.0f);
+		bool& useAutoFont = menuInstance->GetSettings().UseResolutionFont;
 		if (ImGui::Checkbox("Use resolution-based font size", &useAutoFont)) {
 			if (useAutoFont) {
 				themeSettings.FontSize = 0.0f;

--- a/src/Menu/SettingsTabRenderer.cpp
+++ b/src/Menu/SettingsTabRenderer.cpp
@@ -858,9 +858,8 @@ void SettingsTabRenderer::RenderFontsTab()
 
 		bool& useAutoFont = menuInstance->GetSettings().UseResolutionFont;
 		if (ImGui::Checkbox("Use resolution-based font size", &useAutoFont)) {
-			if (useAutoFont) {
-				themeSettings.FontSize = 0.0f;
-			} else {
+			if (!useAutoFont) {
+				// Seed the fixed-size slider with the current effective size so it doesn't jump
 				float effective = ThemeManager::ResolveFontSize(*menuInstance);
 				themeSettings.FontSize = std::clamp(effective, ThemeManager::Constants::MIN_FONT_SIZE, ThemeManager::Constants::MAX_FONT_SIZE);
 			}

--- a/src/Menu/ThemeManager.cpp
+++ b/src/Menu/ThemeManager.cpp
@@ -791,15 +791,16 @@ bool ThemeManager::ValidateThemeData(const json& themeData) const
 
 float ThemeManager::ResolveFontSize(const Menu& menu)
 {
-	const auto& themeSettings = menu.GetTheme();
-	float configured = themeSettings.FontSize;
+	const auto& settings = menu.GetSettings();
 
-	// If user configured a positive size, use it (clamped)
-	if (std::round(configured) > 0) {
-		return std::clamp(configured, Constants::MIN_FONT_SIZE, Constants::MAX_FONT_SIZE);
+	// When resolution-based font is disabled, use the theme's fixed size directly
+	if (!settings.UseResolutionFont) {
+		float configured = settings.Theme.FontSize;
+		if (std::round(configured) > 0)
+			return std::clamp(configured, Constants::MIN_FONT_SIZE, Constants::MAX_FONT_SIZE);
 	}
 
-	// Otherwise, compute dynamic default based on current screen resolution
+	// Compute dynamic size from screen resolution
 	float dynamicSize;
 	if (globals::game::isVR) {
 		// VR: use overlay height


### PR DESCRIPTION
Closes #2166

this PR changes the saving logic for the resolution based font setting. Now it will save in the usersettings, and when it is toggled on, it will apply the fontsize = 0.0f setting on theme load. This way the toggle persists logically, while themes don't get affected by it when saved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a settings option (enabled by default) to toggle resolution-based font sizing in preferences.

* **Improvements**
  * UI updates immediately when switching between automatic (resolution-based) and fixed font sizes; slider enable/disable behavior follows the setting.
  * Dynamic scaling now derives size from display/VR overlay height with safer fallbacks and clamping for consistent results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->