### PR TITLE
fix(water caustics): x4000 warnings

### DIFF
--- a/features/Water Effects/Shaders/WaterEffects/WaterCaustics.hlsli
+++ b/features/Water Effects/Shaders/WaterEffects/WaterCaustics.hlsli
@@ -38,11 +38,9 @@ namespace WaterEffects
 			float2 causticsUV1 = PanCausticsUV(causticsUV, 0.5 * 0.2, 1.0);
 			float2 causticsUV2 = PanCausticsUV(causticsUV, 1.0 * 0.2, -0.5);
 
-			float3 causticsHigh;
+			float3 causticsHigh = 1.0.xxx;
 			if (causticsFade > 0.0) {
 				causticsHigh = min(SampleCausticsDispersion(causticsUV1, dispersionOffset), SampleCausticsDispersion(causticsUV2, dispersionOffset)) * 4.0;
-			} else {
-				causticsHigh = 1.0.xxx;
 			}
 
 			causticsUV *= 0.5;
@@ -51,11 +49,9 @@ namespace WaterEffects
 			causticsUV1 = PanCausticsUV(causticsUV, 0.5 * 0.1, 1.0);
 			causticsUV2 = PanCausticsUV(causticsUV, 1.0 * 0.1, -0.5);
 
-			float3 causticsLow;
+			float3 causticsLow = 1.0.xxx;
 			if (causticsFade < 1.0) {
 				causticsLow = min(SampleCausticsDispersion(causticsUV1, dispersionOffset), SampleCausticsDispersion(causticsUV2, dispersionOffset)) * 4.0;
-			} else {
-				causticsLow = 1.0.xxx;
 			}
 
 			const float3 caustics = lerp(causticsLow, causticsHigh, causticsFade);

--- a/features/Water Effects/Shaders/WaterEffects/WaterCaustics.hlsli
+++ b/features/Water Effects/Shaders/WaterEffects/WaterCaustics.hlsli
@@ -25,6 +25,7 @@ namespace WaterEffects
 
 	float3 ComputeCaustics(float4 waterData, float3 worldPosition)
 	{
+		float3 result = 1.0.xxx;
 		float causticsDistToWater = waterData.w - worldPosition.z;
 		float shoreFactorCaustics = saturate(causticsDistToWater / 64.0);
 
@@ -38,10 +39,10 @@ namespace WaterEffects
 			float2 causticsUV1 = PanCausticsUV(causticsUV, 0.5 * 0.2, 1.0);
 			float2 causticsUV2 = PanCausticsUV(causticsUV, 1.0 * 0.2, -0.5);
 
-			float3 causticsHigh = 1.0.xxx;
-			if (causticsFade > 0.0) {
-				causticsHigh = min(SampleCausticsDispersion(causticsUV1, dispersionOffset), SampleCausticsDispersion(causticsUV2, dispersionOffset)) * 4.0;
-			}
+			const float3 causticsHigh =
+				(causticsFade > 0.0)
+					? (min(SampleCausticsDispersion(causticsUV1, dispersionOffset), SampleCausticsDispersion(causticsUV2, dispersionOffset)) * 4.0)
+					: 1.0.xxx;
 
 			causticsUV *= 0.5;
 			dispersionOffset *= 0.5;
@@ -49,15 +50,15 @@ namespace WaterEffects
 			causticsUV1 = PanCausticsUV(causticsUV, 0.5 * 0.1, 1.0);
 			causticsUV2 = PanCausticsUV(causticsUV, 1.0 * 0.1, -0.5);
 
-			float3 causticsLow = 1.0.xxx;
-			if (causticsFade < 1.0) {
-				causticsLow = min(SampleCausticsDispersion(causticsUV1, dispersionOffset), SampleCausticsDispersion(causticsUV2, dispersionOffset)) * 4.0;
-			}
+			const float3 causticsLow =
+				(causticsFade < 1.0)
+					? (min(SampleCausticsDispersion(causticsUV1, dispersionOffset), SampleCausticsDispersion(causticsUV2, dispersionOffset)) * 4.0)
+					: 1.0.xxx;
 
 			const float3 caustics = lerp(causticsLow, causticsHigh, causticsFade);
-			return lerp(1.0.xxx, caustics, shoreFactorCaustics);
+			result = lerp(1.0.xxx, caustics, shoreFactorCaustics);
 		}
 
-		return 1.0.xxx;
+		return result;
 	}
 }

--- a/features/Water Effects/Shaders/WaterEffects/WaterCaustics.hlsli
+++ b/features/Water Effects/Shaders/WaterEffects/WaterCaustics.hlsli
@@ -38,9 +38,12 @@ namespace WaterEffects
 			float2 causticsUV1 = PanCausticsUV(causticsUV, 0.5 * 0.2, 1.0);
 			float2 causticsUV2 = PanCausticsUV(causticsUV, 1.0 * 0.2, -0.5);
 
-			float3 causticsHigh = 1.0.xxx;
-			if (causticsFade > 0.0)
+			float3 causticsHigh;
+			if (causticsFade > 0.0) {
 				causticsHigh = min(SampleCausticsDispersion(causticsUV1, dispersionOffset), SampleCausticsDispersion(causticsUV2, dispersionOffset)) * 4.0;
+			} else {
+				causticsHigh = 1.0.xxx;
+			}
 
 			causticsUV *= 0.5;
 			dispersionOffset *= 0.5;
@@ -48,11 +51,14 @@ namespace WaterEffects
 			causticsUV1 = PanCausticsUV(causticsUV, 0.5 * 0.1, 1.0);
 			causticsUV2 = PanCausticsUV(causticsUV, 1.0 * 0.1, -0.5);
 
-			float3 causticsLow = 1.0.xxx;
-			if (causticsFade < 1.0)
+			float3 causticsLow;
+			if (causticsFade < 1.0) {
 				causticsLow = min(SampleCausticsDispersion(causticsUV1, dispersionOffset), SampleCausticsDispersion(causticsUV2, dispersionOffset)) * 4.0;
+			} else {
+				causticsLow = 1.0.xxx;
+			}
 
-			float3 caustics = lerp(causticsLow, causticsHigh, causticsFade);
+			const float3 caustics = lerp(causticsLow, causticsHigh, causticsFade);
 			return lerp(1.0.xxx, caustics, shoreFactorCaustics);
 		}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reworked the water caustics shader logic to make the computation flow clearer and more consistent.
  * The caustics calculation is now easier to follow while preserving the existing visual output and behavior of water rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->