### PR TITLE
fix(vol-fog): missing define

### DIFF
--- a/package/Shaders/Sky.hlsl
+++ b/package/Shaders/Sky.hlsl
@@ -194,6 +194,7 @@ cbuffer AlphaTestRefCB : register(b11)
 #	endif
 
 #	if defined(EXP_HEIGHT_FOG)
+#		define SampColorSampler SampBaseSampler
 #		include "ExponentialHeightFog/ExponentialHeightFog.hlsli"
 #	endif
 


### PR DESCRIPTION
fixes 18 shaders failing to compile.
followup on https://github.com/community-shaders/skyrim-community-shaders/pull/2466

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated shader configuration for improved rendering optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->