### PR TITLE
fix(upscaling): UI ghosting when HDR is unloaded

### DIFF
--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -1461,10 +1461,8 @@ void Upscaling::PostDisplay()
 	globals::game::renderer->UpdateViewPort(0, 0, 1);
 	UpdateCameraData();
 
-	if (d3d12SwapChainActive) {
-		if (globals::features::hdrDisplay.loaded)
-			globals::features::hdrDisplay.SetUIBuffer();
-	}
+	if (d3d12SwapChainActive)
+		globals::features::hdrDisplay.SetUIBuffer();
 
 	globals::state->UpdateSharedData(false, false);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HDR display buffer initialization logic to activate based on swap chain status rather than feature load state, enhancing reliability of HDR display functionality during Direct3D 12 operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->