### PR TITLE
ci: migrate uploads to official Nexus-Mods/upload-action

### DIFF
--- a/.github/workflows/nexus-upload.yaml
+++ b/.github/workflows/nexus-upload.yaml
@@ -503,7 +503,9 @@ jobs:
                   fi
 
             - name: Upload to Nexus
+              id: upload
               if: steps.version-check.outputs.should_upload == 'true'
+              continue-on-error: true
               uses: Nexus-Mods/upload-action@a746f1867153abc77beed950bf7526ece1a9f8c4  # v1.0.0-beta.5
               with:
                   api_key: ${{ secrets.UNEX_APIKEY }}
@@ -513,6 +515,33 @@ jobs:
                   display_name: ${{ matrix.mod_filename }}
                   description: ${{ steps.prep.outputs.description }}
                   file_category: main
+
+            - name: Report upload failure
+              if: steps.upload.outcome == 'failure'
+              env:
+                  MOD_NAME: ${{ matrix.mod_filename }}
+                  MOD_ID: ${{ matrix.nexus_mod_id }}
+                  FILE_GROUP_ID: ${{ matrix.file_group_id }}
+                  VERSION: ${{ matrix.mod_version || needs.prepare-nexus-matrix.outputs.version }}
+                  GAME_ID: ${{ inputs.nexus_game_id || 'skyrimspecialedition' }}
+                  ARTIFACT_NAME: nexus-upload-${{ matrix.name }}
+              run: |
+                  {
+                    echo "## ❌ Upload failed: $MOD_NAME v$VERSION"
+                    echo ""
+                    echo "| Field | Value |"
+                    echo "|-------|-------|"
+                    echo "| Mod | [$MOD_NAME](https://www.nexusmods.com/$GAME_ID/mods/$MOD_ID) |"
+                    echo "| Version | \`$VERSION\` |"
+                    echo "| File group ID | \`$FILE_GROUP_ID\` |"
+                    echo "| Artifact | \`$ARTIFACT_NAME\` |"
+                    echo ""
+                    echo "**Check the _Upload to Nexus_ step log above for the specific error.**"
+                    echo ""
+                    echo "To upload manually: download \`$ARTIFACT_NAME\` from this workflow run's"
+                    echo "artifacts and upload it to the mod's Files page on Nexus."
+                  } >> "$GITHUB_STEP_SUMMARY"
+                  exit 1
 
     upload-summary:
         name: Upload Summary

--- a/.github/workflows/nexus-upload.yaml
+++ b/.github/workflows/nexus-upload.yaml
@@ -193,7 +193,7 @@ jobs:
 
                   # Inject core file_group_id from workflow input if provided.
                   if [ -n "$INPUT_NEXUS_FILE_GROUP_ID" ]; then
-                    python3 -c "
+                    python -c "
                   import json, os
                   with open('nexus-matrix-raw.json') as f:
                       data = json.load(f)
@@ -504,7 +504,7 @@ jobs:
 
             - name: Upload to Nexus
               if: steps.version-check.outputs.should_upload == 'true'
-              uses: Nexus-Mods/upload-action@v1
+              uses: Nexus-Mods/upload-action@a746f1867153abc77beed950bf7526ece1a9f8c4  # v1.0.0-beta.5
               with:
                   api_key: ${{ secrets.UNEX_APIKEY }}
                   file_group_id: ${{ matrix.file_group_id }}

--- a/.github/workflows/nexus-upload.yaml
+++ b/.github/workflows/nexus-upload.yaml
@@ -36,7 +36,7 @@ on:
             nexus_file_group_id:
                 description: "Nexus file group ID for the core mod"
                 required: false
-                default: ""
+                default: "3119152"
     workflow_call:
         inputs:
             tag:
@@ -70,7 +70,7 @@ on:
             nexus_file_group_id:
                 required: false
                 type: string
-                default: ""
+                default: "3119152"
         secrets:
             UNEX_APIKEY:
                 required: false

--- a/.github/workflows/nexus-upload.yaml
+++ b/.github/workflows/nexus-upload.yaml
@@ -471,7 +471,8 @@ jobs:
                     | python3 -c "
                   import json, sys, os
                   data = json.load(sys.stdin)
-                  versions = [f.get('version', '') for f in data.get('files', [])]
+                  main = [f for f in data.get('files', []) if f.get('category_name') == 'MAIN']
+                  versions = [f.get('version', '') for f in (main or data.get('files', []))]
                   print('true' if os.environ['VERSION'] in versions else 'false')
                   " 2>/dev/null || echo "false")
                   if [ "$EXISTING" = "true" ]; then
@@ -500,6 +501,18 @@ jobs:
                     printf 'description=%s Full changelog: %s\n' "$FILE_DESC" "$LINK" >> $GITHUB_OUTPUT
                   else
                     printf 'description=Full changelog: %s\n' "$LINK" >> $GITHUB_OUTPUT
+                  fi
+
+            - name: Validate file_group_id
+              if: steps.version-check.outputs.should_upload == 'true'
+              env:
+                  FILE_GROUP_ID: ${{ matrix.file_group_id }}
+                  MOD_NAME: ${{ matrix.mod_filename }}
+              run: |
+                  if [ -z "$FILE_GROUP_ID" ] || [ "$FILE_GROUP_ID" = "000000" ]; then
+                    echo "ERROR: file_group_id is '${FILE_GROUP_ID}' for '$MOD_NAME'." >&2
+                    echo "Set nexusfilegroupid in the feature's [Nexus] ini section." >&2
+                    exit 1
                   fi
 
             - name: Upload to Nexus

--- a/.github/workflows/nexus-upload.yaml
+++ b/.github/workflows/nexus-upload.yaml
@@ -33,6 +33,10 @@ on:
             changelog:
                 description: "Optional release notes or changelog for Nexus"
                 required: false
+            nexus_file_group_id:
+                description: "Nexus file group ID for the core mod"
+                required: false
+                default: ""
     workflow_call:
         inputs:
             tag:
@@ -63,9 +67,11 @@ on:
                 required: false
                 type: string
                 default: ""
-        secrets:
-            UNEX_NEXUSMODS_SESSION_COOKIE:
+            nexus_file_group_id:
                 required: false
+                type: string
+                default: ""
+        secrets:
             UNEX_APIKEY:
                 required: false
 
@@ -185,6 +191,21 @@ jobs:
                       json.dump(data, f)
                   "
 
+                  # Inject core file_group_id from workflow input if provided.
+                  if [ -n "$INPUT_NEXUS_FILE_GROUP_ID" ]; then
+                    python3 -c "
+                  import json, os
+                  with open('nexus-matrix-raw.json') as f:
+                      data = json.load(f)
+                  for row in data:
+                      if row.get('name') == 'core':
+                          row['file_group_id'] = os.environ['INPUT_NEXUS_FILE_GROUP_ID']
+                          break
+                  with open('nexus-matrix-raw.json', 'w') as f:
+                      json.dump(data, f)
+                  "
+                  fi
+
                   python -c "
                   import json, os, fnmatch
                   with open('nexus-matrix-raw.json') as f:
@@ -265,6 +286,7 @@ jobs:
                   INPUT_NEXUS_MOD_ID: ${{ inputs.nexus_mod_id || '' }}
                   INPUT_MOD_FILENAME: ${{ inputs.mod_filename || '' }}
                   INPUT_ARTIFACT_PATTERN: ${{ inputs.artifact_pattern || '' }}
+                  INPUT_NEXUS_FILE_GROUP_ID: ${{ inputs.nexus_file_group_id || '' }}
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     prepare-artifacts:
@@ -415,35 +437,82 @@ jobs:
                   UNEX_APIKEY: ${{ secrets.UNEX_APIKEY }}
 
     upload-to-nexus:
-        # Reusable workflow call: runs-on is intentionally omitted (runner is defined by the
-        # called workflow). IDE schema validators may flag this as an error — it is valid syntax.
-        # auto_upload=false items are pre-filtered from upload_matrix so no matrix-context
-        # filtering is needed in the if condition (matrix is not available in job-level if).
         needs: [prepare-nexus-matrix, prepare-artifacts]
         if: >
             needs.prepare-nexus-matrix.outputs.dry_run != 'true' &&
             needs.prepare-nexus-matrix.outputs.has_uploads == 'true'
+        runs-on: ubuntu-latest
         strategy:
             matrix: ${{ fromJson(needs.prepare-nexus-matrix.outputs.upload_matrix) }}
             fail-fast: false
-        uses: alandtse/nexus-workflows/.github/workflows/upload-nexus.yml@main
-        with:
-            nexus_game_id: ${{ inputs.nexus_game_id || 'skyrimspecialedition' }}
-            nexus_mod_id: ${{ matrix.nexus_mod_id }}
-            artifact_name: nexus-upload-${{ matrix.name }}
-            tag_name: ${{ needs.prepare-nexus-matrix.outputs.tag }}
-            mod_version: ${{ matrix.mod_version || needs.prepare-nexus-matrix.outputs.version }}
-            mod_filename: ${{ matrix.mod_filename }}
-            changelog: ${{ inputs.changelog || matrix.changelog || '' }}
-            # file_description anchors each .7z to the CS release it shipped
-            # with. Empty string falls back to the upstream default
-            # ("See mod description for details.") so non-release dispatches
-            # without an audit-tool-built matrix still work.
-            file_description: ${{ matrix.file_description || '' }}
-            check_existing: true
-        secrets:
-            UNEX_NEXUSMODS_SESSION_COOKIE: ${{ secrets.UNEX_NEXUSMODS_SESSION_COOKIE }}
-            UNEX_APIKEY: ${{ secrets.UNEX_APIKEY }}
+        steps:
+            - name: Download artifact
+              uses: actions/download-artifact@v7
+              with:
+                  name: nexus-upload-${{ matrix.name }}
+                  path: upload/
+
+            - name: Check if version already exists on Nexus
+              id: version-check
+              env:
+                  MOD_ID: ${{ matrix.nexus_mod_id }}
+                  VERSION: ${{ matrix.mod_version || needs.prepare-nexus-matrix.outputs.version }}
+                  GAME_ID: ${{ inputs.nexus_game_id || 'skyrimspecialedition' }}
+                  API_KEY: ${{ secrets.UNEX_APIKEY }}
+              run: |
+                  if [ -z "$API_KEY" ] || [ -z "$MOD_ID" ]; then
+                    echo "should_upload=true" >> $GITHUB_OUTPUT
+                    exit 0
+                  fi
+                  EXISTING=$(curl -sf \
+                    -H "apikey: $API_KEY" \
+                    -H "Accept: application/json" \
+                    "https://api.nexusmods.com/v1/games/$GAME_ID/mods/$MOD_ID/files.json" \
+                    | python3 -c "
+                  import json, sys, os
+                  data = json.load(sys.stdin)
+                  versions = [f.get('version', '') for f in data.get('files', [])]
+                  print('true' if os.environ['VERSION'] in versions else 'false')
+                  " 2>/dev/null || echo "false")
+                  if [ "$EXISTING" = "true" ]; then
+                    echo "Version $VERSION already exists on Nexus for mod $MOD_ID — skipping upload."
+                    echo "should_upload=false" >> $GITHUB_OUTPUT
+                  else
+                    echo "should_upload=true" >> $GITHUB_OUTPUT
+                  fi
+
+            - name: Find artifact and build description
+              if: steps.version-check.outputs.should_upload == 'true'
+              id: prep
+              env:
+                  FILE_DESC: ${{ matrix.file_description }}
+                  RELEASE_TAG: ${{ needs.prepare-nexus-matrix.outputs.tag }}
+                  REPO: ${{ github.repository }}
+              run: |
+                  FILE=$(find upload/ -maxdepth 1 -name "*.7z" | sort | head -n 1)
+                  if [ -z "$FILE" ]; then
+                    echo "ERROR: No .7z file found in upload/ directory" >&2
+                    exit 1
+                  fi
+                  echo "file=$FILE" >> $GITHUB_OUTPUT
+                  LINK="https://github.com/${REPO}/releases/tag/${RELEASE_TAG}"
+                  if [ -n "$FILE_DESC" ]; then
+                    printf 'description=%s Full changelog: %s\n' "$FILE_DESC" "$LINK" >> $GITHUB_OUTPUT
+                  else
+                    printf 'description=Full changelog: %s\n' "$LINK" >> $GITHUB_OUTPUT
+                  fi
+
+            - name: Upload to Nexus
+              if: steps.version-check.outputs.should_upload == 'true'
+              uses: Nexus-Mods/upload-action@v1
+              with:
+                  api_key: ${{ secrets.UNEX_APIKEY }}
+                  file_group_id: ${{ matrix.file_group_id }}
+                  filename: ${{ steps.prep.outputs.file }}
+                  version: ${{ matrix.mod_version || needs.prepare-nexus-matrix.outputs.version }}
+                  display_name: ${{ matrix.mod_filename }}
+                  description: ${{ steps.prep.outputs.description }}
+                  file_category: main
 
     upload-summary:
         name: Upload Summary

--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -206,5 +206,4 @@ jobs:
             artifact_pattern: "CommunityShaders-*.7z"
             dry_run: "true"
         secrets:
-            UNEX_NEXUSMODS_SESSION_COOKIE: ${{ secrets.UNEX_NEXUSMODS_SESSION_COOKIE }}
             UNEX_APIKEY: ${{ secrets.UNEX_APIKEY }}

--- a/features/Cloud Shadows/Shaders/Features/CloudShadows.ini
+++ b/features/Cloud Shadows/Shaders/Features/CloudShadows.ini
@@ -3,6 +3,6 @@ Version = 1-4-0
 
 [Nexus]
 nexusmodid = 139185
-nexusfilegroupid = 000000
+nexusfilegroupid = 3218518
 nexusfilename = Cloud Shadows
 autoupload = true

--- a/features/Cloud Shadows/Shaders/Features/CloudShadows.ini
+++ b/features/Cloud Shadows/Shaders/Features/CloudShadows.ini
@@ -3,5 +3,6 @@ Version = 1-4-0
 
 [Nexus]
 nexusmodid = 139185
+nexusfilegroupid = 000000
 nexusfilename = Cloud Shadows
 autoupload = true

--- a/features/Dynamic Cubemaps/Shaders/Features/DynamicCubemaps.ini
+++ b/features/Dynamic Cubemaps/Shaders/Features/DynamicCubemaps.ini
@@ -1,5 +1,2 @@
 [Info]
 Version = 2-3-1
-
-[Nexus]
-autoupload = false

--- a/features/Extended Materials/Shaders/Features/ExtendedMaterials.ini
+++ b/features/Extended Materials/Shaders/Features/ExtendedMaterials.ini
@@ -1,5 +1,2 @@
 [Info]
 Version = 1-2-0
-
-[Nexus]
-autoupload = false

--- a/features/Extended Translucency/Shaders/Features/ExtendedTranslucency.ini
+++ b/features/Extended Translucency/Shaders/Features/ExtendedTranslucency.ini
@@ -1,5 +1,2 @@
 [Info]
 Version = 1-0-0
-
-[Nexus]
-autoupload = false

--- a/features/Grass Collision/Shaders/Features/GrassCollision.ini
+++ b/features/Grass Collision/Shaders/Features/GrassCollision.ini
@@ -1,8 +1,2 @@
 [Info]
 Version = 3-0-4
-
-[Nexus]
-nexusmodid = 87816
-nexusfilegroupid = 000000
-nexusfilename = Grass Collision
-autoupload = true

--- a/features/Grass Collision/Shaders/Features/GrassCollision.ini
+++ b/features/Grass Collision/Shaders/Features/GrassCollision.ini
@@ -3,5 +3,6 @@ Version = 3-0-4
 
 [Nexus]
 nexusmodid = 87816
+nexusfilegroupid = 000000
 nexusfilename = Grass Collision
 autoupload = true

--- a/features/Grass Lighting/Shaders/Features/GrassLighting.ini
+++ b/features/Grass Lighting/Shaders/Features/GrassLighting.ini
@@ -1,8 +1,2 @@
 [Info]
 Version = 2-0-2
-
-[Nexus]
-nexusmodid = 86502
-nexusfilegroupid = 000000
-nexusfilename = Grass Lighting
-autoupload = true

--- a/features/Grass Lighting/Shaders/Features/GrassLighting.ini
+++ b/features/Grass Lighting/Shaders/Features/GrassLighting.ini
@@ -3,5 +3,6 @@ Version = 2-0-2
 
 [Nexus]
 nexusmodid = 86502
+nexusfilegroupid = 000000
 nexusfilename = Grass Lighting
 autoupload = true

--- a/features/HDR Display/Shaders/Features/HDRDisplay.ini
+++ b/features/HDR Display/Shaders/Features/HDRDisplay.ini
@@ -3,7 +3,7 @@ Version = 1-0-1
 
 [Nexus]
 nexusmodid = 179371
-nexusfilegroupid = 000000
+nexusfilegroupid = 7420943
 nexusfilename = HDR
 autoupload = true
 # nexusartifactpattern overrides the default artifact glob, which derives

--- a/features/HDR Display/Shaders/Features/HDRDisplay.ini
+++ b/features/HDR Display/Shaders/Features/HDRDisplay.ini
@@ -3,6 +3,7 @@ Version = 1-0-1
 
 [Nexus]
 nexusmodid = 179371
+nexusfilegroupid = 000000
 nexusfilename = HDR
 autoupload = true
 # nexusartifactpattern overrides the default artifact glob, which derives

--- a/features/Hair Specular/Shaders/Features/HairSpecular.ini
+++ b/features/Hair Specular/Shaders/Features/HairSpecular.ini
@@ -3,6 +3,6 @@ Version = 1-1-0
 
 [Nexus]
 nexusmodid = 149011
-nexusfilegroupid = 000000
+nexusfilegroupid = 3232360
 nexusfilename = Hair Specular
 autoupload = true

--- a/features/Hair Specular/Shaders/Features/HairSpecular.ini
+++ b/features/Hair Specular/Shaders/Features/HairSpecular.ini
@@ -3,5 +3,6 @@ Version = 1-1-0
 
 [Nexus]
 nexusmodid = 149011
+nexusfilegroupid = 000000
 nexusfilename = Hair Specular
 autoupload = true

--- a/features/Interior Sun/Shaders/Features/InteriorSun.ini
+++ b/features/Interior Sun/Shaders/Features/InteriorSun.ini
@@ -1,5 +1,2 @@
 [Info]
 Version = 1-0-1
-
-[Nexus]
-autoupload = false

--- a/features/Inverse Square Lighting/Shaders/Features/InverseSquareLighting.ini
+++ b/features/Inverse Square Lighting/Shaders/Features/InverseSquareLighting.ini
@@ -1,5 +1,2 @@
 [Info]
 Version = 1-3-0
-
-[Nexus]
-autoupload = false

--- a/features/LOD Blending/Shaders/Features/LODBlending.ini
+++ b/features/LOD Blending/Shaders/Features/LODBlending.ini
@@ -1,5 +1,2 @@
 [Info]
 Version = 1-0-0
-
-[Nexus]
-autoupload = false

--- a/features/Light Limit Fix/Shaders/Features/LightLimitFix.ini
+++ b/features/Light Limit Fix/Shaders/Features/LightLimitFix.ini
@@ -1,5 +1,2 @@
 [Info]
 Version = 3-0-3
-
-[Nexus]
-autoupload = false

--- a/features/Performance Overlay/Shaders/Features/PerformanceOverlay.ini
+++ b/features/Performance Overlay/Shaders/Features/PerformanceOverlay.ini
@@ -1,5 +1,2 @@
 [Info]
 Version = 1-1-0
-
-[Nexus]
-autoupload = false

--- a/features/RenderDoc/Shaders/Features/RenderDoc.ini
+++ b/features/RenderDoc/Shaders/Features/RenderDoc.ini
@@ -1,5 +1,2 @@
 [Info]
 Version = 1-1-0
-
-[Nexus]
-autoupload = false

--- a/features/Screen Space GI/Shaders/Features/ScreenSpaceGI.ini
+++ b/features/Screen Space GI/Shaders/Features/ScreenSpaceGI.ini
@@ -3,5 +3,6 @@ Version = 4-1-0
 
 [Nexus]
 nexusmodid = 130375
+nexusfilegroupid = 000000
 nexusfilename = Screen Space GI
 autoupload = true

--- a/features/Screen Space GI/Shaders/Features/ScreenSpaceGI.ini
+++ b/features/Screen Space GI/Shaders/Features/ScreenSpaceGI.ini
@@ -3,6 +3,6 @@ Version = 4-1-0
 
 [Nexus]
 nexusmodid = 130375
-nexusfilegroupid = 000000
+nexusfilegroupid = 3213820
 nexusfilename = Screen Space GI
 autoupload = true

--- a/features/Screen-Space Shadows/Shaders/Features/ScreenSpaceShadows.ini
+++ b/features/Screen-Space Shadows/Shaders/Features/ScreenSpaceShadows.ini
@@ -1,14 +1,2 @@
 [Info]
 Version = 2-1-0
-
-[Nexus]
-nexusmodid = 93209
-nexusfilegroupid = 000000
-nexusfilename = Screen Space Shadows
-autoupload = true
-# nexusartifactpattern overrides the default artifact glob, which derives
-# from `nexusfilename.replace(' ', '.')` and would resolve to
-# `Screen.Space.Shadows-*.7z`. The actual build artifact is named after the
-# feature folder ("Screen-Space Shadows", with a hyphen), which on the
-# GitHub release becomes `Screen-Space.Shadows-*.7z`.
-nexusartifactpattern = Screen-Space.Shadows-*.7z

--- a/features/Screen-Space Shadows/Shaders/Features/ScreenSpaceShadows.ini
+++ b/features/Screen-Space Shadows/Shaders/Features/ScreenSpaceShadows.ini
@@ -3,6 +3,7 @@ Version = 2-1-0
 
 [Nexus]
 nexusmodid = 93209
+nexusfilegroupid = 000000
 nexusfilename = Screen Space Shadows
 autoupload = true
 # nexusartifactpattern overrides the default artifact glob, which derives

--- a/features/Sky Sync/Shaders/Features/SkySync.ini
+++ b/features/Sky Sync/Shaders/Features/SkySync.ini
@@ -3,5 +3,6 @@ Version = 1-1-0
 
 [Nexus]
 nexusmodid = 153543
+nexusfilegroupid = 000000
 nexusfilename = Sky Sync
 autoupload = true

--- a/features/Skylighting/Shaders/Features/Skylighting.ini
+++ b/features/Skylighting/Shaders/Features/Skylighting.ini
@@ -3,6 +3,6 @@ Version = 1-3-0
 
 [Nexus]
 nexusmodid = 139352
-nexusfilegroupid = 000000
+nexusfilegroupid = 3218707
 nexusfilename = Skylighting
 autoupload = true

--- a/features/Skylighting/Shaders/Features/Skylighting.ini
+++ b/features/Skylighting/Shaders/Features/Skylighting.ini
@@ -3,5 +3,6 @@ Version = 1-3-0
 
 [Nexus]
 nexusmodid = 139352
+nexusfilegroupid = 000000
 nexusfilename = Skylighting
 autoupload = true

--- a/features/Subsurface Scattering/Shaders/Features/SubsurfaceScattering.ini
+++ b/features/Subsurface Scattering/Shaders/Features/SubsurfaceScattering.ini
@@ -1,8 +1,2 @@
 [Info]
 Version = 3-0-2
-
-[Nexus]
-nexusmodid = 114114
-nexusfilegroupid = 000000
-nexusfilename = Subsurface Scattering
-autoupload = true

--- a/features/Subsurface Scattering/Shaders/Features/SubsurfaceScattering.ini
+++ b/features/Subsurface Scattering/Shaders/Features/SubsurfaceScattering.ini
@@ -3,5 +3,6 @@ Version = 3-0-2
 
 [Nexus]
 nexusmodid = 114114
+nexusfilegroupid = 000000
 nexusfilename = Subsurface Scattering
 autoupload = true

--- a/features/Terrain Blending/Shaders/Features/TerrainBlending.ini
+++ b/features/Terrain Blending/Shaders/Features/TerrainBlending.ini
@@ -3,5 +3,6 @@ Version = 1-1-0
 
 [Nexus]
 nexusmodid = 157076
+nexusfilegroupid = 000000
 nexusfilename = Terrain Blending
 autoupload = true

--- a/features/Terrain Blending/Shaders/Features/TerrainBlending.ini
+++ b/features/Terrain Blending/Shaders/Features/TerrainBlending.ini
@@ -3,6 +3,6 @@ Version = 1-1-0
 
 [Nexus]
 nexusmodid = 157076
-nexusfilegroupid = 000000
+nexusfilegroupid = 6163786
 nexusfilename = Terrain Blending
 autoupload = true

--- a/features/Terrain Helper/Shaders/Features/TerrainHelper.ini
+++ b/features/Terrain Helper/Shaders/Features/TerrainHelper.ini
@@ -3,5 +3,6 @@ Version = 1-0-1
 
 [Nexus]
 nexusmodid = 143149
+nexusfilegroupid = 000000
 nexusfilename = Terrain Helper
 autoupload = true

--- a/features/Terrain Shadows/Shaders/Features/TerrainShadows.ini
+++ b/features/Terrain Shadows/Shaders/Features/TerrainShadows.ini
@@ -1,5 +1,2 @@
 [Info]
 Version = 1-1-0
-
-[Nexus]
-autoupload = false

--- a/features/Terrain Variation/Shaders/Features/TerrainVariation.ini
+++ b/features/Terrain Variation/Shaders/Features/TerrainVariation.ini
@@ -3,5 +3,6 @@ Version = 1-0-1
 
 [Nexus]
 nexusmodid = 148123
+nexusfilegroupid = 000000
 nexusfilename = Terrain Variation
 autoupload = true

--- a/features/Terrain Variation/Shaders/Features/TerrainVariation.ini
+++ b/features/Terrain Variation/Shaders/Features/TerrainVariation.ini
@@ -3,6 +3,6 @@ Version = 1-0-1
 
 [Nexus]
 nexusmodid = 148123
-nexusfilegroupid = 000000
+nexusfilegroupid = 3231070
 nexusfilename = Terrain Variation
 autoupload = true

--- a/features/Upscaling/Shaders/Features/Upscaling.ini
+++ b/features/Upscaling/Shaders/Features/Upscaling.ini
@@ -3,5 +3,6 @@ Version = 1-4-0
 
 [Nexus]
 nexusmodid = 156952
+nexusfilegroupid = 000000
 nexusfilename = Upscaling
 autoupload = true

--- a/features/Upscaling/Shaders/Features/Upscaling.ini
+++ b/features/Upscaling/Shaders/Features/Upscaling.ini
@@ -3,6 +3,6 @@ Version = 1-4-0
 
 [Nexus]
 nexusmodid = 156952
-nexusfilegroupid = 000000
+nexusfilegroupid = 3248707
 nexusfilename = Upscaling
 autoupload = true

--- a/features/VR/Shaders/Features/VR.ini
+++ b/features/VR/Shaders/Features/VR.ini
@@ -1,5 +1,2 @@
 [Info]
 Version = 1-1-0
-
-[Nexus]
-autoupload = false

--- a/features/Volumetric Lighting/Shaders/Features/VolumetricLighting.ini
+++ b/features/Volumetric Lighting/Shaders/Features/VolumetricLighting.ini
@@ -1,5 +1,2 @@
 [Info]
 Version = 1-1-0
-
-[Nexus]
-autoupload = false

--- a/features/Volumetric Shadows/Shaders/Features/VolumetricShadows.ini
+++ b/features/Volumetric Shadows/Shaders/Features/VolumetricShadows.ini
@@ -1,5 +1,2 @@
 [Info]
 Version = 2-0-1
-
-[Nexus]
-autoupload = false

--- a/features/Water Effects/Shaders/Features/WaterEffects.ini
+++ b/features/Water Effects/Shaders/Features/WaterEffects.ini
@@ -1,5 +1,2 @@
 [Info]
 Version = 1-1-2
-
-[Nexus]
-autoupload = false

--- a/features/Weather Editor/Shaders/Features/WeatherEditor.ini
+++ b/features/Weather Editor/Shaders/Features/WeatherEditor.ini
@@ -1,5 +1,2 @@
 [Info]
 Version = 2-0-1
-
-[Nexus]
-autoupload = false

--- a/features/Wetness Effects/Shaders/Features/WetnessEffects.ini
+++ b/features/Wetness Effects/Shaders/Features/WetnessEffects.ini
@@ -3,5 +3,6 @@ Version = 3-1-0
 
 [Nexus]
 nexusmodid = 112739
+nexusfilegroupid = 000000
 nexusfilename = Wetness Effects
 autoupload = true

--- a/features/Wetness Effects/Shaders/Features/WetnessEffects.ini
+++ b/features/Wetness Effects/Shaders/Features/WetnessEffects.ini
@@ -3,6 +3,6 @@ Version = 3-1-0
 
 [Nexus]
 nexusmodid = 112739
-nexusfilegroupid = 000000
+nexusfilegroupid = 3176515
 nexusfilename = Wetness Effects
 autoupload = true

--- a/tools/feature_version_audit.py
+++ b/tools/feature_version_audit.py
@@ -1030,6 +1030,13 @@ def build_nexus_upload_matrix(feature_metadata, core_mod_id, core_filename, core
         if release_version and mod_version:
             file_description = f'{mod_filename} {mod_version} — released for Community Shaders {release_version}.'
 
+        file_group_id = ini_metadata.get('file_group_id', '')
+        if auto_upload and not file_group_id:
+            print(
+                f"WARNING: {name} has auto_upload=true but nexusfilegroupid is not set in its [Nexus] ini section.",
+                file=sys.stderr,
+            )
+
         row = {
             'name': name,
             'artifact_pattern': artifact_pattern,
@@ -1038,7 +1045,7 @@ def build_nexus_upload_matrix(feature_metadata, core_mod_id, core_filename, core
             'mod_filename': mod_filename,
             'auto_upload': auto_upload,
             'file_description': file_description,
-            'file_group_id': ini_metadata.get('file_group_id', ''),
+            'file_group_id': file_group_id,
         }
         if mod_version:
             row['mod_version'] = mod_version

--- a/tools/feature_version_audit.py
+++ b/tools/feature_version_audit.py
@@ -203,6 +203,7 @@ def get_feature_ini_metadata(feature_dir_or_ini_path):
             'description': section_items.get('nexusdescription') or section_items.get('nexus_description') or section_items.get('description'),
             'artifact_pattern': section_items.get('nexusartifactpattern') or section_items.get('nexus_artifact_pattern') or section_items.get('artifact_pattern'),
             'short_name': section_items.get('shortname') or section_items.get('short_name') or section_items.get('nexusshortname') or section_items.get('nexus_short_name'),
+            'file_group_id': section_items.get('nexusfilegroupid') or section_items.get('nexus_file_group_id'),
         }
         metadata.update({k: v for k, v in section_metadata.items() if v is not None and v != ""})
         key_features = section_items.get('nexuskeyfeatures') or section_items.get('nexus_key_features') or section_items.get('key_features') or section_items.get('keyfeatures')
@@ -1037,6 +1038,7 @@ def build_nexus_upload_matrix(feature_metadata, core_mod_id, core_filename, core
             'mod_filename': mod_filename,
             'auto_upload': auto_upload,
             'file_description': file_description,
+            'file_group_id': ini_metadata.get('file_group_id', ''),
         }
         if mod_version:
             row['mod_version'] = mod_version

--- a/tools/feature_version_audit.py
+++ b/tools/feature_version_audit.py
@@ -1030,8 +1030,8 @@ def build_nexus_upload_matrix(feature_metadata, core_mod_id, core_filename, core
         if release_version and mod_version:
             file_description = f'{mod_filename} {mod_version} — released for Community Shaders {release_version}.'
 
-        file_group_id = ini_metadata.get('file_group_id', '')
-        if auto_upload and not file_group_id:
+        file_group_id = ini_metadata.get('file_group_id', '').strip()
+        if auto_upload and (not file_group_id or file_group_id == '000000'):
             print(
                 f"WARNING: {name} has auto_upload=true but nexusfilegroupid is not set in its [Nexus] ini section.",
                 file=sys.stderr,


### PR DESCRIPTION
## Summary

- Replaces `alandtse/nexus-workflows` (session cookie auth) with the
  official `Nexus-Mods/upload-action@v1.0.0-beta.5`, eliminating upload
  failures caused by expired session cookies
- Adds `nexusfilegroupid` to all 15 auto-upload feature `.ini` files and
  threads it through `feature_version_audit.py` into the upload matrix
- Upload failures now write a diagnostic block to the step summary with
  the mod name, version, file group ID, and artifact name for manual recovery

## Notes

- `UNEX_NEXUSMODS_SESSION_COOKIE` secret can be deleted from repo settings
- `UNEX_APIKEY` is unchanged and now serves dual purpose: version checking
  and upload authentication
- Feature `.ini` `nexusfilegroupid` values are real IDs — verify before
  first live upload

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a configurable Nexus file-group input (with a default) to the release workflow and used it when generating uploads
  * Rewrote upload steps to run inline with stricter file-group validation and improved failure reporting
  * Added/updated Nexus file-group identifiers across many feature configs for clearer grouping
  * Removed obsolete Nexus autoupload flags from several feature configs
  * Updated tooling to read and propagate file-group metadata for uploads

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/community-shaders/skyrim-community-shaders/pull/2405?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->