### PR TITLE
fix(input): fire combo hotkeys on press not release

### DIFF
--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -1081,6 +1081,61 @@ void Menu::ProcessInputEventQueue()
 			const bool wasCapturingHotkey = IsCapturingHotkeyInput();
 			const bool allowSetupCloseKey = wasCapturingHotkey && HomePageRenderer::ShouldShowFirstTimeSetup() &&
 			                                (key == VK_RETURN || key == VK_ESCAPE);
+
+			// Dispatch bound hotkey actions for `key`. Combo bindings (modifier + key)
+			// fire on key-down for responsiveness; single-key bindings fire on key-up.
+			auto dispatchHotkeyActions = [this, key](bool combosOnly) {
+				struct KeyAction
+				{
+					std::vector<InputCombo>& settingKey;
+					std::function<void()> action;
+				};
+				auto shaderCache = globals::shaderCache;
+				KeyAction keyActions[] = {
+					{ settings.ToggleKey, [this]() {
+						 if (!HomePageRenderer::ShouldShowFirstTimeSetup()) {
+							 IsEnabled = !IsEnabled;
+							 if (IsEnabled)
+								 ImGui::GetIO().ClearInputKeys();  // Prevent toggle key from remaining "held" in ImGui after open.
+						 }
+					 } },
+					{ settings.SkipCompilationKey, [this, shaderCache]() { if (!ShouldSwallowInput() && shaderCache->IsCompiling()) shaderCache->backgroundCompilation = true; } },
+					{ settings.EffectToggleKey, [shaderCache]() { shaderCache->SetEnabled(!shaderCache->IsEnabled()); } },
+					{ settings.ShaderBlockPrevKey, [this, shaderCache]() { if (settings.EnableShaderBlocking) shaderCache->IterateShaderBlock(); } },
+					{ settings.ShaderBlockNextKey, [this, shaderCache]() { if (settings.EnableShaderBlocking) shaderCache->IterateShaderBlock(false); } },
+					{ settings.OverlayToggleKey, []() { Menu::GetSingleton()->overlayVisible = !Menu::GetSingleton()->overlayVisible; } },
+					{ settings.CSEditorToggleKey, []() {
+						 auto* ew = EditorWindow::GetSingleton();
+						 if (!ew)
+							 return;
+						 if (ew->GetPreviewMode() == EditorWindow::PreviewMode::FreeCamera) {
+							 // Flying → lock camera position for editing
+							 ew->ToggleFreeCameraLock();
+						 } else if (ew->IsInPreviewMode()) {
+							 // Locked or PlayMode → fully exit preview
+							 ew->ExitPreviewMode();
+						 } else {
+							 CSEditor::ToggleEditorWindow();
+						 }
+					 } },
+					{ settings.ScreenshotKey, []() {
+						 if (globals::features::screenshotFeature.loaded)
+							 globals::features::screenshotFeature.captureRequested = true;
+					 } },
+				};
+				// RenderDoc's capture key is a single, unmodified key; only consider it on key-up.
+				if (!combosOnly && globals::features::renderDoc.HandleCaptureHotkey(key))
+					return true;
+				for (const auto& ka : keyActions) {
+					const bool isCombo = ka.settingKey.size() > 1;
+					if (isCombo == combosOnly && InputCombo::MatchesKeyboardCombo(ka.settingKey, key)) {
+						ka.action();
+						return true;
+					}
+				}
+				return false;
+			};
+
 			if (!event.IsPressed()) {
 				// Skip key release if it was used to close the first-time setup dialog
 				if (HomePageRenderer::ShouldSkipKeyRelease(key)) {
@@ -1094,7 +1149,6 @@ void Menu::ProcessInputEventQueue()
 					bool* settingFlag;
 					std::function<void(std::vector<InputCombo>)> action;
 				};
-				auto shaderCache = globals::shaderCache;
 				HotkeyAction hotkeyActions[] = {
 					{ &settings.ToggleKey, &settingToggleKey, [this](std::vector<InputCombo> keys) {
 						 settings.ToggleKey = keys;
@@ -1155,51 +1209,11 @@ void Menu::ProcessInputEventQueue()
 					}
 				}
 				if (!handled) {
-					struct KeyAction
-					{
-						std::vector<InputCombo>& settingKey;
-						std::function<void()> action;
-					};
-					KeyAction keyActions[] = {
-						{ settings.ToggleKey, [this]() {
-							 if (!HomePageRenderer::ShouldShowFirstTimeSetup()) {
-								 IsEnabled = !IsEnabled;
-								 if (IsEnabled)
-									 ImGui::GetIO().ClearInputKeys();  // Prevent toggle key from remaining "held" in ImGui after open.
-							 }
-						 } },
-						{ settings.SkipCompilationKey, [this, shaderCache]() { if (!ShouldSwallowInput() && shaderCache->IsCompiling()) shaderCache->backgroundCompilation = true; } },
-						{ settings.EffectToggleKey, [shaderCache]() { shaderCache->SetEnabled(!shaderCache->IsEnabled()); } },
-						{ settings.ShaderBlockPrevKey, [this, shaderCache]() { if (settings.EnableShaderBlocking) shaderCache->IterateShaderBlock(); } },
-						{ settings.ShaderBlockNextKey, [this, shaderCache]() { if (settings.EnableShaderBlocking) shaderCache->IterateShaderBlock(false); } },
-						{ settings.OverlayToggleKey, []() { Menu::GetSingleton()->overlayVisible = !Menu::GetSingleton()->overlayVisible; } },
-						{ settings.CSEditorToggleKey, []() {
-							 auto* ew = EditorWindow::GetSingleton();
-							 if (!ew)
-								 return;
-							 if (ew->GetPreviewMode() == EditorWindow::PreviewMode::FreeCamera) {
-								 // Flying → lock camera position for editing
-								 ew->ToggleFreeCameraLock();
-							 } else if (ew->IsInPreviewMode()) {
-								 // Locked or PlayMode → fully exit preview
-								 ew->ExitPreviewMode();
-							 } else {
-								 CSEditor::ToggleEditorWindow();
-							 }
-						 } },
-						{ settings.ScreenshotKey, []() {
-							 if (globals::features::screenshotFeature.loaded)
-								 globals::features::screenshotFeature.captureRequested = true;
-						 } },
-					};
-					if (!globals::features::renderDoc.HandleCaptureHotkey(key)) {
-						for (const auto& ka : keyActions) {
-							if (InputCombo::MatchesKeyboardCombo(ka.settingKey, key)) {
-								ka.action();
-								break;
-							}
-						}
-					}
+					// Single-key hotkeys fire on key-up; combos already fired on key-down.
+					// If this key's key-down already fired a combo, suppress the single-key
+					// binding so releasing the modifier first doesn't trigger it as well.
+					if (_comboFiredKeys.erase(key) == 0)
+						dispatchHotkeyActions(false);
 				}
 
 				// Handle ESC key for menu and editor window
@@ -1213,6 +1227,12 @@ void Menu::ProcessInputEventQueue()
 						IsEnabled = false;
 					}
 				}
+			} else if (event.IsDown() && !wasCapturingHotkey) {
+				// Fire combo hotkeys on the key-down transition so they respond on
+				// press rather than release. IsDown() (not IsPressed()) ensures we
+				// trigger only once instead of every frame the key is held.
+				if (dispatchHotkeyActions(true))
+					_comboFiredKeys.insert(key);
 			}
 
 			// Don't forward hotkey events to ImGui when input is captured (prevents e.g. End key scrolling the feature list)

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -14,6 +14,7 @@
 #include <string>
 #include <string_view>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 #include <winrt/base.h>
 
@@ -513,6 +514,11 @@ private:
 	// Input event handling
 	std::vector<KeyEvent> _keyEventQueue;
 	mutable std::shared_mutex _inputEventMutex;
+
+	// Keys whose key-down already fired a combo hotkey. Their matching key-up is
+	// suppressed so a shared single-key binding (e.g. End) doesn't also fire once
+	// the modifier is released first.
+	std::unordered_set<uint32_t> _comboFiredKeys;
 
 	Menu() = default;
 


### PR DESCRIPTION
Combo hotkeys (modifier + key, e.g. Shift+End) only fired when the
final key was released. Single-key bindings firing on release is
imperceptible, but combos felt laggy and unresponsive.

Dispatch combo bindings on the key-down transition instead. Use
IsDown() rather than IsPressed() so the action triggers once on the
initial press rather than every frame the key is held. Single-key
bindings continue to fire on key-up to preserve existing behavior.

Also fixes a double-trigger: when a key is shared between a combo and
a single binding (Shift+End closes the editor, End opens the menu),
releasing the modifier before the key made the key-up match the
single binding and fire it too. Keys whose press fired a combo are
tracked and have their matching key-up suppressed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced hotkey handling to prevent unintended duplicate triggers when using modifier+key combinations. Hotkeys for toggle, compilation, effects, overlays, shaders, editors, and screenshots now respond more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->