### PR TITLE
fix(weather-editor): scale button size with text

### DIFF
--- a/src/WeatherEditor/EditorWindow.cpp
+++ b/src/WeatherEditor/EditorWindow.cpp
@@ -1857,8 +1857,11 @@ void EditorWindow::DrawTimeControls()
 	if (!calendar || !calendar->gameHour || !calendar->timeScale)
 		return;
 
-	const float scale = Util::GetUIScale();
-	float buttonWidth = 120.0f * scale;
+	const float framePadX = ImGui::GetStyle().FramePadding.x * 2.0f;
+	const float buttonWidth = std::max({ ImGui::CalcTextSize("Resume Time").x,
+							   ImGui::CalcTextSize("Pause Time").x,
+							   ImGui::CalcTextSize("Reset Speed").x }) +
+	                          framePadX;
 	if (ImGui::Button(timePaused ? "Resume Time" : "Pause Time", ImVec2(buttonWidth, 0)))
 		TogglePause();
 	if (auto _tt = Util::HoverTooltipWrapper())


### PR DESCRIPTION
specifically for the time control sliders, at various resolutions it could be cutting off.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Time controls pause/resume button now dynamically adjusts width based on text content for improved layout consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/community-shaders/skyrim-community-shaders/pull/2366?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->