### PR TITLE
ci: remove vs2022 from PR checks

### DIFF
--- a/.github/actions/prepare-shaders/action.yml
+++ b/.github/actions/prepare-shaders/action.yml
@@ -3,7 +3,7 @@ description: "Prepare shaders for validation or analysis (requires setup-build-e
 
 inputs:
     cmake-preset:
-        description: "The CMake configure/build preset to use (e.g. ALL, ALL-VS2022)."
+        description: "The CMake configure/build preset to use."
         required: false
         default: "ALL"
 

--- a/.github/actions/setup-build-environment/action.yaml
+++ b/.github/actions/setup-build-environment/action.yaml
@@ -4,10 +4,6 @@ inputs:
     cache-key-suffix:
         description: "A suffix to make the cache key unique (e.g., validation, tests)"
         required: true
-    vs-version:
-        description: "Visual Studio version to use. Defaults to '2026'."
-        required: false
-        default: "2026"
     cmake-preset:
         description: "The CMake configure preset name. Used to resolve the expected generator for cache validation."
         required: false
@@ -33,7 +29,6 @@ runs:
               cmakeVersion: "~4.2.0"
 
         - name: Install Visual Studio 2026 Build Tools
-          if: inputs.vs-version == '2026'
           shell: pwsh
           run: |
               $installerUrl = "https://aka.ms/vs/stable/vs_BuildTools.exe"

--- a/.github/actions/setup-build-environment/action.yaml
+++ b/.github/actions/setup-build-environment/action.yaml
@@ -34,12 +34,15 @@ runs:
               $installerUrl = "https://aka.ms/vs/stable/vs_BuildTools.exe"
               $installerPath = "$env:TEMP\vs_buildtools.exe"
               Invoke-WebRequest -Uri $installerUrl -OutFile $installerPath -UseBasicParsing
-              Start-Process -FilePath $installerPath -ArgumentList `
+              $proc = Start-Process -FilePath $installerPath -ArgumentList `
                   "--quiet", "--wait", "--norestart", "--nocache", `
                   "--add", "Microsoft.VisualStudio.Workload.VCTools", `
                   "--add", "Microsoft.VisualStudio.Component.VC.Tools.x86.x64", `
                   "--add", "Microsoft.VisualStudio.Component.Windows11SDK.26100" `
-                  -Wait -NoNewWindow
+                  -Wait -NoNewWindow -PassThru
+              if ($proc.ExitCode -ne 0) {
+                  throw "Visual Studio Build Tools installer failed with exit code $($proc.ExitCode)."
+              }
               Remove-Item $installerPath -ErrorAction SilentlyContinue
 
         - name: Setup MSVC environment

--- a/.github/actions/setup-build-environment/action.yaml
+++ b/.github/actions/setup-build-environment/action.yaml
@@ -5,15 +5,15 @@ inputs:
         description: "A suffix to make the cache key unique (e.g., validation, tests)"
         required: true
     vs-version:
-        description: "Visual Studio version to use ('2022' or '2026'). Defaults to '2026'."
+        description: "Visual Studio version to use. Defaults to '2026'."
         required: false
         default: "2026"
     cmake-preset:
-        description: "The CMake configure preset name (e.g. ALL, ALL-VS2022). Used to resolve the expected generator for cache validation."
+        description: "The CMake configure preset name. Used to resolve the expected generator for cache validation."
         required: false
         default: "ALL"
     build-dir:
-        description: "The CMake binary directory to cache (e.g. build/ALL, build/ALL-VS2022)."
+        description: "The CMake binary directory to cache."
         required: false
         default: "build/ALL"
 outputs:
@@ -51,7 +51,7 @@ runs:
           uses: ilammy/msvc-dev-cmd@v1
           with:
               arch: x64
-              vsversion: ${{ inputs.vs-version == '2026' && '18.0' || '17.0' }}
+              vsversion: "18.0"
 
         - name: Get MSVC version
           id: msvc_version
@@ -119,8 +119,7 @@ runs:
                 }
 
                 # Check generator mismatch — resolve the expected generator from the
-                # configure preset, following the inherits chain, so VS2022 and VS2026
-                # presets each validate against their own generator string.
+                # configure preset, following the inherits chain.
                 if ($content -match 'CMAKE_GENERATOR:INTERNAL=(.+)') {
                   $cachedGenerator = $Matches[1].Trim()
                   $allPresets = (Get-Content "CMakePresets.json" -Raw | ConvertFrom-Json).configurePresets

--- a/.github/workflows/_shared-build.yaml
+++ b/.github/workflows/_shared-build.yaml
@@ -56,7 +56,6 @@ jobs:
             matrix:
                 compiler:
                     - name: vs2026
-                      vs-version: "2026"
                       cmake-preset: ALL
                       build-dir: build/ALL
             fail-fast: false
@@ -73,7 +72,6 @@ jobs:
               uses: ./.github/actions/setup-build-environment
               with:
                   cache-key-suffix: "cpp-${{ matrix.compiler.name }}${{ inputs.cache-key-suffix }}"
-                  vs-version: ${{ matrix.compiler.vs-version }}
                   cmake-preset: ${{ matrix.compiler.cmake-preset }}
                   build-dir: ${{ matrix.compiler.build-dir }}
 
@@ -235,7 +233,6 @@ jobs:
               uses: ./.github/actions/setup-build-environment
               with:
                   cache-key-suffix: "tests${{ inputs.cache-key-suffix }}"
-                  vs-version: "2026"
                   cmake-preset: "ALL"
                   build-dir: "build/ALL"
 

--- a/.github/workflows/_shared-build.yaml
+++ b/.github/workflows/_shared-build.yaml
@@ -35,10 +35,6 @@ on:
                 description: "Optional suffix to invalidate the build cache"
                 type: string
                 default: ""
-            run-vs2022:
-                description: "Include vs2022 in the build matrix; set false for release builds where only vs2026 artifacts are shipped"
-                type: boolean
-                default: true
         outputs:
             version:
                 description: "CMake project version extracted from the build"
@@ -63,13 +59,6 @@ jobs:
                       vs-version: "2026"
                       cmake-preset: ALL
                       build-dir: build/ALL
-                    - name: vs2022
-                      vs-version: "2022"
-                      cmake-preset: ALL-VS2022
-                      build-dir: build/ALL-VS2022
-                exclude:
-                    - compiler:
-                          name: ${{ !inputs.run-vs2022 && 'vs2022' || '' }}
             fail-fast: false
         steps:
             - name: Checkout code
@@ -246,23 +235,23 @@ jobs:
               uses: ./.github/actions/setup-build-environment
               with:
                   cache-key-suffix: "tests${{ inputs.cache-key-suffix }}"
-                  vs-version: "2022"
-                  cmake-preset: "ALL-VS2022"
-                  build-dir: "build/ALL-VS2022"
+                  vs-version: "2026"
+                  cmake-preset: "ALL"
+                  build-dir: "build/ALL"
 
             - name: Build shader tests
               if: steps.check-hlsl.outputs.skip != 'true'
               uses: lukka/run-cmake@v10
               with:
-                  configurePreset: ALL-VS2022
+                  configurePreset: ALL
                   configurePresetAdditionalArgs: "['-DBUILD_SHADER_TESTS=ON']"
-                  buildPreset: ALL-VS2022
+                  buildPreset: ALL
                   buildPresetAdditionalArgs: "['--target shader_tests']"
 
             - name: Run shader unit tests
               if: steps.check-hlsl.outputs.skip != 'true'
               run: |
-                  ctest --test-dir build/ALL-VS2022 -C Release --output-on-failure -R ShaderTests --timeout 300
+                  ctest --test-dir build/ALL -C Release --output-on-failure -R ShaderTests --timeout 300
 
             - name: Upload test results on failure
               if: failure() && steps.check-hlsl.outputs.skip != 'true'
@@ -270,6 +259,6 @@ jobs:
               with:
                   name: shader-test-results
                   path: |
-                      build/ALL-VS2022/Testing/**
+                      build/ALL/Testing/**
                   retention-days: 7
                   if-no-files-found: ignore

--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -40,7 +40,6 @@ jobs:
             run-shader-validation: ${{ github.event_name != 'workflow_dispatch' || inputs.validate-shaders == true }}
             run-shader-tests: ${{ github.event_name != 'workflow_dispatch' || inputs.validate-shaders == true }}
             cache-key-suffix: ${{ inputs.cache-key-suffix || '' }}
-            run-vs2022: ${{ github.ref_type != 'tag' }}
 
     feature-audit:
         name: Feature Version Audit (Release)


### PR DESCRIPTION
PR checks fail due to vs2022 failing to run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Unified CI to a single compiler target (VS2026) and removed legacy VS2022 build paths.
  * Removed legacy build inputs and flags tied to VS2022.
  * Simplified and clarified build-action input descriptions and cleanup comments.
  * Aligned shader test/build paths and artifact uploads with the unified build preset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->