### PR TITLE
fix(weather-editor): Volumetric Lighting slider

### DIFF
--- a/src/WeatherEditor/Weather/VolumetricLightingWidget.cpp
+++ b/src/WeatherEditor/Weather/VolumetricLightingWidget.cpp
@@ -55,7 +55,7 @@ void VolumetricLightingWidget::DrawWidget()
 			ImGui::SeparatorText("Phase Function");
 			if (WeatherUtils::DrawSliderFloat("Contribution", settings.phaseFunctionContribution, 0.0f, 1.0f))
 				changed = true;
-			if (WeatherUtils::DrawSliderFloat("Scattering", settings.phaseFunctionScattering, 0.0f, 1.0f))
+			if (WeatherUtils::DrawSliderFloat("Scattering", settings.phaseFunctionScattering, -1.0f, 1.0f))
 				changed = true;
 
 			ImGui::SeparatorText("Sampling");


### PR DESCRIPTION
This should be the last one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded the scattering control range in volumetric lighting Phase Function settings from [0.0, 1.0] to [-1.0, 1.0] for more granular parameter adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->