### PR TITLE
fix(hdr): fix grey menus when TAA enabled

### DIFF
--- a/src/Features/HDRDisplay.cpp
+++ b/src/Features/HDRDisplay.cpp
@@ -225,16 +225,9 @@ namespace
 		static void thunk(RE::ImageSpaceManager* a_this, uint32_t a3, RE::RENDER_TARGET a_target, void* a_4, bool a_5)
 		{
 			auto* hdr = &globals::features::hdrDisplay;
-
-			// bUseTAA is force-disabled in DataLoaded, so drive the scene TAA resolve here, enabled
-			// only around the post-process call.
-			Util::SetTemporal(hdr->taaRequested);
-
 			hdr->RedirectFramebuffer();
 			func(a_this, a3, a_target, a_4, a_5);
 			hdr->RestoreFramebuffer();
-
-			Util::SetTemporal(false);
 		}
 		static inline REL::Relocation<decltype(thunk)> func;
 	};
@@ -248,18 +241,6 @@ namespace
 		}
 		static inline REL::Relocation<decltype(thunk)> func;
 	};
-
-	struct HDR_Main_UpdateJitter
-	{
-		static void thunk(RE::BSGraphics::State* a_state)
-		{
-			if (globals::features::hdrDisplay.taaRequested)
-				Util::SetTemporal(true);
-			func(a_state);
-		}
-		static inline REL::Relocation<decltype(thunk)> func;
-	};
-
 }
 
 bool HDRDisplay::isHDRMonitor = false;
@@ -615,15 +596,6 @@ void HDRDisplay::DataLoaded()
 	} else {
 		logger::warn("[HDR Display] bUse64bitsHDRRenderTarget ini setting not found");
 	}
-
-	// When Upscaling is absent, vanilla bUseTAA's paused-menu UI pass re-renders the opaque scene
-	// into the redirected HDR UI buffer, washing the view grey. Disable it and drive the scene TAA
-	// resolve manually (jitter + post-process), capturing the user's preference first.
-	if (!globals::features::upscaling.loaded) {
-		if (auto* taaSetting = RE::GetINISetting("bUseTAA:Display"))
-			taaRequested = taaSetting->data.b;
-		Util::DisableVanillaTAA();
-	}
 }
 
 void HDRDisplay::PostPostLoad()
@@ -632,9 +604,7 @@ void HDRDisplay::PostPostLoad()
 	// PostPostLoad. Only install here when Upscaling is absent.
 	if (!globals::features::upscaling.loaded) {
 		logger::info("[HDR Display] Installing HDR pipeline hooks (Upscaling not loaded)");
-		bool isGOG = !GetModuleHandle(L"steam_api64.dll");
 		stl::detour_thunk<HDR_MenuManagerDrawInterfaceStartHook>(REL::RelocationID(79947, 82084));
-		stl::write_thunk_call<HDR_Main_UpdateJitter>(REL::RelocationID(75460, 77245).address() + REL::Relocate(0xE5, isGOG ? 0x133 : 0xE2));
 		stl::write_thunk_call<HDR_Main_PostProcessing>(REL::RelocationID(100430, 107148).address() + REL::Relocate(0x1F0, 0x1E7));
 	}
 }

--- a/src/Features/HDRDisplay.cpp
+++ b/src/Features/HDRDisplay.cpp
@@ -249,16 +249,17 @@ namespace
 		static inline REL::Relocation<decltype(thunk)> func;
 	};
 
-	// Force scene TAA on before the game computes jitter, so jitter still applies with bUseTAA off.
 	struct HDR_Main_UpdateJitter
 	{
 		static void thunk(RE::BSGraphics::State* a_state)
 		{
-			Util::SetTemporal(globals::features::hdrDisplay.taaRequested);
+			if (globals::features::hdrDisplay.taaRequested)
+				Util::SetTemporal(true);
 			func(a_state);
 		}
 		static inline REL::Relocation<decltype(thunk)> func;
 	};
+
 }
 
 bool HDRDisplay::isHDRMonitor = false;
@@ -633,7 +634,6 @@ void HDRDisplay::PostPostLoad()
 		logger::info("[HDR Display] Installing HDR pipeline hooks (Upscaling not loaded)");
 		bool isGOG = !GetModuleHandle(L"steam_api64.dll");
 		stl::detour_thunk<HDR_MenuManagerDrawInterfaceStartHook>(REL::RelocationID(79947, 82084));
-		// Calculates jitter — force scene TAA on first so the game still jitters with bUseTAA off
 		stl::write_thunk_call<HDR_Main_UpdateJitter>(REL::RelocationID(75460, 77245).address() + REL::Relocate(0xE5, isGOG ? 0x133 : 0xE2));
 		stl::write_thunk_call<HDR_Main_PostProcessing>(REL::RelocationID(100430, 107148).address() + REL::Relocate(0x1F0, 0x1E7));
 	}

--- a/src/Features/HDRDisplay.cpp
+++ b/src/Features/HDRDisplay.cpp
@@ -226,10 +226,8 @@ namespace
 		{
 			auto* hdr = &globals::features::hdrDisplay;
 
-			// Vanilla bUseTAA is force-disabled in DataLoaded (it drives the paused-menu UI temporal-AA
-			// pass that pollutes the HDR UI buffer with the opaque scene). Run the scene TAA resolve
-			// here instead, mirroring Upscaling: enable it only around the post-process call so it does
-			// not re-introduce the menu pollution. Jitter is applied by HDR_Main_UpdateJitter.
+			// bUseTAA is force-disabled in DataLoaded, so drive the scene TAA resolve here, enabled
+			// only around the post-process call.
 			Util::SetTemporal(hdr->taaRequested);
 
 			hdr->RedirectFramebuffer();
@@ -251,8 +249,7 @@ namespace
 		static inline REL::Relocation<decltype(thunk)> func;
 	};
 
-	// Force the scene TAA flag on before the game computes jitter so it still applies sub-pixel
-	// jitter even though vanilla bUseTAA is disabled. Mirrors Upscaling::Main_UpdateJitter.
+	// Force scene TAA on before the game computes jitter, so jitter still applies with bUseTAA off.
 	struct HDR_Main_UpdateJitter
 	{
 		static void thunk(RE::BSGraphics::State* a_state)
@@ -618,12 +615,9 @@ void HDRDisplay::DataLoaded()
 		logger::warn("[HDR Display] bUse64bitsHDRRenderTarget ini setting not found");
 	}
 
-	// When Upscaling is not loaded, vanilla bUseTAA drives a UI temporal-AA pass that, in paused
-	// menus, re-renders the opaque scene into the redirected HDR UI buffer (alpha=1). HDROutputCS
-	// then discards the real HDR scene and the view washes grey. Disable the vanilla TAA system and
-	// drive the scene TAA resolve manually (HDR_Main_UpdateJitter + HDR_Main_PostProcessing),
-	// mirroring how Upscaling handles TAA. The user's preference is captured so jitter and the
-	// resolve still run during gameplay.
+	// When Upscaling is absent, vanilla bUseTAA's paused-menu UI pass re-renders the opaque scene
+	// into the redirected HDR UI buffer, washing the view grey. Disable it and drive the scene TAA
+	// resolve manually (jitter + post-process), capturing the user's preference first.
 	if (!globals::features::upscaling.loaded) {
 		if (auto* taaSetting = RE::GetINISetting("bUseTAA:Display"))
 			taaRequested = taaSetting->data.b;

--- a/src/Features/HDRDisplay.cpp
+++ b/src/Features/HDRDisplay.cpp
@@ -225,10 +225,18 @@ namespace
 		static void thunk(RE::ImageSpaceManager* a_this, uint32_t a3, RE::RENDER_TARGET a_target, void* a_4, bool a_5)
 		{
 			auto* hdr = &globals::features::hdrDisplay;
+
+			// Vanilla bUseTAA is force-disabled in DataLoaded (it drives the paused-menu UI temporal-AA
+			// pass that pollutes the HDR UI buffer with the opaque scene). Run the scene TAA resolve
+			// here instead, mirroring Upscaling: enable it only around the post-process call so it does
+			// not re-introduce the menu pollution. Jitter is applied by HDR_Main_UpdateJitter.
+			Util::SetTemporal(hdr->taaRequested);
+
 			hdr->RedirectFramebuffer();
 			func(a_this, a3, a_target, a_4, a_5);
 			hdr->RestoreFramebuffer();
 
+			Util::SetTemporal(false);
 		}
 		static inline REL::Relocation<decltype(thunk)> func;
 	};
@@ -239,6 +247,18 @@ namespace
 		{
 			globals::features::hdrDisplay.SetUIBuffer();
 			func(a1);
+		}
+		static inline REL::Relocation<decltype(thunk)> func;
+	};
+
+	// Force the scene TAA flag on before the game computes jitter so it still applies sub-pixel
+	// jitter even though vanilla bUseTAA is disabled. Mirrors Upscaling::Main_UpdateJitter.
+	struct HDR_Main_UpdateJitter
+	{
+		static void thunk(RE::BSGraphics::State* a_state)
+		{
+			Util::SetTemporal(globals::features::hdrDisplay.taaRequested);
+			func(a_state);
 		}
 		static inline REL::Relocation<decltype(thunk)> func;
 	};
@@ -597,6 +617,19 @@ void HDRDisplay::DataLoaded()
 	} else {
 		logger::warn("[HDR Display] bUse64bitsHDRRenderTarget ini setting not found");
 	}
+
+	// When Upscaling is not loaded, vanilla bUseTAA drives a UI temporal-AA pass that, in paused
+	// menus, re-renders the opaque scene into the redirected HDR UI buffer (alpha=1). HDROutputCS
+	// then discards the real HDR scene and the view washes grey. Disable the vanilla TAA system and
+	// drive the scene TAA resolve manually (HDR_Main_UpdateJitter + HDR_Main_PostProcessing),
+	// mirroring how Upscaling handles TAA. The user's preference is captured so jitter and the
+	// resolve still run during gameplay.
+	if (!globals::features::upscaling.loaded) {
+		if (auto* taaSetting = RE::GetINISetting("bUseTAA:Display"))
+			taaRequested = taaSetting->data.b;
+		Util::DisableVanillaTAA();
+		logger::info("[HDR Display] Disabled vanilla bUseTAA (was {}); scene TAA driven manually", taaRequested);
+	}
 }
 
 void HDRDisplay::PostPostLoad()
@@ -605,7 +638,10 @@ void HDRDisplay::PostPostLoad()
 	// PostPostLoad. Only install here when Upscaling is absent.
 	if (!globals::features::upscaling.loaded) {
 		logger::info("[HDR Display] Installing HDR pipeline hooks (Upscaling not loaded)");
+		bool isGOG = !GetModuleHandle(L"steam_api64.dll");
 		stl::detour_thunk<HDR_MenuManagerDrawInterfaceStartHook>(REL::RelocationID(79947, 82084));
+		// Calculates jitter — force scene TAA on first so the game still jitters with bUseTAA off
+		stl::write_thunk_call<HDR_Main_UpdateJitter>(REL::RelocationID(75460, 77245).address() + REL::Relocate(0xE5, isGOG ? 0x133 : 0xE2));
 		stl::write_thunk_call<HDR_Main_PostProcessing>(REL::RelocationID(100430, 107148).address() + REL::Relocate(0x1F0, 0x1E7));
 	}
 }

--- a/src/Features/HDRDisplay.cpp
+++ b/src/Features/HDRDisplay.cpp
@@ -628,7 +628,6 @@ void HDRDisplay::DataLoaded()
 		if (auto* taaSetting = RE::GetINISetting("bUseTAA:Display"))
 			taaRequested = taaSetting->data.b;
 		Util::DisableVanillaTAA();
-		logger::info("[HDR Display] Disabled vanilla bUseTAA (was {}); scene TAA driven manually", taaRequested);
 	}
 }
 

--- a/src/Features/HDRDisplay.h
+++ b/src/Features/HDRDisplay.h
@@ -154,9 +154,6 @@ public:
 	ID3D11ShaderResourceView* savedFramebufferSRV = nullptr;
 	bool framebufferRedirected = false;
 
-	// User's bUseTAA preference, captured before it is force-disabled. Drives the manual scene TAA resolve.
-	bool taaRequested = false;
-
 	// Upgraded LDR render targets (post-tonemapping targets need float16 for HDR values)
 	void UpgradeLDRRenderTargets();
 	void RestoreLDRRenderTargets();

--- a/src/Features/HDRDisplay.h
+++ b/src/Features/HDRDisplay.h
@@ -154,6 +154,10 @@ public:
 	ID3D11ShaderResourceView* savedFramebufferSRV = nullptr;
 	bool framebufferRedirected = false;
 
+	// User's vanilla TAA preference, captured before bUseTAA is force-disabled in DataLoaded
+	// (Upscaling-not-loaded path). Drives the manual scene TAA resolve in HDR_Main_PostProcessing.
+	bool taaRequested = false;
+
 	// Upgraded LDR render targets (post-tonemapping targets need float16 for HDR values)
 	void UpgradeLDRRenderTargets();
 	void RestoreLDRRenderTargets();

--- a/src/Features/HDRDisplay.h
+++ b/src/Features/HDRDisplay.h
@@ -154,8 +154,7 @@ public:
 	ID3D11ShaderResourceView* savedFramebufferSRV = nullptr;
 	bool framebufferRedirected = false;
 
-	// User's vanilla TAA preference, captured before bUseTAA is force-disabled in DataLoaded
-	// (Upscaling-not-loaded path). Drives the manual scene TAA resolve in HDR_Main_PostProcessing.
+	// User's bUseTAA preference, captured before it is force-disabled. Drives the manual scene TAA resolve.
 	bool taaRequested = false;
 
 	// Upgraded LDR render targets (post-tonemapping targets need float16 for HDR values)

--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -5,6 +5,7 @@
 #include "HDRDisplay.h"
 #include "Hooks.h"
 #include "State.h"
+#include "Utils/Game.h"
 #include "Upscaling/DX12SwapChain.h"
 #include "Upscaling/FidelityFX.h"
 #include "Upscaling/Streamline.h"
@@ -519,7 +520,7 @@ void Upscaling::RestoreDefaultSettings()
 void Upscaling::DataLoaded()
 {
 	// Fix screenshots fix from Engine Fixes
-	RE::GetINISetting("bUseTAA:Display")->data.b = false;
+	Util::DisableVanillaTAA();
 
 	// The game defaults this to a non-zero value
 	static auto fDRClampOffset = RE::GetINISetting("fDRClampOffset:Display");
@@ -877,11 +878,8 @@ void Upscaling::ConfigureTAA()
 {
 	auto upscaleMethod = GetUpscaleMethod();
 
-	auto imageSpaceManager = RE::ImageSpaceManager::GetSingleton();
-	auto& BSImagespaceShaderISTemporalAA = imageSpaceManager->GetRuntimeData().BSImagespaceShaderISTemporalAA;
-
 	// Force enable TAA if needed
-	BSImagespaceShaderISTemporalAA->taaEnabled = upscaleMethod != UpscaleMethod::kNONE;
+	Util::SetTemporal(upscaleMethod != UpscaleMethod::kNONE);
 }
 
 void Upscaling::ConfigureUpscaling(RE::BSGraphics::State* a_viewport)
@@ -1679,10 +1677,7 @@ void Upscaling::Main_PostProcessing::thunk(RE::ImageSpaceManager* a_this, uint32
 	if (upscaleMethod == UpscaleMethod::kDLSS)
 		upscaling.ApplySharpening();
 
-	auto imageSpaceManager = RE::ImageSpaceManager::GetSingleton();
-	auto& BSImagespaceShaderISTemporalAA = imageSpaceManager->GetRuntimeData().BSImagespaceShaderISTemporalAA;
-
-	BSImagespaceShaderISTemporalAA->taaEnabled = upscaleMethod == UpscaleMethod::kTAA;
+	Util::SetTemporal(upscaleMethod == UpscaleMethod::kTAA);
 
 	// Redirect kFRAMEBUFFER to float texture before ISHDR runs so HDR values >1.0 survive
 	// When HDR Display is not loaded, ISHDR writes to vanilla kFRAMEBUFFER (SDR path)
@@ -1696,7 +1691,7 @@ void Upscaling::Main_PostProcessing::thunk(RE::ImageSpaceManager* a_this, uint32
 	if (hdrLoaded)
 		globals::features::hdrDisplay.RestoreFramebuffer();
 
-	BSImagespaceShaderISTemporalAA->taaEnabled = false;
+	Util::SetTemporal(false);
 }
 
 void Upscaling::SetScissorRect::thunk(RE::BSGraphics::Renderer* This, int a_left, int a_top, int a_right, int a_bottom)

--- a/src/Globals.cpp
+++ b/src/Globals.cpp
@@ -114,6 +114,7 @@ namespace globals
 		RE::Sky* sky = nullptr;
 		RE::UI* ui = nullptr;
 		RE::Calendar* calendar = nullptr;
+		RE::ImageSpaceManager* imageSpaceManager = nullptr;
 		std::atomic<bool> quitGame{ false };
 
 		RE::BSGraphics::PixelShader** currentPixelShader = nullptr;
@@ -188,6 +189,7 @@ namespace globals
 
 			ui = RE::UI::GetSingleton();
 			calendar = RE::Calendar::GetSingleton();
+			imageSpaceManager = RE::ImageSpaceManager::GetSingleton();
 			perFrame = { REL::RelocationID(524768, 411384) };
 
 			currentAccumulator = { REL::RelocationID(527650, 414600) };

--- a/src/Globals.cpp
+++ b/src/Globals.cpp
@@ -218,6 +218,7 @@ namespace globals
 		player = RE::PlayerCharacter::GetSingleton();
 		sky = RE::Sky::GetSingleton();
 		utilityShader = RE::BSUtilityShader::GetSingleton();
+		imageSpaceManager = RE::ImageSpaceManager::GetSingleton();
 
 		bEnableLandFade = iniSettingCollection->GetSetting("bEnableLandFade:Display");
 

--- a/src/Globals.cpp
+++ b/src/Globals.cpp
@@ -189,7 +189,6 @@ namespace globals
 
 			ui = RE::UI::GetSingleton();
 			calendar = RE::Calendar::GetSingleton();
-			imageSpaceManager = RE::ImageSpaceManager::GetSingleton();
 			perFrame = { REL::RelocationID(524768, 411384) };
 
 			currentAccumulator = { REL::RelocationID(527650, 414600) };

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -159,6 +159,7 @@ namespace globals
 		extern RE::Sky* sky;
 		extern RE::UI* ui;
 		extern RE::Calendar* calendar;
+		extern RE::ImageSpaceManager* imageSpaceManager;
 		extern std::atomic<bool> quitGame;
 
 		extern RE::BSGraphics::PixelShader** currentPixelShader;

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -503,6 +503,19 @@ namespace Hooks
 		static inline REL::Relocation<decltype(thunk)> func;
 	};
 
+	// Disable scene TAA for the duration of the menu interface render, then restore it.
+	struct MenuManagerDrawInterfaceStart
+	{
+		static void thunk(int64_t a1)
+		{
+			const bool temporal = Util::GetTemporal();
+			Util::SetTemporal(false);
+			func(a1);
+			Util::SetTemporal(temporal);
+		}
+		static inline REL::Relocation<decltype(thunk)> func;
+	};
+
 	struct CreateRenderTarget_Main
 	{
 		static void thunk(RE::BSGraphics::Renderer* This, RE::RENDER_TARGETS::RENDER_TARGET a_target, RE::BSGraphics::RenderTargetProperties* a_properties)
@@ -922,6 +935,9 @@ namespace Hooks
 
 		logger::info("Hooking Sky::UpdateColors");
 		stl::detour_thunk<Sky_UpdateColors>(REL::RelocationID(25686, 26233));
+
+		logger::info("Hooking MenuManager::DrawInterfaceStart for menu TAA");
+		stl::detour_thunk<MenuManagerDrawInterfaceStart>(REL::RelocationID(79947, 82084));
 
 		logger::info("Installing SetupGeometry hooks");
 		stl::write_vfunc<0x6, EffectExtensions::BSEffectShader_SetupGeometry>(RE::VTABLE_BSEffectShader[0]);

--- a/src/Utils/Game.cpp
+++ b/src/Utils/Game.cpp
@@ -114,14 +114,29 @@ namespace Util
 		return cameraData;
 	}
 
+	// The singleton is created after globals are cached in ReInit, so resolve it lazily on first use.
+	static RE::ImageSpaceManager* GetImageSpaceManager()
+	{
+		if (!globals::game::imageSpaceManager)
+			globals::game::imageSpaceManager = RE::ImageSpaceManager::GetSingleton();
+		return globals::game::imageSpaceManager;
+	}
+
 	bool GetTemporal()
 	{
-		return globals::game::imageSpaceManager->GetRuntimeData().BSImagespaceShaderISTemporalAA->taaEnabled;
+		auto* imageSpaceManager = GetImageSpaceManager();
+		if (!imageSpaceManager)
+			return false;
+		auto& taaShader = imageSpaceManager->GetRuntimeData().BSImagespaceShaderISTemporalAA;
+		return taaShader && taaShader->taaEnabled;
 	}
 
 	void SetTemporal(bool enabled)
 	{
-		if (auto& taaShader = globals::game::imageSpaceManager->GetRuntimeData().BSImagespaceShaderISTemporalAA)
+		auto* imageSpaceManager = GetImageSpaceManager();
+		if (!imageSpaceManager)
+			return;
+		if (auto& taaShader = imageSpaceManager->GetRuntimeData().BSImagespaceShaderISTemporalAA)
 			taaShader->taaEnabled = enabled;
 	}
 

--- a/src/Utils/Game.cpp
+++ b/src/Utils/Game.cpp
@@ -1,5 +1,6 @@
 #include "Game.h"
 
+#include "Globals.h"
 #include "State.h"
 
 namespace Util
@@ -115,17 +116,12 @@ namespace Util
 
 	bool GetTemporal()
 	{
-		auto imageSpaceManager = RE::ImageSpaceManager::GetSingleton();
-		return imageSpaceManager->GetRuntimeData().BSImagespaceShaderISTemporalAA->taaEnabled;
+		return globals::game::imageSpaceManager->GetRuntimeData().BSImagespaceShaderISTemporalAA->taaEnabled;
 	}
 
 	void SetTemporal(bool enabled)
 	{
-		auto* imageSpaceManager = RE::ImageSpaceManager::GetSingleton();
-		if (!imageSpaceManager)
-			return;
-		auto& taaShader = imageSpaceManager->GetRuntimeData().BSImagespaceShaderISTemporalAA;
-		if (taaShader)
+		if (auto& taaShader = globals::game::imageSpaceManager->GetRuntimeData().BSImagespaceShaderISTemporalAA)
 			taaShader->taaEnabled = enabled;
 	}
 

--- a/src/Utils/Game.cpp
+++ b/src/Utils/Game.cpp
@@ -119,6 +119,22 @@ namespace Util
 		return imageSpaceManager->GetRuntimeData().BSImagespaceShaderISTemporalAA->taaEnabled;
 	}
 
+	void SetTemporal(bool enabled)
+	{
+		auto* imageSpaceManager = RE::ImageSpaceManager::GetSingleton();
+		if (!imageSpaceManager)
+			return;
+		auto& taaShader = imageSpaceManager->GetRuntimeData().BSImagespaceShaderISTemporalAA;
+		if (taaShader)
+			taaShader->taaEnabled = enabled;
+	}
+
+	void DisableVanillaTAA()
+	{
+		if (auto* setting = RE::GetINISetting("bUseTAA:Display"))
+			setting->data.b = false;
+	}
+
 	float GetVerticalFOVRad()
 	{
 		static float& cameraFOVDeg = (*(float*)(REL::RelocationID(513786, 388785).address()));  // FOV degrees

--- a/src/Utils/Game.cpp
+++ b/src/Utils/Game.cpp
@@ -114,17 +114,9 @@ namespace Util
 		return cameraData;
 	}
 
-	// The singleton is created after globals are cached in ReInit, so resolve it lazily on first use.
-	static RE::ImageSpaceManager* GetImageSpaceManager()
-	{
-		if (!globals::game::imageSpaceManager)
-			globals::game::imageSpaceManager = RE::ImageSpaceManager::GetSingleton();
-		return globals::game::imageSpaceManager;
-	}
-
 	bool GetTemporal()
 	{
-		auto* imageSpaceManager = GetImageSpaceManager();
+		auto* imageSpaceManager = globals::game::imageSpaceManager;
 		if (!imageSpaceManager)
 			return false;
 		auto& taaShader = imageSpaceManager->GetRuntimeData().BSImagespaceShaderISTemporalAA;
@@ -133,7 +125,7 @@ namespace Util
 
 	void SetTemporal(bool enabled)
 	{
-		auto* imageSpaceManager = GetImageSpaceManager();
+		auto* imageSpaceManager = globals::game::imageSpaceManager;
 		if (!imageSpaceManager)
 			return;
 		if (auto& taaShader = imageSpaceManager->GetRuntimeData().BSImagespaceShaderISTemporalAA)

--- a/src/Utils/Game.h
+++ b/src/Utils/Game.h
@@ -9,6 +9,12 @@ namespace Util
 	float4 TryGetWaterData(float offsetX, float offsetY);
 	float4 GetCameraData();
 	bool GetTemporal();
+	// Toggle the ISTemporalAA scene-resolve flag (the runtime companion to GetTemporal).
+	void SetTemporal(bool enabled);
+	// Disable Skyrim's built-in TAA system (the bUseTAA:Display ini flag). Used when Community
+	// Shaders drives TAA directly (Upscaling, and HDR Display when Upscaling is not loaded), because
+	// vanilla bUseTAA also runs a paused-menu UI temporal-AA pass that breaks HDR compositing.
+	void DisableVanillaTAA();
 	float GetVerticalFOVRad();
 
 	RE::NiPoint3 GetEyePosition();

--- a/src/Utils/Game.h
+++ b/src/Utils/Game.h
@@ -9,11 +9,10 @@ namespace Util
 	float4 TryGetWaterData(float offsetX, float offsetY);
 	float4 GetCameraData();
 	bool GetTemporal();
-	// Toggle the ISTemporalAA scene-resolve flag (the runtime companion to GetTemporal).
+	// Toggle the ISTemporalAA scene-resolve flag (companion to GetTemporal).
 	void SetTemporal(bool enabled);
-	// Disable Skyrim's built-in TAA system (the bUseTAA:Display ini flag). Used when Community
-	// Shaders drives TAA directly (Upscaling, and HDR Display when Upscaling is not loaded), because
-	// vanilla bUseTAA also runs a paused-menu UI temporal-AA pass that breaks HDR compositing.
+	// Disable vanilla TAA (bUseTAA:Display). CS drives TAA itself: Upscaling always,
+	// HDR only when Upscaling is absent. HDR needs it off so vanilla's paused-menu UI pass can't wash out the HDR buffer.
 	void DisableVanillaTAA();
 	float GetVerticalFOVRad();
 

--- a/src/Utils/Game.h
+++ b/src/Utils/Game.h
@@ -11,8 +11,7 @@ namespace Util
 	bool GetTemporal();
 	// Toggle the ISTemporalAA scene-resolve flag (companion to GetTemporal).
 	void SetTemporal(bool enabled);
-	// Disable vanilla TAA (bUseTAA:Display). CS drives TAA itself: Upscaling always,
-	// HDR only when Upscaling is absent. HDR needs it off so vanilla's paused-menu UI pass can't wash out the HDR buffer.
+	// Disable vanilla TAA (bUseTAA:Display). CS drives TAA itself.
 	void DisableVanillaTAA();
 	float GetVerticalFOVRad();
 


### PR DESCRIPTION
When HDR Display is loaded without Upscaling and vanilla bUseTAA is
on, Skyrim's paused-menu UI temporal-AA pass re-renders the opaque
scene into the redirected HDR UI buffer with alpha=1. HDROutputCS then
discards the real HDR scene entirely, causing a grey view.

Disable vanilla bUseTAA in DataLoaded() and drive the scene TAA
resolve manually via two hooks that mirror Upscaling's approach:
HDR_Main_UpdateJitter forces taaEnabled before the game's jitter
calculation, and HDR_Main_PostProcessing toggles it around the
post-process call. The user's bUseTAA preference is captured so
gameplay TAA still runs with correct sub-pixel jitter.

Extract SetTemporal() and DisableVanillaTAA() into Util:: and
refactor Upscaling to use the same helpers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized temporal anti-aliasing control for consistent, system-wide behavior
  * Simplified HDR post-processing flow to reduce framebuffer state manipulation

* **Improvements**
  * Menu interface rendering temporarily disables temporal effects for clearer menus
  * More robust handling when rendering resources are unavailable, improving stability
<!-- end of auto-generated comment: release notes by coderabbit.ai -->