### PR TITLE
refactor(ui): consolidate popupmodal

### DIFF
--- a/src/FeatureIssues.cpp
+++ b/src/FeatureIssues.cpp
@@ -663,7 +663,7 @@ namespace FeatureIssues
 			}
 
 			// Confirmation popup for deletion
-			if (ImGui::BeginPopupModal(confirmPopupId.c_str(), NULL, ImGuiWindowFlags_AlwaysAutoResize)) {
+			if (auto popup = Util::CenteredPopupModal(confirmPopupId.c_str())) {
 				ImGui::TextWrapped("Are you sure? This will delete all files for feature '%s'?",
 					issue.displayName.empty() ? issue.shortName.c_str() : issue.displayName.c_str());
 				ImGui::Spacing();
@@ -712,7 +712,6 @@ namespace FeatureIssues
 				if (ImGui::Button("Cancel", ImVec2(120, 0))) {
 					ImGui::CloseCurrentPopup();
 				}
-				ImGui::EndPopup();
 			}
 		}
 		ImGui::PopID();

--- a/src/Features/HDRDisplay.cpp
+++ b/src/Features/HDRDisplay.cpp
@@ -407,11 +407,7 @@ void HDRDisplay::DrawSettings()
 		}
 	}
 
-	if (ImGui::BeginPopupModal("HDR Warning##HDRDisplay", &showHDRWarningPopup, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove)) {
-		// Center popup on screen
-		ImVec2 center = ImGui::GetMainViewport()->GetCenter();
-		ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
-
+	if (auto popup = Util::CenteredPopupModal("HDR Warning##HDRDisplay", &showHDRWarningPopup, ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove)) {
 		// Prevent background dimming by pushing lower modal dimming
 		ImGui::PushStyleVar(ImGuiStyleVar_PopupBorderSize, 1.0f);
 
@@ -471,7 +467,6 @@ void HDRDisplay::DrawSettings()
 		ImGui::PopStyleVar();
 
 		ImGui::PopStyleVar();
-		ImGui::EndPopup();
 	}
 
 	// HDR settings sliders

--- a/src/Features/VR/SettingsUI.cpp
+++ b/src/Features/VR/SettingsUI.cpp
@@ -1021,8 +1021,7 @@ void VR::DrawSettings()
 	// Combo recording popup
 	if (this->isCapturingCombo) {
 		ImGui::OpenPopup("Record Combo");
-		ImGui::SetNextWindowSize(ImVec2(400 * Util::GetUIScale(), 200 * Util::GetUIScale()), ImGuiCond_FirstUseEver);
-		if (ImGui::BeginPopupModal("Record Combo", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
+		if (auto popup = Util::CenteredPopupModal("Record Combo")) {
 			auto GetButtonName = [](uint32_t key) -> const char* {
 				switch (key) {
 				case static_cast<uint32_t>(RE::BSOpenVRControllerDevice::Keys::kTrigger):
@@ -1135,8 +1134,6 @@ void VR::DrawSettings()
 				ResetComboRecording();
 				ImGui::CloseCurrentPopup();
 			}
-
-			ImGui::EndPopup();
 		}
 	}
 }

--- a/src/Menu/SettingsTabRenderer.cpp
+++ b/src/Menu/SettingsTabRenderer.cpp
@@ -717,7 +717,7 @@ void SettingsTabRenderer::RenderThemesTab()
 		}
 
 		// Popup modal for creating new theme
-		if (ImGui::BeginPopupModal("Create New Theme", &showCreateThemePopup, ImGuiWindowFlags_AlwaysAutoResize)) {
+		if (auto popup = Util::CenteredPopupModal("Create New Theme", &showCreateThemePopup)) {
 			ImGui::Text("Create a new theme with your current settings:");
 			ImGui::Separator();
 
@@ -827,8 +827,6 @@ void SettingsTabRenderer::RenderThemesTab()
 				showCreateThemePopup = false;
 				ImGui::CloseCurrentPopup();
 			}
-
-			ImGui::EndPopup();
 		}
 
 		if (deleteThemePopup.Draw() && currentThemeInfo && !currentThemeInfo->filePath.empty()) {

--- a/src/Utils/UI.cpp
+++ b/src/Utils/UI.cpp
@@ -116,6 +116,24 @@ namespace Util
 		}
 	}
 
+	CenteredPopupModal::CenteredPopupModal(const char* name, bool* p_open, ImGuiWindowFlags flags, ImVec2 pos, ImVec2 pivot)
+	{
+		if (pos.x == -FLT_MAX && pos.y == -FLT_MAX)
+			pos = ImGui::GetMainViewport()->GetCenter();
+		ImGui::SetNextWindowPos(pos, ImGuiCond_Always, pivot);
+		// Fix first-frame vertical stretch: AlwaysAutoResize resets width to 0 on the hidden
+		// measurement frame, causing TextWrapped to wrap at 0px and produce an enormous height.
+		// Setting an initial width gives TextWrapped a sensible wrap column on that frame.
+		ImGui::SetNextWindowSize(ImVec2(400.0f * GetUIScale(), 0.0f), ImGuiCond_Appearing);
+		isOpen = ImGui::BeginPopupModal(name, p_open, flags | ImGuiWindowFlags_NoSavedSettings);
+	}
+
+	CenteredPopupModal::~CenteredPopupModal()
+	{
+		if (isOpen)
+			ImGui::EndPopup();
+	}
+
 	DisableGuard::DisableGuard(bool disable) :
 		disable(disable)
 	{
@@ -264,11 +282,7 @@ namespace Util
 
 		ImGui::OpenPopup("Clear Shader Cache?");
 
-		// Center the popup
-		ImVec2 center = ImGui::GetMainViewport()->GetCenter();
-		ImGui::SetNextWindowPos(center, ImGuiCond_Always, ImVec2(0.5f, 0.5f));
-
-		if (ImGui::BeginPopupModal("Clear Shader Cache?", &showClearCacheConfirmation, ImGuiWindowFlags_AlwaysAutoResize)) {
+		if (auto popup = CenteredPopupModal("Clear Shader Cache?", &showClearCacheConfirmation)) {
 			ImGui::Text("Are you sure you want to clear the shader cache?");
 			ImGui::Spacing();
 			ImGui::Spacing();
@@ -312,8 +326,6 @@ namespace Util
 				showClearCacheConfirmation = false;
 				ImGui::CloseCurrentPopup();
 			}
-
-			ImGui::EndPopup();
 		}
 	}
 
@@ -340,11 +352,9 @@ namespace Util
 			return false;
 
 		ImGui::OpenPopup(title.c_str());
-		ImVec2 center = ImGui::GetMainViewport()->GetCenter();
-		ImGui::SetNextWindowPos(center, ImGuiCond_Always, ImVec2(0.5f, 0.5f));
 
 		bool result = false;
-		if (ImGui::BeginPopupModal(title.c_str(), &show, ImGuiWindowFlags_AlwaysAutoResize)) {
+		if (auto popup = CenteredPopupModal(title.c_str(), &show)) {
 			ImGui::TextWrapped("%s", message.c_str());
 			ImGui::Spacing();
 			ImGui::Separator();
@@ -374,8 +384,6 @@ namespace Util
 				show = false;
 				ImGui::CloseCurrentPopup();
 			}
-
-			ImGui::EndPopup();
 		}
 		return result;
 	}

--- a/src/Utils/UI.h
+++ b/src/Utils/UI.h
@@ -92,6 +92,39 @@ namespace Util
 	};
 
 	/**
+	 * RAII wrapper for centered popup modals. Positions the window before BeginPopupModal
+	 * (prevents first-frame stretch) and calls EndPopup() automatically on destruction.
+	 *
+	 * By default centers to the viewport center. Pass an explicit pos/pivot to override.
+	 * Pass kPopupCenter as pos to use the default viewport-center behavior.
+	 *
+	 * Usage:
+	 * // Centered (default):
+	 * if (auto popup = Util::CenteredPopupModal("Title")) { ... }
+	 *
+	 * // Custom position:
+	 * if (auto popup = Util::CenteredPopupModal("Title", nullptr, ImGuiWindowFlags_AlwaysAutoResize,
+	 *                                            ImVec2(x, y), ImVec2(0.0f, 0.0f))) { ... }
+	 */
+	class CenteredPopupModal
+	{
+	public:
+		static constexpr ImVec2 kPopupCenter{ -FLT_MAX, -FLT_MAX };
+
+		CenteredPopupModal(const char* name, bool* p_open = nullptr, ImGuiWindowFlags flags = ImGuiWindowFlags_AlwaysAutoResize, ImVec2 pos = kPopupCenter, ImVec2 pivot = ImVec2(0.5f, 0.5f));
+		~CenteredPopupModal();
+		operator bool() const { return isOpen; }
+
+		CenteredPopupModal(const CenteredPopupModal&) = delete;
+		CenteredPopupModal& operator=(const CenteredPopupModal&) = delete;
+		CenteredPopupModal(CenteredPopupModal&&) = delete;
+		CenteredPopupModal& operator=(CenteredPopupModal&&) = delete;
+
+	private:
+		bool isOpen;
+	};
+
+	/**
 	 * Usage:
 	 * {
 	 *      auto _ = DisableGuard(disableThis);

--- a/src/WeatherEditor/Widget.cpp
+++ b/src/WeatherEditor/Widget.cpp
@@ -219,7 +219,7 @@ void Widget::DrawDeleteConfirmationModal(const char* popupId)
 	if (deleteConfirmationFrame == ImGui::GetFrameCount())
 		return;
 
-	if (ImGui::BeginPopupModal(popupId, nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
+	if (auto popup = Util::CenteredPopupModal(popupId)) {
 		deleteConfirmationFrame = ImGui::GetFrameCount();
 		ImGui::Text("Are you sure you want to delete the saved settings file?");
 		ImGui::Spacing();
@@ -244,8 +244,6 @@ void Widget::DrawDeleteConfirmationModal(const char* popupId)
 			ImGui::CloseCurrentPopup();
 		}
 		ImGui::SetItemDefaultFocus();
-
-		ImGui::EndPopup();
 	}
 }
 


### PR DESCRIPTION
This PR also fixes a bug where the popupwindows would be stretched for 1 frame. I consolidated all of these into this helper so that the bug won't reappear again and 1 fix fixes them all.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Consolidated modal dialog handling by introducing a reusable centered popup utility that standardizes dialog positioning throughout the application.
  * Replaced duplicate manual modal positioning logic across multiple UI components with the new centralized utility, improving code consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->