### PR TITLE
fix(weather-editor): disable viewport when HDR Display enabled

### DIFF
--- a/src/WeatherEditor/EditorWindow.cpp
+++ b/src/WeatherEditor/EditorWindow.cpp
@@ -890,7 +890,7 @@ void EditorWindow::RenderUI()
 	float previousScale = ImGui::GetStyle().FontScaleMain;
 	ImGui::GetStyle().FontScaleMain = settings.editorUIScale;
 
-	if (settings.showViewport) {
+	if (IsViewportActive()) {
 		ImGui::GetBackgroundDrawList()->AddRectFilled({ 0, 0 }, io.DisplaySize, ImGui::GetColorU32(ImGuiCol_ModalWindowDimBg));
 	}
 
@@ -1304,7 +1304,7 @@ void EditorWindow::RenderUI()
 	ImGui::SetNextWindowPos(ImVec2(pad, menuBarHeight + pad), layoutCond);
 	ShowObjectsWindow();
 
-	if (settings.showViewport) {
+	if (IsViewportActive()) {
 		// Size viewport height to match game aspect ratio so the preview fits snugly
 		const float aspectRatio = width / height;
 		const float imageHeight = viewportWidth / aspectRatio;
@@ -1403,6 +1403,11 @@ void EditorWindow::SetupResources()
 	WidgetFactory::PopulateSimpleWidgets<RE::TESEffectShader>(effectShaderWidgets);
 }
 
+bool EditorWindow::IsViewportActive() const
+{
+	return settings.showViewport && !globals::features::hdrDisplay.settings.enableHDR;
+}
+
 void EditorWindow::UpdateOpenState()
 {
 	static bool wasOpen = false;
@@ -1410,9 +1415,7 @@ void EditorWindow::UpdateOpenState()
 	if (open && !wasOpen) {
 		DisableVanityCamera();
 		HideGameMenus();
-		if (globals::features::hdrDisplay.settings.enableHDR)
-			settings.showViewport = false;
-		BackgroundBlur::SetWeatherEditorActive(settings.showViewport);
+		BackgroundBlur::SetWeatherEditorActive(IsViewportActive());
 
 	} else if (!open && wasOpen) {
 		RestoreVanityCamera();
@@ -1433,7 +1436,7 @@ void EditorWindow::Draw()
 		}
 	}
 
-	if (!settings.showViewport) {
+	if (!IsViewportActive()) {
 		delete tempTexture;
 		tempTexture = nullptr;
 	} else {

--- a/src/WeatherEditor/EditorWindow.cpp
+++ b/src/WeatherEditor/EditorWindow.cpp
@@ -1,7 +1,9 @@
 #include "EditorWindow.h"
 
+#include "Features/HDRDisplay.h"
 #include "Features/Upscaling.h"
 #include "Features/WeatherEditor.h"
+#include "Globals.h"
 #include "InteriorOnlyPanel.h"
 #include "Menu.h"
 #include "Menu/BackgroundBlur.h"
@@ -993,9 +995,17 @@ void EditorWindow::RenderUI()
 			ImGui::EndMenu();
 		}
 		if (ImGui::BeginMenu("Window")) {
+			const bool hdrActive = globals::features::hdrDisplay.settings.enableHDR;
+			if (hdrActive)
+				ImGui::BeginDisabled();
 			if (ImGui::Checkbox("Viewport", &settings.showViewport)) {
 				BackgroundBlur::SetWeatherEditorActive(settings.showViewport);
 				Save();
+			}
+			if (hdrActive) {
+				ImGui::EndDisabled();
+				if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
+					ImGui::SetTooltip("Viewport is unavailable when HDR Display is enabled");
 			}
 			if (ImGui::Checkbox("Palette", &PaletteWindow::GetSingleton()->open)) {
 			}
@@ -1400,6 +1410,8 @@ void EditorWindow::UpdateOpenState()
 	if (open && !wasOpen) {
 		DisableVanityCamera();
 		HideGameMenus();
+		if (globals::features::hdrDisplay.settings.enableHDR)
+			settings.showViewport = false;
 		BackgroundBlur::SetWeatherEditorActive(settings.showViewport);
 
 	} else if (!open && wasOpen) {

--- a/src/WeatherEditor/EditorWindow.cpp
+++ b/src/WeatherEditor/EditorWindow.cpp
@@ -1428,6 +1428,16 @@ void EditorWindow::UpdateOpenState()
 
 void EditorWindow::Draw()
 {
+	// Keep background blur in sync when HDR toggles while the editor stays open
+	{
+		static bool prevViewportActive = false;
+		const bool viewportActive = IsViewportActive();
+		if (viewportActive != prevViewportActive) {
+			BackgroundBlur::SetWeatherEditorActive(viewportActive);
+			prevViewportActive = viewportActive;
+		}
+	}
+
 	// Re-enforce weather lock if active (handles time changes)
 	if (weatherLockActive && lockedWeather) {
 		auto sky = RE::Sky::GetSingleton();

--- a/src/WeatherEditor/EditorWindow.cpp
+++ b/src/WeatherEditor/EditorWindow.cpp
@@ -995,7 +995,7 @@ void EditorWindow::RenderUI()
 			ImGui::EndMenu();
 		}
 		if (ImGui::BeginMenu("Window")) {
-			const bool hdrActive = globals::features::hdrDisplay.settings.enableHDR;
+			const bool hdrActive = globals::features::hdrDisplay.loaded && globals::features::hdrDisplay.settings.enableHDR;
 			if (hdrActive)
 				ImGui::BeginDisabled();
 			if (ImGui::Checkbox("Viewport", &settings.showViewport)) {
@@ -1405,7 +1405,7 @@ void EditorWindow::SetupResources()
 
 bool EditorWindow::IsViewportActive() const
 {
-	return settings.showViewport && !globals::features::hdrDisplay.settings.enableHDR;
+	return settings.showViewport && !(globals::features::hdrDisplay.loaded && globals::features::hdrDisplay.settings.enableHDR);
 }
 
 void EditorWindow::UpdateOpenState()

--- a/src/WeatherEditor/EditorWindow.h
+++ b/src/WeatherEditor/EditorWindow.h
@@ -96,6 +96,7 @@ public:
 	void EnterPreviewMode(PreviewMode mode);
 	void ExitPreviewMode();
 	bool IsInPreviewMode() const { return previewMode != PreviewMode::None; }
+	bool IsViewportActive() const;
 	bool IsPreviewFlying() const { return previewMode == PreviewMode::FreeCamera || previewMode == PreviewMode::PlayMode; }
 	PreviewMode GetPreviewMode() const { return previewMode; }
 	void ToggleFreeCameraLock();


### PR DESCRIPTION
the viewport has compatibility issues with HDR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Viewport is automatically disabled when HDR Display is enabled to avoid rendering issues; the menu checkbox remains visible but cannot activate the viewport in HDR mode.
  * Hover tooltip explains why the Viewport is unavailable under HDR.
  * Background blur now correctly follows viewport availability.
  * Viewport/show-state updates while the editor is open are kept in sync with HDR toggles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->