### PR TITLE
feat(weather-editor): adaptively set weather editor key

### DIFF
--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -879,6 +879,27 @@ void Menu::DrawOverlay()
  * @note This method contains Menu-specific logic and state management that makes it
  *       inappropriate for extraction to a utility class.
  */
+static std::vector<InputCombo> DeriveWeatherEditorKey(const std::vector<InputCombo>& menuKey)
+{
+	bool hasShift = false;
+	uint32_t baseKey = 0;
+
+	for (const auto& combo : menuKey) {
+		uint32_t vk = combo.GetKey();
+		if (vk == VK_SHIFT || vk == VK_LSHIFT || vk == VK_RSHIFT) {
+			hasShift = true;
+		} else if (vk != VK_CONTROL && vk != VK_LCONTROL && vk != VK_RCONTROL &&
+		           vk != VK_MENU && vk != VK_LMENU && vk != VK_RMENU) {
+			baseKey = vk;
+		}
+	}
+
+	if (hasShift || baseKey == 0)
+		return {};
+
+	return { InputCombo::Keyboard(VK_SHIFT), InputCombo::Keyboard(baseKey) };
+}
+
 void Menu::ProcessInputEventQueue()
 {
 	std::unique_lock<std::shared_mutex> mutex(_inputEventMutex);
@@ -950,7 +971,12 @@ void Menu::ProcessInputEventQueue()
 				};
 				auto shaderCache = globals::shaderCache;
 				HotkeyAction hotkeyActions[] = {
-					{ &settings.ToggleKey, &settingToggleKey, [this](std::vector<InputCombo> keys) { settings.ToggleKey = keys; settingToggleKey = false; } },
+					{ &settings.ToggleKey, &settingToggleKey, [this](std::vector<InputCombo> keys) {
+						settings.ToggleKey = keys;
+						settingToggleKey = false;
+						if (!settings.FirstTimeSetupCompleted)
+							settings.WeatherEditorToggleKey = DeriveWeatherEditorKey(keys);
+					} },
 					{ &settings.SkipCompilationKey, &settingSkipCompilationKey, [this](std::vector<InputCombo> keys) { settings.SkipCompilationKey = keys; settingSkipCompilationKey = false; } },
 					{ &settings.EffectToggleKey, &settingsEffectsToggle, [this](std::vector<InputCombo> keys) { settings.EffectToggleKey = keys; settingsEffectsToggle = false; } },
 					{ &settings.OverlayToggleKey, &settingOverlayToggleKey, [this](std::vector<InputCombo> keys) { settings.OverlayToggleKey = keys; settingOverlayToggleKey = false; } },

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -404,7 +404,7 @@ public:
 		std::vector<InputCombo> OverlayToggleKey = { InputCombo::Keyboard(VK_F10) };        // Global overlay toggle key for all overlays
 		std::vector<InputCombo> ShaderBlockPrevKey = { InputCombo::Keyboard(VK_PRIOR) };    // Debug: cycle backward through shaders (PageUp)
 		std::vector<InputCombo> ShaderBlockNextKey = { InputCombo::Keyboard(VK_NEXT) };     // Debug: cycle forward through shaders (PageDown)
-		std::vector<InputCombo> WeatherEditorToggleKey = { InputCombo::Keyboard(VK_F11) };  // Weather Editor toggle key
+		std::vector<InputCombo> WeatherEditorToggleKey = { InputCombo::Keyboard(VK_SHIFT), InputCombo::Keyboard(VK_END) };  // Weather Editor toggle key
 		bool EnableShaderBlocking = false;                                                  // Enable shader blocking hotkeys for debugging
 		bool FirstTimeSetupCompleted = false;                                               // Track if first-time setup has been completed
 		bool SkipClearCacheConfirmation = false;                                            // Skip confirmation dialog when clearing shader cache

--- a/src/Menu/HomePageRenderer.cpp
+++ b/src/Menu/HomePageRenderer.cpp
@@ -523,6 +523,20 @@ void HomePageRenderer::RenderFirstTimeSetupDialog()
 		ImGui::TextDisabled("%s", pressKeyText);
 	}
 
+	// Weather Editor hotkey status — updates live as user picks keys
+	{
+		auto& weatherKey = menu->GetSettings().WeatherEditorToggleKey;
+		if (weatherKey.empty()) {
+			const char* warnText = "Weather Editor hotkey unbound \xe2\x80\x94 chosen key uses Shift";
+			centerText(warnText);
+			ImGui::TextColored(ImVec4(1.0f, 0.75f, 0.0f, 1.0f), "%s", warnText);
+		} else {
+			std::string infoStr = "Weather Editor hotkey will be: " + Util::Input::KeyIdToString(weatherKey);
+			centerText(infoStr.c_str());
+			ImGui::TextDisabled("%s", infoStr.c_str());
+		}
+	}
+
 	ImGui::Spacing();
 
 	const char* laterText = "You can change this later in General > Keybindings.";


### PR DESCRIPTION
previously it was defaulted to F11, however after feedback it is probably better to move it to shift end.
it also follows the CS menu key, so if someone changes the CS menu key to X, the weather editor will be bound to Shift + X.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The first-time setup dialog now displays real-time feedback for Weather Editor hotkey selection, showing which keys are bound and alerting users when the hotkey is unbound.

* **Configuration Updates**
  * Updated the Weather Editor hotkey default configuration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/community-shaders/skyrim-community-shaders/pull/2334)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->