### PR TITLE
fix(weather-editor): weather data on game load

### DIFF
--- a/features/Weather Editor/Shaders/Features/WeatherEditor.ini
+++ b/features/Weather Editor/Shaders/Features/WeatherEditor.ini
@@ -1,5 +1,5 @@
 [Info]
-Version = 2-0-0
+Version = 2-0-1
 
 [Nexus]
 autoupload = false

--- a/src/Features/WeatherEditor.cpp
+++ b/src/Features/WeatherEditor.cpp
@@ -43,7 +43,7 @@ bool WeatherEditor::HasWidgetJsonFiles()
 		const bool isDirectory = std::filesystem::is_directory(widgetSettingsPath, ec);
 		if (ec) {
 			logger::warn("[WeatherEditor] Failed to inspect widget settings path '{}': {}", widgetSettingsPath.string(), ec.message());
-			return false;
+			continue;
 		}
 		if (!isDirectory)
 			continue;
@@ -53,7 +53,7 @@ bool WeatherEditor::HasWidgetJsonFiles()
 			const bool isRegularFile = it->is_regular_file(entryEc);
 			if (entryEc) {
 				logger::warn("[WeatherEditor] Failed to inspect widget settings file '{}': {}", it->path().string(), entryEc.message());
-				return false;
+				continue;
 			}
 			if (isRegularFile && _stricmp(it->path().extension().string().c_str(), kJsonExtension) == 0) {
 				s_hasWidgetJsonFiles = true;
@@ -63,7 +63,7 @@ bool WeatherEditor::HasWidgetJsonFiles()
 		}
 		if (ec) {
 			logger::warn("[WeatherEditor] Failed to scan widget settings path '{}': {}", widgetSettingsPath.string(), ec.message());
-			return false;
+			continue;
 		}
 	}
 

--- a/src/Features/WeatherEditor.cpp
+++ b/src/Features/WeatherEditor.cpp
@@ -36,25 +36,38 @@ bool WeatherEditor::HasWidgetJsonFiles()
 	if (s_checkedWidgetJsonFiles)
 		return s_hasWidgetJsonFiles;
 
-	s_checkedWidgetJsonFiles = true;
 	const auto communityShaderPath = Util::PathHelpers::GetCommunityShaderPath();
 	for (const auto folderName : Widget::kSaveFolderNames) {
 		const auto widgetSettingsPath = communityShaderPath / std::filesystem::path(folderName);
 		std::error_code ec;
-		if (!std::filesystem::is_directory(widgetSettingsPath, ec))
+		const bool isDirectory = std::filesystem::is_directory(widgetSettingsPath, ec);
+		if (ec) {
+			logger::warn("[WeatherEditor] Failed to inspect widget settings path '{}': {}", widgetSettingsPath.string(), ec.message());
+			return false;
+		}
+		if (!isDirectory)
 			continue;
 
 		for (std::filesystem::directory_iterator it(widgetSettingsPath, ec), end; !ec && it != end; it.increment(ec)) {
 			std::error_code entryEc;
-			if (it->is_regular_file(entryEc) && _stricmp(it->path().extension().string().c_str(), kJsonExtension) == 0) {
+			const bool isRegularFile = it->is_regular_file(entryEc);
+			if (entryEc) {
+				logger::warn("[WeatherEditor] Failed to inspect widget settings file '{}': {}", it->path().string(), entryEc.message());
+				return false;
+			}
+			if (isRegularFile && _stricmp(it->path().extension().string().c_str(), kJsonExtension) == 0) {
 				s_hasWidgetJsonFiles = true;
+				s_checkedWidgetJsonFiles = true;
 				return true;
 			}
 		}
-		if (ec)
+		if (ec) {
 			logger::warn("[WeatherEditor] Failed to scan widget settings path '{}': {}", widgetSettingsPath.string(), ec.message());
+			return false;
+		}
 	}
 
+	s_checkedWidgetJsonFiles = true;
 	return false;
 }
 

--- a/src/Features/WeatherEditor.cpp
+++ b/src/Features/WeatherEditor.cpp
@@ -10,7 +10,14 @@
 #include "WeatherManager.h"
 
 #include "WeatherEditor/EditorWindow.h"
+#include <cstring>
+#include <filesystem>
 #include <nlohmann/json.hpp>
+
+namespace
+{
+	constexpr const char* kJsonExtension = ".json";
+}
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	WeatherEditor::WeatherDetailsWindowSettings,
@@ -24,6 +31,46 @@ void WeatherEditor::DataLoaded()
 	s_dataAvailable = true;
 }
 
+bool WeatherEditor::HasWidgetJsonFiles()
+{
+	if (s_checkedWidgetJsonFiles)
+		return s_hasWidgetJsonFiles;
+
+	s_checkedWidgetJsonFiles = true;
+	const auto communityShaderPath = Util::PathHelpers::GetCommunityShaderPath();
+	for (const auto folderName : Widget::kSaveFolderNames) {
+		const auto widgetSettingsPath = communityShaderPath / std::filesystem::path(folderName);
+		std::error_code ec;
+		if (!std::filesystem::is_directory(widgetSettingsPath, ec))
+			continue;
+
+		for (std::filesystem::directory_iterator it(widgetSettingsPath, ec), end; !ec && it != end; it.increment(ec)) {
+			std::error_code entryEc;
+			if (it->is_regular_file(entryEc) && _stricmp(it->path().extension().string().c_str(), kJsonExtension) == 0) {
+				s_hasWidgetJsonFiles = true;
+				return true;
+			}
+		}
+		if (ec)
+			logger::warn("[WeatherEditor] Failed to scan widget settings path '{}': {}", widgetSettingsPath.string(), ec.message());
+	}
+
+	return false;
+}
+
+bool WeatherEditor::ShouldPreloadEditorResources()
+{
+	return s_dataAvailable && !s_resourcesInitialized && EditorWindow::CanBeOpen() && HasWidgetJsonFiles();
+}
+
+void WeatherEditor::EnsureWeatherListLoaded()
+{
+	if (!s_dataAvailable)
+		return;
+
+	LoadAllWeathers();
+}
+
 void WeatherEditor::EnsureDataLoaded()
 {
 	if (!s_dataAvailable)
@@ -34,6 +81,28 @@ void WeatherEditor::EnsureDataLoaded()
 		s_resourcesInitialized = true;
 	}
 	LoadAllWeathers();
+}
+
+void WeatherEditor::OpenEditorWindow()
+{
+	if (!EditorWindow::CanBeOpen())
+		return;
+
+	EnsureDataLoaded();
+	EditorWindow::GetSingleton()->open = true;
+}
+
+void WeatherEditor::ToggleEditorWindow()
+{
+	auto* editorWindow = EditorWindow::GetSingleton();
+	if (!editorWindow)
+		return;
+
+	if (!editorWindow->open && !EditorWindow::CanBeOpen())
+		return;
+	if (!editorWindow->open)
+		EnsureDataLoaded();
+	editorWindow->open = !editorWindow->open;
 }
 
 int8_t LerpInt8_t(const int8_t oldValue, const int8_t newVal, const float lerpValue)
@@ -74,11 +143,11 @@ void LerpDirectional(RE::BGSDirectionalAmbientLightingColors::Directional& oldCo
 
 void WeatherEditor::DrawSettings()
 {
-	EnsureDataLoaded();
+	EnsureWeatherListLoaded();
 	bool canOpen = EditorWindow::CanBeOpen();
 	ImGui::BeginDisabled(!canOpen);
 	if (ImGui::Button("Open Editor", { -1, 0 }))
-		EditorWindow::GetSingleton()->open = true;
+		OpenEditorWindow();
 	ImGui::EndDisabled();
 
 	// Time controls
@@ -93,7 +162,7 @@ void WeatherEditor::DrawSettings()
 
 void WeatherEditor::Prepass()
 {
-	if (s_dataAvailable && !s_resourcesInitialized && EditorWindow::CanBeOpen()) {
+	if (ShouldPreloadEditorResources()) {
 		EnsureDataLoaded();
 	}
 

--- a/src/Features/WeatherEditor.cpp
+++ b/src/Features/WeatherEditor.cpp
@@ -93,7 +93,7 @@ void WeatherEditor::DrawSettings()
 
 void WeatherEditor::Prepass()
 {
-	if (!s_resourcesInitialized && EditorWindow::CanBeOpen()) {
+	if (s_dataAvailable && !s_resourcesInitialized && EditorWindow::CanBeOpen()) {
 		EnsureDataLoaded();
 	}
 

--- a/src/Features/WeatherEditor.cpp
+++ b/src/Features/WeatherEditor.cpp
@@ -93,6 +93,10 @@ void WeatherEditor::DrawSettings()
 
 void WeatherEditor::Prepass()
 {
+	if (!s_resourcesInitialized && EditorWindow::CanBeOpen()) {
+		EnsureDataLoaded();
+	}
+
 	// Re-enforce weather lock if active (handles time changes)
 	auto editorWindow = EditorWindow::GetSingleton();
 	if (editorWindow->IsWeatherLocked()) {

--- a/src/Features/WeatherEditor.h
+++ b/src/Features/WeatherEditor.h
@@ -41,6 +41,9 @@ public:
 	virtual void DataLoaded() override;
 	virtual void Prepass() override;
 
+	static void OpenEditorWindow();
+	static void ToggleEditorWindow();
+
 	void LerpWeather(RE::TESWeather*, RE::TESWeather*, float);
 
 	/**
@@ -134,6 +137,8 @@ private:
 	static inline bool s_dataAvailable = false;
 	static inline bool s_weathersLoaded = false;
 	static inline bool s_resourcesInitialized = false;
+	static inline bool s_checkedWidgetJsonFiles = false;
+	static inline bool s_hasWidgetJsonFiles = false;
 	static inline std::vector<RE::TESWeather*> s_allWeathers;
 	static inline std::vector<RE::TESWeather*> s_filteredWeathers;
 	static inline int s_selectedWeatherIdx = -1;
@@ -164,6 +169,9 @@ private:
 	static void DisplayWindInfo(RE::TESWeather* weather);
 
 	// Helper functions
+	static bool HasWidgetJsonFiles();
+	static bool ShouldPreloadEditorResources();
+	static void EnsureWeatherListLoaded();
 	static void EnsureDataLoaded();
 	static void LoadAllWeathers();
 	static void UpdateFilteredWeathers();

--- a/src/Features/WeatherEditor.h
+++ b/src/Features/WeatherEditor.h
@@ -41,6 +41,8 @@ public:
 	virtual void DataLoaded() override;
 	virtual void Prepass() override;
 
+	static void EnsureDataLoaded();
+
 	void LerpWeather(RE::TESWeather*, RE::TESWeather*, float);
 
 	/**
@@ -164,7 +166,6 @@ private:
 	static void DisplayWindInfo(RE::TESWeather* weather);
 
 	// Helper functions
-	static void EnsureDataLoaded();
 	static void LoadAllWeathers();
 	static void UpdateFilteredWeathers();
 	static int FindWeatherIndex(RE::TESWeather* targetWeather);

--- a/src/Features/WeatherEditor.h
+++ b/src/Features/WeatherEditor.h
@@ -41,8 +41,6 @@ public:
 	virtual void DataLoaded() override;
 	virtual void Prepass() override;
 
-	static void EnsureDataLoaded();
-
 	void LerpWeather(RE::TESWeather*, RE::TESWeather*, float);
 
 	/**
@@ -166,6 +164,7 @@ private:
 	static void DisplayWindInfo(RE::TESWeather* weather);
 
 	// Helper functions
+	static void EnsureDataLoaded();
 	static void LoadAllWeathers();
 	static void UpdateFilteredWeathers();
 	static int FindWeatherIndex(RE::TESWeather* targetWeather);

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -1055,8 +1055,8 @@ void Menu::ProcessInputEventQueue()
 							 } else if (ew->IsInPreviewMode()) {
 								 // Locked or PlayMode → fully exit preview
 								 ew->ExitPreviewMode();
-							 } else if (EditorWindow::CanBeOpen()) {
-								 ew->open = !ew->open;
+							 } else {
+								 WeatherEditor::ToggleEditorWindow();
 							 }
 						 } },
 					};

--- a/src/WeatherEditor/WeatherUtils.h
+++ b/src/WeatherEditor/WeatherUtils.h
@@ -192,7 +192,7 @@ namespace WidgetFactory
 			if (form) {
 				auto widget = std::make_unique<WidgetType>(form);
 				widget->CacheFormData();
-				widget->Load();
+				widget->Load(false);
 				widgets.push_back(std::move(widget));
 			}
 		}

--- a/src/WeatherEditor/Widget.cpp
+++ b/src/WeatherEditor/Widget.cpp
@@ -70,7 +70,7 @@ void Widget::Save()
 	}
 }
 
-void Widget::Load()
+void Widget::Load(bool showNotification)
 {
 	std::string filePath = GetSaveFilePath();
 
@@ -78,10 +78,12 @@ void Widget::Load()
 		js = json();
 		LoadSettings();
 
-		EditorWindow::GetSingleton()->ShowNotification(
-			std::format("No saved file - reset {} to vanilla values", GetEditorID()),
-			ImVec4(0.3f, 0.8f, 1.0f, 1.0f),
-			3.0f);
+		if (showNotification) {
+			EditorWindow::GetSingleton()->ShowNotification(
+				std::format("No saved file - reset {} to vanilla values", GetEditorID()),
+				ImVec4(0.3f, 0.8f, 1.0f, 1.0f),
+				3.0f);
+		}
 		return;
 	}
 
@@ -115,10 +117,12 @@ void Widget::Load()
 
 		LoadSettings();
 
-		EditorWindow::GetSingleton()->ShowNotification(
-			std::format("Loaded saved settings for {}", GetEditorID()),
-			ImVec4(0.0f, 1.0f, 0.5f, 1.0f),
-			3.0f);
+		if (showNotification) {
+			EditorWindow::GetSingleton()->ShowNotification(
+				std::format("Loaded saved settings for {}", GetEditorID()),
+				ImVec4(0.0f, 1.0f, 0.5f, 1.0f),
+				3.0f);
+		}
 
 	} catch (const nlohmann::json::parse_error& e) {
 		logger::error("Error parsing settings for file ({}) : {}\n", filePath, e.what());

--- a/src/WeatherEditor/Widget.cpp
+++ b/src/WeatherEditor/Widget.cpp
@@ -262,21 +262,21 @@ std::string Widget::GetFolderName() const
 {
 	switch (form->GetFormType()) {
 	case RE::FormType::Weather:
-		return "Weathers";
+		return std::string(kWeatherFolderName);
 	case RE::FormType::LightingMaster:
-		return "Lighting Templates";
+		return std::string(kLightingTemplateFolderName);
 	case RE::FormType::ImageSpace:
-		return "ImageSpaces";
+		return std::string(kImageSpaceFolderName);
 	case RE::FormType::VolumetricLighting:
-		return "Volumetric Lighting";
+		return std::string(kVolumetricLightingFolderName);
 	case RE::FormType::ShaderParticleGeometryData:
-		return "Precipitation";
+		return std::string(kPrecipitationFolderName);
 	case RE::FormType::ReferenceEffect:
-		return "Visual Effects";
+		return std::string(kVisualEffectsFolderName);
 	case RE::FormType::Cell:
-		return "Cell Lighting";
+		return std::string(kCellLightingFolderName);
 	default:
-		return "Other Editor Widgets";
+		return std::string(kOtherEditorWidgetsFolderName);
 	}
 }
 

--- a/src/WeatherEditor/Widget.cpp
+++ b/src/WeatherEditor/Widget.cpp
@@ -92,10 +92,12 @@ void Widget::Load(bool showNotification)
 
 	if (!settingsFile.good() || !settingsFile.is_open()) {
 		logger::warn("Failed to open settings file: {}", filePath);
-		EditorWindow::GetSingleton()->ShowNotification(
-			std::format("Failed to open file for {}", GetEditorID()),
-			ImVec4(1.0f, 0.5f, 0.0f, 1.0f),
-			3.0f);
+		if (showNotification) {
+			EditorWindow::GetSingleton()->ShowNotification(
+				std::format("Failed to open file for {}", GetEditorID()),
+				ImVec4(1.0f, 0.5f, 0.0f, 1.0f),
+				3.0f);
+		}
 		return;
 	}
 
@@ -106,10 +108,12 @@ void Widget::Load(bool showNotification)
 		// Validate that we loaded valid JSON
 		if (js.is_null()) {
 			logger::warn("{}: Loaded JSON is null, file may be empty or invalid", filePath);
-			EditorWindow::GetSingleton()->ShowNotification(
-				std::format("Invalid file for {} - resetting to vanilla", GetEditorID()),
-				ImVec4(1.0f, 0.5f, 0.0f, 1.0f),
-				3.0f);
+			if (showNotification) {
+				EditorWindow::GetSingleton()->ShowNotification(
+					std::format("Invalid file for {} - resetting to vanilla", GetEditorID()),
+					ImVec4(1.0f, 0.5f, 0.0f, 1.0f),
+					3.0f);
+			}
 			js = json();
 			LoadSettings();
 			return;
@@ -128,20 +132,24 @@ void Widget::Load(bool showNotification)
 		logger::error("Error parsing settings for file ({}) : {}\n", filePath, e.what());
 		logger::error("Parse error at byte {}: {}", e.byte, e.what());
 		settingsFile.close();
-		EditorWindow::GetSingleton()->ShowNotification(
-			std::format("Parse error for {} - resetting to vanilla", GetEditorID()),
-			ImVec4(1.0f, 0.0f, 0.0f, 1.0f),
-			3.0f);
+		if (showNotification) {
+			EditorWindow::GetSingleton()->ShowNotification(
+				std::format("Parse error for {} - resetting to vanilla", GetEditorID()),
+				ImVec4(1.0f, 0.0f, 0.0f, 1.0f),
+				3.0f);
+		}
 		js = json();
 		LoadSettings();
 		return;
 	} catch (const std::exception& e) {
 		logger::error("Unexpected error loading settings file ({}) : {}\n", filePath, e.what());
 		settingsFile.close();
-		EditorWindow::GetSingleton()->ShowNotification(
-			std::format("Error loading {} - resetting to vanilla", GetEditorID()),
-			ImVec4(1.0f, 0.0f, 0.0f, 1.0f),
-			3.0f);
+		if (showNotification) {
+			EditorWindow::GetSingleton()->ShowNotification(
+				std::format("Error loading {} - resetting to vanilla", GetEditorID()),
+				ImVec4(1.0f, 0.0f, 0.0f, 1.0f),
+				3.0f);
+		}
 		js = json();
 		LoadSettings();
 		return;

--- a/src/WeatherEditor/Widget.h
+++ b/src/WeatherEditor/Widget.h
@@ -136,7 +136,7 @@ public:
 	}
 
 	void Save();
-	void Load();
+	void Load(bool showNotification = true);
 	bool HasSavedFile() const;
 
 	virtual void Delete();

--- a/src/WeatherEditor/Widget.h
+++ b/src/WeatherEditor/Widget.h
@@ -3,6 +3,8 @@
 
 #include "Util.h"
 #include "Utils/Form.h"
+#include <array>
+#include <string_view>
 
 class WidgetSharedData
 {
@@ -28,6 +30,26 @@ public:
 	RE::TESForm* form = nullptr;
 
 	virtual ~Widget() {};
+
+	static constexpr std::string_view kWeatherFolderName = "Weathers";
+	static constexpr std::string_view kLightingTemplateFolderName = "Lighting Templates";
+	static constexpr std::string_view kImageSpaceFolderName = "ImageSpaces";
+	static constexpr std::string_view kVolumetricLightingFolderName = "Volumetric Lighting";
+	static constexpr std::string_view kPrecipitationFolderName = "Precipitation";
+	static constexpr std::string_view kVisualEffectsFolderName = "Visual Effects";
+	static constexpr std::string_view kCellLightingFolderName = "Cell Lighting";
+	static constexpr std::string_view kOtherEditorWidgetsFolderName = "Other Editor Widgets";
+
+	static constexpr std::array kSaveFolderNames = {
+		kWeatherFolderName,
+		kLightingTemplateFolderName,
+		kImageSpaceFolderName,
+		kVolumetricLightingFolderName,
+		kPrecipitationFolderName,
+		kVisualEffectsFolderName,
+		kCellLightingFolderName,
+		kOtherEditorWidgetsFolderName
+	};
 
 	virtual std::string GetEditorID() const
 	{

--- a/src/XSEPlugin.cpp
+++ b/src/XSEPlugin.cpp
@@ -1,4 +1,5 @@
 #include "Deferred.h"
+#include "Features/WeatherEditor.h"
 #include "Features/Upscaling.h"
 #include "FrameAnnotations.h"
 #include "Globals.h"
@@ -136,6 +137,14 @@ void MessageHandler(SKSE::MessagingInterface::Message* message)
 				Feature::ForEachLoadedFeature("DataLoaded", [](Feature* feature) { feature->DataLoaded(); });
 			}
 
+			break;
+		}
+	case SKSE::MessagingInterface::kNewGame:
+	case SKSE::MessagingInterface::kPostLoadGame:
+		{
+			if (errors.empty()) {
+				WeatherEditor::EnsureDataLoaded();
+			}
 			break;
 		}
 	}

--- a/src/XSEPlugin.cpp
+++ b/src/XSEPlugin.cpp
@@ -1,5 +1,4 @@
 #include "Deferred.h"
-#include "Features/WeatherEditor.h"
 #include "Features/Upscaling.h"
 #include "FrameAnnotations.h"
 #include "Globals.h"
@@ -137,14 +136,6 @@ void MessageHandler(SKSE::MessagingInterface::Message* message)
 				Feature::ForEachLoadedFeature("DataLoaded", [](Feature* feature) { feature->DataLoaded(); });
 			}
 
-			break;
-		}
-	case SKSE::MessagingInterface::kNewGame:
-	case SKSE::MessagingInterface::kPostLoadGame:
-		{
-			if (errors.empty()) {
-				WeatherEditor::EnsureDataLoaded();
-			}
 			break;
 		}
 	}


### PR DESCRIPTION
fixes bug introduced in https://github.com/community-shaders/skyrim-community-shaders/commit/790044b052f6427f3bb7ee20846ce02964dde820 that caused weather editor data to be loaded only after the weather editor menu was opened. This leads to no overrides being applied until the menu is opened.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Editor resources now preload selectively for faster responsiveness when appropriate.
  * Settings UI ensures the weather presets list is loaded, improving reliability.
  * Widget loading notifications are suppressed by default to reduce unnecessary alerts.
  * Editor open/toggle behavior and hotkey handling improved for more consistent operation.

* **Chores**
  * Version bumped to 2-0-1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->