### PR TITLE
feat(HDR): warn users when in exclusive fullscreen

### DIFF
--- a/src/Features/HDRDisplay.cpp
+++ b/src/Features/HDRDisplay.cpp
@@ -248,6 +248,7 @@ namespace
 }
 
 bool HDRDisplay::isHDRMonitor = false;
+bool HDRDisplay::wasExclusiveFullscreen = false;
 
 bool HDRDisplay::DetectHDR()
 {
@@ -278,6 +279,20 @@ void HDRDisplay::DrawSettings()
 	} else {
 		ImGui::TextColored(Util::Colors::GetWarning(), "SDR Display (HDR not detected)");
 	}
+
+	const bool isExclusiveFullscreen = globals::features::upscaling.loaded
+	                                        ? !globals::features::upscaling.isWindowed
+	                                        : wasExclusiveFullscreen;
+
+	if (isExclusiveFullscreen) {
+		ImGui::Spacing();
+		ImGui::PushStyleColor(ImGuiCol_Text, Util::Colors::GetWarning());
+		ImGui::TextWrapped("WARNING: Exclusive Fullscreen detected.");
+		ImGui::TextWrapped("HDR is not compatible with Exclusive Fullscreen and may not work correctly. Switch to Borderless Windowed mode for proper HDR support.");
+		ImGui::PopStyleColor();
+		ImGui::Spacing();
+	}
+
 	ImGui::Spacing();
 
 	// Gate HDR checkbox behind monitor detection

--- a/src/Features/HDRDisplay.cpp
+++ b/src/Features/HDRDisplay.cpp
@@ -280,9 +280,7 @@ void HDRDisplay::DrawSettings()
 		ImGui::TextColored(Util::Colors::GetWarning(), "SDR Display (HDR not detected)");
 	}
 
-	const bool isExclusiveFullscreen = globals::features::upscaling.loaded
-	                                        ? !globals::features::upscaling.isWindowed
-	                                        : wasExclusiveFullscreen;
+	const bool isExclusiveFullscreen = globals::features::upscaling.loaded ? !globals::features::upscaling.isWindowed : wasExclusiveFullscreen;
 
 	if (isExclusiveFullscreen) {
 		ImGui::Spacing();

--- a/src/Features/HDRDisplay.h
+++ b/src/Features/HDRDisplay.h
@@ -114,6 +114,7 @@ struct HDRDisplay : public Feature
 
 	static bool DetectHDR();
 	static bool isHDRMonitor;
+	static bool wasExclusiveFullscreen;  // EFS detected at swapchain creation; incompatible with HDR
 	bool pendingAutoDetect = false;
 
 	float GetDisplayMaxLuminance() const;

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -364,6 +364,10 @@ HRESULT WINAPI hk_D3D11CreateDeviceAndSwapChain(
 		modifiedDesc.SwapEffect = DXGI_SWAP_EFFECT_FLIP_DISCARD;
 		if (modifiedDesc.BufferCount < 2)
 			modifiedDesc.BufferCount = 2;
+
+		if (!modifiedDesc.Windowed)
+			HDRDisplay::wasExclusiveFullscreen = true;
+
 		logger::info("[HDR] Upgraded swap chain: R10G10B10A2_UNORM + FLIP_DISCARD");
 	}
 

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -365,8 +365,7 @@ HRESULT WINAPI hk_D3D11CreateDeviceAndSwapChain(
 		if (modifiedDesc.BufferCount < 2)
 			modifiedDesc.BufferCount = 2;
 
-		if (!modifiedDesc.Windowed)
-			HDRDisplay::wasExclusiveFullscreen = true;
+		HDRDisplay::wasExclusiveFullscreen = !modifiedDesc.Windowed;
 
 		logger::info("[HDR] Upgraded swap chain: R10G10B10A2_UNORM + FLIP_DISCARD");
 	}


### PR DESCRIPTION
HDR swapchain format expects borderless mode. Exclusive fullscreen works, but is fragile.

Closes https://github.com/doodlum/skyrim-community-shaders/issues/2181

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Settings now detect Exclusive Fullscreen (including cases detected at startup) and alert users that HDR may not work correctly in this mode.
  * UI advice recommends switching to Borderless Windowed mode for more reliable HDR behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->