### PR TITLE
fix(weather-editor): reinit weathers for record changes

### DIFF
--- a/src/WeatherEditor/Weather/PrecipitationWidget.cpp
+++ b/src/WeatherEditor/Weather/PrecipitationWidget.cpp
@@ -99,9 +99,6 @@ void PrecipitationWidget::DrawWidget()
 			ImGui::EndTabBar();
 		}
 
-		if (changed && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
-			ApplyChanges();
-		}
 	}
 	ImGui::End();
 }
@@ -226,6 +223,7 @@ void PrecipitationWidget::ApplyChanges()
 	runtime.data[(uint32_t)RE::BGSShaderParticleGeometryData::DataID::kParticleDensity].f = settings.particleDensity;
 	runtime.particleTexture.textureName = settings.particleTexture.c_str();
 	ApplyLiveParticleTexture(settings.particleTexture);
+	Widget::ForceCurrentWeatherReinit();
 }
 
 void PrecipitationWidget::ApplyLiveParticleTexture(const std::string& path)

--- a/src/WeatherEditor/Weather/PrecipitationWidget.cpp
+++ b/src/WeatherEditor/Weather/PrecipitationWidget.cpp
@@ -98,7 +98,6 @@ void PrecipitationWidget::DrawWidget()
 
 			ImGui::EndTabBar();
 		}
-
 	}
 	ImGui::End();
 }

--- a/src/WeatherEditor/Weather/PrecipitationWidget.h
+++ b/src/WeatherEditor/Weather/PrecipitationWidget.h
@@ -21,6 +21,7 @@ public:
 
 	void DrawWidget() override;
 	const char* GetWidgetTypeName() const override { return "Precipitation"; }
+	bool RequiresManualApply() const override { return true; }
 	void LoadSettings() override;
 	void SaveSettings() override;
 	void ApplyChanges() override;

--- a/src/WeatherEditor/Weather/ReferenceEffectWidget.cpp
+++ b/src/WeatherEditor/Weather/ReferenceEffectWidget.cpp
@@ -36,10 +36,6 @@ void ReferenceEffectWidget::DrawWidget()
 			if (ImGui::Checkbox("Inherit Rotation", &settings.inheritRotation))
 				changed = true;
 
-			if (changed && editorWindow->settings.autoApplyChanges) {
-				editorWindow->PushUndoState(this);
-				ApplyChanges();
-			}
 		}
 		EndScrollableContent();
 	}
@@ -126,6 +122,8 @@ void ReferenceEffectWidget::ApplyChanges()
 		referenceEffect->data.flags.set(RE::BGSReferenceEffect::Flag::kAttachToCamera);
 	if (settings.inheritRotation)
 		referenceEffect->data.flags.set(RE::BGSReferenceEffect::Flag::kInheritRotation);
+
+	Widget::ForceCurrentWeatherReinit();
 }
 
 void ReferenceEffectWidget::RevertChanges()

--- a/src/WeatherEditor/Weather/ReferenceEffectWidget.cpp
+++ b/src/WeatherEditor/Weather/ReferenceEffectWidget.cpp
@@ -35,7 +35,6 @@ void ReferenceEffectWidget::DrawWidget()
 				changed = true;
 			if (ImGui::Checkbox("Inherit Rotation", &settings.inheritRotation))
 				changed = true;
-
 		}
 		EndScrollableContent();
 	}

--- a/src/WeatherEditor/Weather/ReferenceEffectWidget.h
+++ b/src/WeatherEditor/Weather/ReferenceEffectWidget.h
@@ -20,6 +20,7 @@ public:
 
 	void DrawWidget() override;
 	const char* GetWidgetTypeName() const override { return "Visual Effect"; }
+	bool RequiresManualApply() const override { return true; }
 	void LoadSettings() override;
 	void SaveSettings() override;
 	void ApplyChanges() override;

--- a/src/WeatherEditor/Weather/WeatherWidget.cpp
+++ b/src/WeatherEditor/Weather/WeatherWidget.cpp
@@ -225,6 +225,7 @@ void WeatherWidget::DrawWidget()
 			auto* editorWindow = EditorWindow::GetSingleton();
 
 			bool recordChanged = false;
+			bool needsReinit = false;
 			bool hasParent = editorWindow->settings.enableInheritFromParent && HasParent();
 			WeatherWidget* parentWidget = hasParent ? GetParent() : nullptr;
 			const float todLabelOffset = (hasParent ? 120.0f : 100.0f) * scale;
@@ -337,6 +338,7 @@ void WeatherWidget::DrawWidget()
 						if (settings.precipitationData != parentWidget->settings.precipitationData) {
 							settings.precipitationData = parentWidget->settings.precipitationData;
 							recordChanged = true;
+							needsReinit = true;
 						}
 					}
 					if (ImGui::IsItemHovered()) {
@@ -349,6 +351,7 @@ void WeatherWidget::DrawWidget()
 				ImGui::SameLine(formLabelOffset);
 				if (WeatherUtils::DrawFormPickerCached("##Precipitation", settings.precipitationData, editorWindow->precipitationWidgets, false, true, pickerWidth)) {
 					recordChanged = true;
+					needsReinit = true;
 				}  // Add "Open" button
 				if (settings.precipitationData) {
 					ImGui::SameLine();
@@ -378,6 +381,7 @@ void WeatherWidget::DrawWidget()
 						if (settings.referenceEffect != parentWidget->settings.referenceEffect) {
 							settings.referenceEffect = parentWidget->settings.referenceEffect;
 							recordChanged = true;
+							needsReinit = true;
 						}
 					}
 					if (ImGui::IsItemHovered()) {
@@ -390,6 +394,7 @@ void WeatherWidget::DrawWidget()
 				ImGui::SameLine(formLabelOffset);
 				if (WeatherUtils::DrawFormPickerCached("##ReferenceEffect", settings.referenceEffect, editorWindow->referenceEffectWidgets, false, true, pickerWidth)) {
 					recordChanged = true;
+					needsReinit = true;
 				}  // Add "Open" button
 				if (settings.referenceEffect) {
 					ImGui::SameLine();
@@ -411,6 +416,9 @@ void WeatherWidget::DrawWidget()
 
 			if (recordChanged && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
 				ApplyChanges();
+				if (needsReinit) {
+					Widget::ForceWeatherReinit(weather);
+				}
 			}
 
 			EndScrollableContent();
@@ -496,6 +504,7 @@ void WeatherWidget::LoadSettings()
 	}
 	originalSettings = settings;
 	ApplyChanges();
+	Widget::ForceWeatherReinit(weather);
 }
 
 void WeatherWidget::SaveSettings()
@@ -1685,6 +1694,7 @@ void WeatherWidget::RevertChanges()
 	weatherManager->ClearAllFeatureSettingsForWeather(weather);
 	settings = vanillaSettings;
 	ApplyChanges();
+	Widget::ForceWeatherReinit(weather);
 }
 
 void WeatherWidget::Delete()

--- a/src/WeatherEditor/Weather/WeatherWidget.cpp
+++ b/src/WeatherEditor/Weather/WeatherWidget.cpp
@@ -408,7 +408,7 @@ void WeatherWidget::DrawWidget()
 				ImGui::Spacing();
 			}
 
-			if (pendingReinit && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
+			if (pendingReinit) {
 				ApplyChanges();
 			}
 

--- a/src/WeatherEditor/Weather/WeatherWidget.cpp
+++ b/src/WeatherEditor/Weather/WeatherWidget.cpp
@@ -224,7 +224,6 @@ void WeatherWidget::DrawWidget()
 			ImGui::Spacing();
 			auto* editorWindow = EditorWindow::GetSingleton();
 
-			bool recordChanged = false;
 			bool hasParent = editorWindow->settings.enableInheritFromParent && HasParent();
 			WeatherWidget* parentWidget = hasParent ? GetParent() : nullptr;
 			const float todLabelOffset = (hasParent ? 120.0f : 100.0f) * scale;
@@ -245,7 +244,6 @@ void WeatherWidget::DrawWidget()
 						if (inheritFlag && parentWidget) {
 							if (settings.imageSpaceRefs[i] != parentWidget->settings.imageSpaceRefs[i]) {
 								settings.imageSpaceRefs[i] = parentWidget->settings.imageSpaceRefs[i];
-								recordChanged = true;
 								pendingReinit = true;
 							}
 						}
@@ -258,7 +256,6 @@ void WeatherWidget::DrawWidget()
 					ImGui::Text("%s:", label.c_str());
 					ImGui::SameLine(todLabelOffset);
 					if (WeatherUtils::DrawFormPickerCached("##ImageSpace", settings.imageSpaceRefs[i], editorWindow->imageSpaceWidgets, false, true, pickerWidth)) {
-						recordChanged = true;
 						pendingReinit = true;
 					}  // Add "Open" button
 					if (settings.imageSpaceRefs[i]) {
@@ -295,7 +292,6 @@ void WeatherWidget::DrawWidget()
 						if (inheritFlag && parentWidget) {
 							if (settings.volumetricLightingRefs[i] != parentWidget->settings.volumetricLightingRefs[i]) {
 								settings.volumetricLightingRefs[i] = parentWidget->settings.volumetricLightingRefs[i];
-								recordChanged = true;
 								pendingReinit = true;
 							}
 						}
@@ -308,7 +304,6 @@ void WeatherWidget::DrawWidget()
 					ImGui::Text("%s:", label.c_str());
 					ImGui::SameLine(todLabelOffset);
 					if (WeatherUtils::DrawFormPickerCached("##VolumetricLighting", settings.volumetricLightingRefs[i], editorWindow->volumetricLightingWidgets, false, true, pickerWidth)) {
-						recordChanged = true;
 						pendingReinit = true;
 					}  // Add "Open" button
 					if (settings.volumetricLightingRefs[i]) {
@@ -340,7 +335,6 @@ void WeatherWidget::DrawWidget()
 					if (inheritFlag && parentWidget) {
 						if (settings.precipitationData != parentWidget->settings.precipitationData) {
 							settings.precipitationData = parentWidget->settings.precipitationData;
-							recordChanged = true;
 							pendingReinit = true;
 						}
 					}
@@ -353,7 +347,6 @@ void WeatherWidget::DrawWidget()
 				ImGui::Text("Particle Shader:");
 				ImGui::SameLine(formLabelOffset);
 				if (WeatherUtils::DrawFormPickerCached("##Precipitation", settings.precipitationData, editorWindow->precipitationWidgets, false, true, pickerWidth)) {
-					recordChanged = true;
 					pendingReinit = true;
 				}  // Add "Open" button
 				if (settings.precipitationData) {
@@ -383,7 +376,6 @@ void WeatherWidget::DrawWidget()
 					if (inheritFlag && parentWidget) {
 						if (settings.referenceEffect != parentWidget->settings.referenceEffect) {
 							settings.referenceEffect = parentWidget->settings.referenceEffect;
-							recordChanged = true;
 							pendingReinit = true;
 						}
 					}
@@ -396,7 +388,6 @@ void WeatherWidget::DrawWidget()
 				ImGui::Text("Reference Effect:");
 				ImGui::SameLine(formLabelOffset);
 				if (WeatherUtils::DrawFormPickerCached("##ReferenceEffect", settings.referenceEffect, editorWindow->referenceEffectWidgets, false, true, pickerWidth)) {
-					recordChanged = true;
 					pendingReinit = true;
 				}  // Add "Open" button
 				if (settings.referenceEffect) {
@@ -417,7 +408,7 @@ void WeatherWidget::DrawWidget()
 				ImGui::Spacing();
 			}
 
-			if (recordChanged && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
+			if (pendingReinit && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
 				ApplyChanges();
 			}
 
@@ -1540,7 +1531,8 @@ void WeatherWidget::InheritAllFromParent()
 	settings.inheritFlags["Precipitation"] = true;
 	settings.inheritFlags["ReferenceEffect"] = true;
 
-	// Apply the changes
+	// Apply the changes — form references require a weather reinit to propagate
+	pendingReinit = true;
 	if (EditorWindow::GetSingleton()->settings.autoApplyChanges) {
 		ApplyChanges();
 	}

--- a/src/WeatherEditor/Weather/WeatherWidget.cpp
+++ b/src/WeatherEditor/Weather/WeatherWidget.cpp
@@ -1184,12 +1184,8 @@ void WeatherWidget::DrawCloudSettings()
 	if (enableChanged) {
 		// Apply enable/disable immediately for instant feedback, regardless of autoApplyChanges.
 		editorWindow->PushUndoState(this);
+		pendingReinit = true;
 		ApplyChanges();
-		if (editorWindow->IsWeatherLocked() && editorWindow->GetLockedWeather() == weather) {
-			if (auto sky = RE::Sky::GetSingleton()) {
-				sky->ForceWeather(weather, true);  // override=true for immediate application; matches "instant feedback" intent above
-			}
-		}
 	} else if (changed && editorWindow->settings.autoApplyChanges) {
 		editorWindow->PushUndoState(this);
 		ApplyChanges();

--- a/src/WeatherEditor/Weather/WeatherWidget.cpp
+++ b/src/WeatherEditor/Weather/WeatherWidget.cpp
@@ -225,7 +225,6 @@ void WeatherWidget::DrawWidget()
 			auto* editorWindow = EditorWindow::GetSingleton();
 
 			bool recordChanged = false;
-			bool needsReinit = false;
 			bool hasParent = editorWindow->settings.enableInheritFromParent && HasParent();
 			WeatherWidget* parentWidget = hasParent ? GetParent() : nullptr;
 			const float todLabelOffset = (hasParent ? 120.0f : 100.0f) * scale;
@@ -338,7 +337,7 @@ void WeatherWidget::DrawWidget()
 						if (settings.precipitationData != parentWidget->settings.precipitationData) {
 							settings.precipitationData = parentWidget->settings.precipitationData;
 							recordChanged = true;
-							needsReinit = true;
+							pendingReinit = true;
 						}
 					}
 					if (ImGui::IsItemHovered()) {
@@ -351,7 +350,7 @@ void WeatherWidget::DrawWidget()
 				ImGui::SameLine(formLabelOffset);
 				if (WeatherUtils::DrawFormPickerCached("##Precipitation", settings.precipitationData, editorWindow->precipitationWidgets, false, true, pickerWidth)) {
 					recordChanged = true;
-					needsReinit = true;
+					pendingReinit = true;
 				}  // Add "Open" button
 				if (settings.precipitationData) {
 					ImGui::SameLine();
@@ -381,7 +380,7 @@ void WeatherWidget::DrawWidget()
 						if (settings.referenceEffect != parentWidget->settings.referenceEffect) {
 							settings.referenceEffect = parentWidget->settings.referenceEffect;
 							recordChanged = true;
-							needsReinit = true;
+							pendingReinit = true;
 						}
 					}
 					if (ImGui::IsItemHovered()) {
@@ -394,7 +393,7 @@ void WeatherWidget::DrawWidget()
 				ImGui::SameLine(formLabelOffset);
 				if (WeatherUtils::DrawFormPickerCached("##ReferenceEffect", settings.referenceEffect, editorWindow->referenceEffectWidgets, false, true, pickerWidth)) {
 					recordChanged = true;
-					needsReinit = true;
+					pendingReinit = true;
 				}  // Add "Open" button
 				if (settings.referenceEffect) {
 					ImGui::SameLine();
@@ -416,9 +415,6 @@ void WeatherWidget::DrawWidget()
 
 			if (recordChanged && EditorWindow::GetSingleton()->settings.autoApplyChanges) {
 				ApplyChanges();
-				if (needsReinit) {
-					Widget::ForceWeatherReinit(weather);
-				}
 			}
 
 			EndScrollableContent();
@@ -503,6 +499,7 @@ void WeatherWidget::LoadSettings()
 		LoadFeatureSettings();
 	}
 	originalSettings = settings;
+	pendingReinit = false;
 	ApplyChanges();
 	Widget::ForceWeatherReinit(weather);
 }
@@ -1666,6 +1663,10 @@ void WeatherWidget::LoadFeatureSettings()
 void WeatherWidget::ApplyChanges()
 {
 	SetWeatherValues();
+	if (pendingReinit) {
+		Widget::ForceWeatherReinit(weather);
+		pendingReinit = false;
+	}
 }
 
 void WeatherWidget::RevertChanges()
@@ -1693,6 +1694,7 @@ void WeatherWidget::RevertChanges()
 
 	weatherManager->ClearAllFeatureSettingsForWeather(weather);
 	settings = vanillaSettings;
+	pendingReinit = false;
 	ApplyChanges();
 	Widget::ForceWeatherReinit(weather);
 }

--- a/src/WeatherEditor/Weather/WeatherWidget.cpp
+++ b/src/WeatherEditor/Weather/WeatherWidget.cpp
@@ -246,6 +246,7 @@ void WeatherWidget::DrawWidget()
 							if (settings.imageSpaceRefs[i] != parentWidget->settings.imageSpaceRefs[i]) {
 								settings.imageSpaceRefs[i] = parentWidget->settings.imageSpaceRefs[i];
 								recordChanged = true;
+								pendingReinit = true;
 							}
 						}
 						if (ImGui::IsItemHovered()) {
@@ -258,6 +259,7 @@ void WeatherWidget::DrawWidget()
 					ImGui::SameLine(todLabelOffset);
 					if (WeatherUtils::DrawFormPickerCached("##ImageSpace", settings.imageSpaceRefs[i], editorWindow->imageSpaceWidgets, false, true, pickerWidth)) {
 						recordChanged = true;
+						pendingReinit = true;
 					}  // Add "Open" button
 					if (settings.imageSpaceRefs[i]) {
 						ImGui::SameLine();
@@ -294,6 +296,7 @@ void WeatherWidget::DrawWidget()
 							if (settings.volumetricLightingRefs[i] != parentWidget->settings.volumetricLightingRefs[i]) {
 								settings.volumetricLightingRefs[i] = parentWidget->settings.volumetricLightingRefs[i];
 								recordChanged = true;
+								pendingReinit = true;
 							}
 						}
 						if (ImGui::IsItemHovered()) {
@@ -306,6 +309,7 @@ void WeatherWidget::DrawWidget()
 					ImGui::SameLine(todLabelOffset);
 					if (WeatherUtils::DrawFormPickerCached("##VolumetricLighting", settings.volumetricLightingRefs[i], editorWindow->volumetricLightingWidgets, false, true, pickerWidth)) {
 						recordChanged = true;
+						pendingReinit = true;
 					}  // Add "Open" button
 					if (settings.volumetricLightingRefs[i]) {
 						ImGui::SameLine();
@@ -499,9 +503,8 @@ void WeatherWidget::LoadSettings()
 		LoadFeatureSettings();
 	}
 	originalSettings = settings;
-	pendingReinit = false;
+	pendingReinit = true;
 	ApplyChanges();
-	Widget::ForceWeatherReinit(weather);
 }
 
 void WeatherWidget::SaveSettings()
@@ -1694,9 +1697,8 @@ void WeatherWidget::RevertChanges()
 
 	weatherManager->ClearAllFeatureSettingsForWeather(weather);
 	settings = vanillaSettings;
-	pendingReinit = false;
+	pendingReinit = true;
 	ApplyChanges();
-	Widget::ForceWeatherReinit(weather);
 }
 
 void WeatherWidget::Delete()

--- a/src/WeatherEditor/Weather/WeatherWidget.h
+++ b/src/WeatherEditor/Weather/WeatherWidget.h
@@ -152,4 +152,5 @@ private:
 	void DrawProperties(std::string category, std::map<std::string, int> properties);
 	void InheritFromParent(const std::string& property);
 	void InheritAllFromParent();
+	bool pendingReinit = false;
 };

--- a/src/WeatherEditor/Widget.cpp
+++ b/src/WeatherEditor/Widget.cpp
@@ -283,6 +283,14 @@ void Widget::ForceWeatherReinit(RE::TESWeather* weather)
 	}
 }
 
+void Widget::ForceCurrentWeatherReinit()
+{
+	if (auto sky = RE::Sky::GetSingleton()) {
+		if (sky->currentWeather)
+			sky->ForceWeather(sky->currentWeather, true);
+	}
+}
+
 void Widget::DrawWidgetHeader(const char* searchId, bool showApply, bool showSaveLoadRevert, bool showForceWeather, RE::TESWeather* weather)
 {
 	auto editorWindow = EditorWindow::GetSingleton();
@@ -355,8 +363,17 @@ void Widget::DrawWidgetHeader(const char* searchId, bool showApply, bool showSav
 		};
 
 		// Apply button
-		if (showApply && !editorWindow->settings.autoApplyChanges)
-			iconButton("_Apply", menu->uiIcons.applyToGame.texture, "Apply changes to the game", [&]() { ApplyChanges(); });
+		if (showApply && (!editorWindow->settings.autoApplyChanges || RequiresManualApply())) {
+			if (menu->uiIcons.applyToGame.texture) {
+				iconButton("_Apply", menu->uiIcons.applyToGame.texture, "Apply changes to the game", [&]() { ApplyChanges(); });
+			} else {
+				ImGui::SameLine();
+				if (ImGui::Button("Apply"))
+					ApplyChanges();
+				if (ImGui::IsItemHovered())
+					ImGui::SetTooltip("Apply changes to the game");
+			}
+		}
 
 		// Save/Load/Revert/Delete group
 		if (showSaveLoadRevert) {
@@ -422,7 +439,7 @@ void Widget::DrawWidgetHeader(const char* searchId, bool showApply, bool showSav
 		};
 
 		// Apply button
-		if (showApply && !editorWindow->settings.autoApplyChanges)
+		if (showApply && (!editorWindow->settings.autoApplyChanges || RequiresManualApply()))
 			styledTextButton("Apply", palette.SuccessColor, "Apply changes to the game", [&]() { ApplyChanges(); });
 
 		// Save/Load/Revert/Delete group
@@ -439,6 +456,13 @@ void Widget::DrawWidgetHeader(const char* searchId, bool showApply, bool showSav
 	}
 
 	DrawDeleteConfirmationModal();
+
+	if (RequiresManualApply() && editorWindow->settings.autoApplyChanges && menu) {
+		ImGui::SameLine();
+		ImGui::TextColored(menu->GetTheme().StatusPalette.Warning, "(Changes require manual apply)");
+		if (ImGui::IsItemHovered())
+			ImGui::SetTooltip("This form type is only re-read by the engine on weather reinit.\nAuto-apply is disabled - use the Apply button.");
+	}
 
 	ImGui::Separator();
 }

--- a/src/WeatherEditor/Widget.cpp
+++ b/src/WeatherEditor/Widget.cpp
@@ -276,6 +276,13 @@ bool Widget::BeginWidgetWindow()
 	return result;
 }
 
+void Widget::ForceWeatherReinit(RE::TESWeather* weather)
+{
+	if (auto sky = RE::Sky::GetSingleton()) {
+		sky->ForceWeather(weather, true);
+	}
+}
+
 void Widget::DrawWidgetHeader(const char* searchId, bool showApply, bool showSaveLoadRevert, bool showForceWeather, RE::TESWeather* weather)
 {
 	auto editorWindow = EditorWindow::GetSingleton();

--- a/src/WeatherEditor/Widget.cpp
+++ b/src/WeatherEditor/Widget.cpp
@@ -278,17 +278,15 @@ bool Widget::BeginWidgetWindow()
 
 void Widget::ForceWeatherReinit(RE::TESWeather* weather)
 {
-	if (auto sky = RE::Sky::GetSingleton()) {
-		sky->ForceWeather(weather, true);
-	}
+	if (weather && globals::game::sky)
+		globals::game::sky->ForceWeather(weather, true);
 }
 
 void Widget::ForceCurrentWeatherReinit()
 {
-	if (auto sky = RE::Sky::GetSingleton()) {
-		if (sky->currentWeather)
-			sky->ForceWeather(sky->currentWeather, true);
-	}
+	auto* sky = globals::game::sky;
+	if (sky && sky->currentWeather)
+		sky->ForceWeather(sky->currentWeather, true);
 }
 
 void Widget::DrawWidgetHeader(const char* searchId, bool showApply, bool showSaveLoadRevert, bool showForceWeather, RE::TESWeather* weather)

--- a/src/WeatherEditor/Widget.cpp
+++ b/src/WeatherEditor/Widget.cpp
@@ -278,8 +278,9 @@ bool Widget::BeginWidgetWindow()
 
 void Widget::ForceWeatherReinit(RE::TESWeather* weather)
 {
-	if (weather && globals::game::sky)
-		globals::game::sky->ForceWeather(weather, true);
+	auto* sky = globals::game::sky;
+	if (weather && sky && sky->currentWeather == weather)
+		sky->ForceWeather(weather, true);
 }
 
 void Widget::ForceCurrentWeatherReinit()
@@ -455,7 +456,7 @@ void Widget::DrawWidgetHeader(const char* searchId, bool showApply, bool showSav
 
 	DrawDeleteConfirmationModal();
 
-	if (RequiresManualApply() && editorWindow->settings.autoApplyChanges && menu) {
+	if (showApply && RequiresManualApply() && editorWindow->settings.autoApplyChanges && menu) {
 		ImGui::SameLine();
 		ImGui::TextColored(menu->GetTheme().StatusPalette.Warning, "(Changes require manual apply)");
 		if (ImGui::IsItemHovered())

--- a/src/WeatherEditor/Widget.h
+++ b/src/WeatherEditor/Widget.h
@@ -148,6 +148,11 @@ public:
 
 	// Reinitialize weather to apply form refs that are only read at load time.
 	static void ForceWeatherReinit(RE::TESWeather* weather);
+	// Reinitialize the current sky weather (use when the specific weather is unknown).
+	static void ForceCurrentWeatherReinit();
+
+	// Override to suppress per-frame auto-apply and show a manual-apply warning in the header.
+	virtual bool RequiresManualApply() const { return false; }
 
 	// Draw common header with search bar and action buttons
 	void DrawWidgetHeader(const char* searchId, bool showApply = true, bool showSaveLoadRevert = false, bool showForceWeather = false, RE::TESWeather* weather = nullptr);

--- a/src/WeatherEditor/Widget.h
+++ b/src/WeatherEditor/Widget.h
@@ -146,6 +146,9 @@ public:
 	virtual void RevertChanges() { LoadSettings(); }
 	virtual bool HasUnsavedChanges() const { return false; }
 
+	// Reinitialize weather to apply form refs that are only read at load time.
+	static void ForceWeatherReinit(RE::TESWeather* weather);
+
 	// Draw common header with search bar and action buttons
 	void DrawWidgetHeader(const char* searchId, bool showApply = true, bool showSaveLoadRevert = false, bool showForceWeather = false, RE::TESWeather* weather = nullptr);
 


### PR DESCRIPTION
When a weathers with records that are tied to them, like precipitation, only read which precipitation record it should play when the weather initialized. Changes to these values wouldn't propagate until the weather was re-initialized, either through forcing the weather or by having it reappear naturally.

This PR introduces some new helpers and logic to re-init weathers when these records are changed so that the changes are actually viewable live. Fixes the issue where changes related to precipitation and reference effects were not applying during edits.
Adds some extra guards to prevent weathers being reforced every frame when for example a slider is used.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Precipitation and reference-effect editors now require an explicit Apply, show a “(Changes require manual apply)” indicator, and display the Apply control even when auto-apply is enabled.
  * Editors mark relevant changes as pending so applying them triggers a full weather refresh.

* **Bug Fixes**
  * Weather reliably reinitializes after changes to precipitation, reference effects, cloud layers, loading, or reverting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->