### PR TITLE
ci: use prebuilt CommonLib

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -57,7 +57,8 @@
                 "ENABLE_SKYRIM_AE": "ON",
                 "ENABLE_SKYRIM_SE": "ON",
                 "ENABLE_SKYRIM_VR": "ON",
-                "AUTO_PLUGIN_DEPLOYMENT": "OFF"
+                "AUTO_PLUGIN_DEPLOYMENT": "OFF",
+                "COMMONLIB_PREBUILT_MULTICONFIG": "ON"
             },
             "inherits": "skyrim"
         },
@@ -68,9 +69,18 @@
                 "ENABLE_SKYRIM_AE": "ON",
                 "ENABLE_SKYRIM_SE": "ON",
                 "ENABLE_SKYRIM_VR": "ON",
-                "AUTO_PLUGIN_DEPLOYMENT": "OFF"
+                "AUTO_PLUGIN_DEPLOYMENT": "OFF",
+                "COMMONLIB_PREBUILT_MULTICONFIG": "ON"
             },
             "inherits": "skyrim"
+        },
+        {
+            "name": "ALL-DEBUG",
+            "description": "Like ALL but builds CommonLib from source. The prebuilt package is Release-only (Debug maps to no imported location), so a Debug build off ALL fails to link — this preset keeps Debug-from-source working in its own build/ALL-DEBUG dir.",
+            "inherits": "ALL",
+            "cacheVariables": {
+                "COMMONLIB_PREBUILT_MULTICONFIG": "OFF"
+            }
         }
     ],
     "buildPresets": [
@@ -112,7 +122,7 @@
         {
             "name": "Debug",
             "description": "Debug build for CS SKSE plugin, generate an AIO folder thats ready to copy",
-            "configurePreset": "ALL",
+            "configurePreset": "ALL-DEBUG",
             "configuration": "Debug",
             "targets": ["CommunityShaders", "AIO"]
         }


### PR DESCRIPTION
Opts CS into the prebuilt CommonLibSSE auto-fetch so CI downloads + links the prebuilt static lib instead of compiling CommonLib from source (~16 min → a few min). Sets `COMMONLIB_PREBUILT_MULTICONFIG=ON` in the `ALL` / `ALL-VS2022` presets.

## Why the flag is needed
The cmake prebuilt is baked **Release-only, single-config**, and the resolver skips multi-config generators by default (it can't rule out a Debug build, which would mislink the Release lib). CS uses the **Visual Studio generator** but only builds **Release**, so it opts in via `COMMONLIB_PREBUILT_MULTICONFIG` (added in CommonLibVR#173): the IMPORTED target serves Release and maps Debug→nothing (a stray Debug build fails loudly).

Cherrypicked from Open Shaders

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CMake build configuration presets to introduce separate Debug preset for building CommonLib from source during development while maintaining optimized prebuilt CommonLib setup for Release builds
  * Updated project dependency submodule reference

<!-- end of auto-generated comment: release notes by coderabbit.ai -->