### PR TITLE
ci: pin cmake and avoid cloudcache

### DIFF
--- a/.github/actions/setup-build-environment/action.yaml
+++ b/.github/actions/setup-build-environment/action.yaml
@@ -24,9 +24,10 @@ runs:
           shell: bash
 
         - name: Install CMake 4.x
-          uses: lukka/get-cmake@latest
+          uses: lukka/get-cmake@v4.3.3
           with:
               cmakeVersion: "~4.2.0"
+              useCloudCache: false
 
         - name: Install Visual Studio 2026 Build Tools
           shell: pwsh


### PR DESCRIPTION
prevents a faulty small cloud cache from failing to setup the build env on this PR:https://github.com/community-shaders/skyrim-community-shaders/pull/2414

Also keeps cmake at a static version so it doesn't float and potentially break compilation again

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build environment setup for enhanced reproducibility and stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/community-shaders/skyrim-community-shaders/pull/2415?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->