### PR TITLE
feat(upscaling): framegen in menus option

### DIFF
--- a/features/Upscaling/Shaders/Features/Upscaling.ini
+++ b/features/Upscaling/Shaders/Features/Upscaling.ini
@@ -1,5 +1,5 @@
 [Info]
-Version = 1-3-0
+Version = 1-4-0
 
 [Nexus]
 nexusmodid = 156952

--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -1615,7 +1615,12 @@ bool Upscaling::IsFrameGenerationActive() const
 bool Upscaling::ShouldUseFrameGeneration() const
 {
 	auto* ui = globals::game::ui;
-	return settings.frameGenerationMode && (settings.frameGenerationAllowInMenus || !ui || !ui->GameIsPaused());
+	auto* state = globals::state;
+	const bool menuOpen =
+		(state && (state->isMapMenuOpen || state->isMainMenuOpen || state->isLoadingMenuOpen)) ||
+		(ui && ui->GameIsPaused());
+
+	return settings.frameGenerationMode && (settings.frameGenerationAllowInMenus || !menuOpen);
 }
 
 bool Upscaling::IsUpscalingActive() const

--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -332,7 +332,7 @@ void Upscaling::DrawSettings()
 			ImGui::Checkbox("Frame Generation in Menus", &settings.frameGenerationAllowInMenus);
 			if (auto _tt = Util::HoverTooltipWrapper()) {
 				ImGui::TextUnformatted("Keeps frame generation active while game menus are open.");
-				ImGui::TextUnformatted("May feel smoother, but can increase menu input latency.");
+				ImGui::TextUnformatted("May feel smoother, but increases menu input latency.");
 			}
 
 			ImGui::TreePop();

--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -23,6 +23,7 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	frameLimitMode,
 	frameGenerationMode,
 	frameGenerationForceEnable,
+	frameGenerationAllowInMenus,
 	streamlineLogLevel,
 	sharpnessFSR,
 	sharpnessDLSS,
@@ -327,6 +328,12 @@ void Upscaling::DrawSettings()
 
 			ImGui::TextWrapped("Allows frame generation to function on low refresh rate monitors. Detected: %.2f Hz", refreshRate);
 			ImGui::SliderInt("Force Enable Frame Generation", (int*)&settings.frameGenerationForceEnable, 0, 1, std::format("{}", toggleModes[settings.frameGenerationForceEnable]).c_str());
+
+			ImGui::Checkbox("Frame Generation in Menus", &settings.frameGenerationAllowInMenus);
+			if (auto _tt = Util::HoverTooltipWrapper()) {
+				ImGui::TextUnformatted("Keeps frame generation active while game menus are open.");
+				ImGui::TextUnformatted("May feel smoother, but can increase menu input latency.");
+			}
 
 			ImGui::TreePop();
 		}
@@ -1520,7 +1527,7 @@ void Upscaling::FrameLimiter()
 		if (settings.frameLimitMode) {
 			// Fall back to the original timing method
 			// Use integer arithmetic for more precise timing
-			int64_t targetFrameTimeNS = int64_t(1000000000.0 / (refreshRate * (settings.frameGenerationMode && !globals::game::ui->GameIsPaused() ? 0.5 : 1.0)));
+			int64_t targetFrameTimeNS = int64_t(1000000000.0 / (refreshRate * (ShouldUseFrameGeneration() ? 0.5 : 1.0)));
 			int64_t targetFrameTicks = (targetFrameTimeNS * qpf.QuadPart) / 1000000000LL;
 
 			static LARGE_INTEGER lastFrame = {};
@@ -1603,6 +1610,12 @@ bool Upscaling::IsFrameGenerationDx12PathActive() const
 bool Upscaling::IsFrameGenerationActive() const
 {
 	return IsFrameGenerationDx12PathActive() && settings.frameGenerationMode && fidelityFX.isFrameGenActive;
+}
+
+bool Upscaling::ShouldUseFrameGeneration() const
+{
+	auto* ui = globals::game::ui;
+	return settings.frameGenerationMode && (settings.frameGenerationAllowInMenus || !ui || !ui->GameIsPaused());
 }
 
 bool Upscaling::IsUpscalingActive() const

--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -1525,10 +1525,11 @@ void Upscaling::FrameLimiter()
 		WaitForSingleObject(waitableObject, INFINITE);
 
 		if (settings.frameLimitMode) {
-			// Fall back to the original timing method
-			// Use integer arithmetic for more precise timing
-			int64_t targetFrameTimeNS = int64_t(1000000000.0 / (refreshRate * (ShouldUseFrameGeneration() ? 0.5 : 1.0)));
-			int64_t targetFrameTicks = (targetFrameTimeNS * qpf.QuadPart) / 1000000000LL;
+			static constexpr int64_t kNanosecondsPerSecond = 1000000000LL;
+			static constexpr double kFrameGenerationRateScale = 0.5;
+			const double frameRateScale = ShouldUseFrameGenerationThisFrame() ? kFrameGenerationRateScale : 1.0;
+			int64_t targetFrameTimeNS = int64_t(static_cast<double>(kNanosecondsPerSecond) / (refreshRate * frameRateScale));
+			int64_t targetFrameTicks = (targetFrameTimeNS * qpf.QuadPart) / kNanosecondsPerSecond;
 
 			static LARGE_INTEGER lastFrame = {};
 			LARGE_INTEGER timeNow;
@@ -1612,7 +1613,7 @@ bool Upscaling::IsFrameGenerationActive() const
 	return IsFrameGenerationDx12PathActive() && settings.frameGenerationMode && fidelityFX.isFrameGenActive;
 }
 
-bool Upscaling::ShouldUseFrameGeneration() const
+bool Upscaling::ShouldUseFrameGenerationThisFrame() const
 {
 	auto* ui = globals::game::ui;
 	auto* state = globals::state;
@@ -1620,7 +1621,7 @@ bool Upscaling::ShouldUseFrameGeneration() const
 		(state && (state->isMapMenuOpen || state->isMainMenuOpen || state->isLoadingMenuOpen)) ||
 		(ui && ui->GameIsPaused());
 
-	return settings.frameGenerationMode && (settings.frameGenerationAllowInMenus || !menuOpen);
+	return IsFrameGenerationDx12PathActive() && settings.frameGenerationMode && (settings.frameGenerationAllowInMenus || !menuOpen);
 }
 
 bool Upscaling::IsUpscalingActive() const
@@ -2098,7 +2099,7 @@ void Upscaling::Main_PostProcessing::thunk(RE::ImageSpaceManager* a_this, uint32
 	auto& upscaling = globals::features::upscaling;
 	auto upscaleMethod = upscaling.GetUpscaleMethod();
 
-	if (upscaling.d3d12SwapChainActive && upscaling.settings.frameGenerationMode)
+	if (upscaling.ShouldUseFrameGenerationThisFrame())
 		upscaling.CopySharedD3D12Resources();
 
 	if (upscaleMethod != UpscaleMethod::kNONE && upscaleMethod != UpscaleMethod::kTAA)

--- a/src/Features/Upscaling.h
+++ b/src/Features/Upscaling.h
@@ -99,7 +99,7 @@ public:
 	// FG FPS Measurement for Overlay
 	bool IsFrameGenerationDx12PathActive() const;
 	bool IsFrameGenerationActive() const;
-	bool ShouldUseFrameGeneration() const;
+	bool ShouldUseFrameGenerationThisFrame() const;
 	float GetFrameGenerationFrameTime() const;
 	bool IsUpscalingActive() const;
 

--- a/src/Features/Upscaling.h
+++ b/src/Features/Upscaling.h
@@ -54,6 +54,7 @@ public:
 		uint frameLimitMode = 1;
 		uint frameGenerationMode = 1;
 		uint frameGenerationForceEnable = 0;
+		bool frameGenerationAllowInMenus = false;
 		uint streamlineLogLevel = 0;  // 0=Off, 1=Default, 2=Verbose
 		float sharpnessFSR = 0.0f;
 		float sharpnessDLSS = 0.0f;
@@ -98,6 +99,7 @@ public:
 	// FG FPS Measurement for Overlay
 	bool IsFrameGenerationDx12PathActive() const;
 	bool IsFrameGenerationActive() const;
+	bool ShouldUseFrameGeneration() const;
 	float GetFrameGenerationFrameTime() const;
 	bool IsUpscalingActive() const;
 

--- a/src/Features/Upscaling/DX12SwapChain.cpp
+++ b/src/Features/Upscaling/DX12SwapChain.cpp
@@ -194,7 +194,7 @@ HRESULT DX12SwapChain::Present(UINT SyncInterval, UINT Flags)
 		}
 	}
 
-	globals::features::upscaling.fidelityFX.Present(upscaling.ShouldUseFrameGeneration(), isHDR);
+	upscaling.fidelityFX.Present(upscaling.ShouldUseFrameGenerationThisFrame(), isHDR);
 
 	DX::ThrowIfFailed(commandLists[frameIndex]->Close());
 

--- a/src/Features/Upscaling/DX12SwapChain.cpp
+++ b/src/Features/Upscaling/DX12SwapChain.cpp
@@ -194,7 +194,7 @@ HRESULT DX12SwapChain::Present(UINT SyncInterval, UINT Flags)
 		}
 	}
 
-	globals::features::upscaling.fidelityFX.Present(upscaling.settings.frameGenerationMode && !globals::game::ui->GameIsPaused(), isHDR);
+	globals::features::upscaling.fidelityFX.Present(upscaling.ShouldUseFrameGeneration(), isHDR);
 
 	DX::ThrowIfFailed(commandLists[frameIndex]->Close());
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Frame Generation in Menus" option (off by default) with tooltip; frame generation now respects this setting and whether menus/paused state allow it.
  * Centralized per-frame decision for when frame generation runs, used across timing, limiter, postprocessing, and presentation paths for consistent behavior.
* **Chores**
  * Upscaling feature version bumped to 1-4-0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->