### PR TITLE
fix(cache): reserve extra thread

### DIFF
--- a/src/ShaderCache.h
+++ b/src/ShaderCache.h
@@ -544,10 +544,21 @@ namespace SIE
 
 		ShaderFileDependencyTracker* GetDependencyTracker() { return dependencyTracker.get(); }
 
-		// Use all logical cores minus one at startup for OS headroom (E-cores included).
+		static constexpr int32_t kLowCoreCompilationThreadThreshold = 8;
+		static constexpr int32_t kLowCoreReservedCompilationThreads = 1;
+		static constexpr int32_t kDefaultReservedCompilationThreads = 2;
+
+		static int32_t GetDefaultCompilationThreadCount()
+		{
+			const auto threadCount = static_cast<int32_t>(std::thread::hardware_concurrency());
+			const auto reservedThreads = threadCount <= kLowCoreCompilationThreadThreshold ? kLowCoreReservedCompilationThreads : kDefaultReservedCompilationThreads;
+			return std::max(threadCount - reservedThreads, 1);
+		}
+
+		// Reserve fewer threads on low-core systems to avoid overly slow startup compilation.
 		// Management and file watcher run on dedicated jthreads, not pool slots.
 		// Background (in-game): half of P-cores only, to avoid starving the render thread.
-		int32_t compilationThreadCount = std::max(static_cast<int32_t>(std::thread::hardware_concurrency()) - 1, 1);
+		int32_t compilationThreadCount = GetDefaultCompilationThreadCount();
 		int32_t backgroundCompilationThreadCount = std::max(static_cast<int32_t>(Util::GetPerformanceCoreCount()) / 2, 1);
 		BS::thread_pool<> compilationPool{ static_cast<std::size_t>(compilationThreadCount) };
 		std::jthread managementJthread;  // dedicated thread for ManageCompilationSet (not in pool)


### PR DESCRIPTION
added a small helper to decide how many threads should be used by default for shader compilation.
If less than 8 available threads, only reserve 1 thread, otherwise 2.
8 available threads are either 4c8t systems or 8c8t systems which are usually very old.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved shader compilation efficiency through adaptive thread allocation based on CPU core count. Low-core systems now reserve fewer threads while higher-core systems allocate additional compilation resources, enhancing performance across different hardware configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->