### PR TITLE
fix(hdr): exclude menu blur from clean captures

### DIFF
--- a/features/HDR Display/Shaders/HDRDisplay/HDROutputCS.hlsl
+++ b/features/HDR Display/Shaders/HDRDisplay/HDROutputCS.hlsl
@@ -20,6 +20,7 @@ cbuffer PerFrame : register(b0)
 	float isSceneLinear : packoffset(c1.y);
 	float isMainOrLoadingMenu : packoffset(c1.z);
 	float fgTweenMenuMidAlphaBoost : packoffset(c1.w);  ///< TweenMenu: soften AA band when compositing here (UIBrightnessCS skips while paused)
+	float previewSDR : packoffset(c2.x);                ///< 1.0 = emit sRGB SDR (crop preview) instead of PQ HDR10
 }
 
 [numthreads(8, 8, 1)] void main(uint3 dispatchID : SV_DispatchThreadID) {
@@ -80,10 +81,15 @@ cbuffer PerFrame : register(b0)
 			compositedColorLinear = Color::GammaToLinearSafe(compositedColorGamma);
 		}
 
-		compositedColorLinear = Color::BT709ToBT2020(compositedColorLinear);
-		finalColor = Color::pq::Encode(max(0.0, compositedColorLinear), paperWhite);
+		if (previewSDR > 0.5) {
+			// Crop preview lives in the SDR menu buffer: emit sRGB instead of PQ.
+			finalColor = saturate(Color::LinearToSrgb(max(0.0, compositedColorLinear)));
+		} else {
+			compositedColorLinear = Color::BT709ToBT2020(compositedColorLinear);
+			finalColor = Color::pq::Encode(max(0.0, compositedColorLinear), paperWhite);
 
-		finalColor = saturate(finalColor);
+			finalColor = saturate(finalColor);
+		}
 	} else {
 		float3 sceneGamma = scene.rgb;
 

--- a/src/Features/HDRDisplay.cpp
+++ b/src/Features/HDRDisplay.cpp
@@ -1161,8 +1161,6 @@ void HDRDisplay::ApplyHDR()
 	state->BeginPerfEvent("HDR Processing");
 
 	{
-		auto dispatchCount = Util::GetScreenDispatchCount(false);
-
 		// When HDR is enabled, ISHDR wrote to hdrTexture (float16, values >1.0 preserved).
 		// When SDR, ISHDR wrote to kFRAMEBUFFER (UNORM, tonemapped 0-1).
 		auto& framebufferRT = renderer->GetRuntimeData().renderTargets[RE::RENDER_TARGETS::kFRAMEBUFFER];
@@ -1182,31 +1180,8 @@ void HDRDisplay::ApplyHDR()
 			uiSRV = uiTexture->srv.get();
 		}
 
-		ID3D11ShaderResourceView* views[2] = { sceneSRV, uiSRV };
-		context->CSSetShaderResources(0, ARRAYSIZE(views), views);
-
-		ID3D11UnorderedAccessView* uavs[1] = { outputTexture->uav.get() };
-		context->CSSetUnorderedAccessViews(0, ARRAYSIZE(uavs), uavs, nullptr);
-
-		ID3D11Buffer* cbs[1] = { hdrDataCB->CB() };
-
-		context->CSSetConstantBuffers(0, ARRAYSIZE(cbs), cbs);
-
-		auto computeShader = GetHDROutputCS();
-		if (!computeShader) {
+		if (!GetHDROutputCS()) {
 			// Fallback: HDR shader files not present - copy kFRAMEBUFFER directly to output
-			// Cleanup any bound resources
-			views[0] = nullptr;
-			views[1] = nullptr;
-			context->CSSetShaderResources(0, ARRAYSIZE(views), views);
-
-			uavs[0] = { nullptr };
-			context->CSSetUnorderedAccessViews(0, ARRAYSIZE(uavs), uavs, nullptr);
-
-			cbs[0] = { nullptr };
-			context->CSSetConstantBuffers(0, ARRAYSIZE(cbs), cbs);
-
-			// Copy kFRAMEBUFFER directly to destination (bypassing HDR processing)
 			if (upscaling.d3d12SwapChainActive) {
 				// SetUIBuffer keeps non-FG fallback UI in kFRAMEBUFFER; FG keeps using
 				// uiBufferWrapped for FidelityFX UI composition.
@@ -1225,22 +1200,7 @@ void HDRDisplay::ApplyHDR()
 			return;
 		}
 
-		context->CSSetShader(computeShader, nullptr, 0);
-		globals::profiler->BeginPass("HDRDisplay::HDROutput");
-		context->Dispatch(dispatchCount.x, dispatchCount.y, 1);
-		globals::profiler->EndPass();
-
-		views[0] = nullptr;
-		views[1] = nullptr;
-		context->CSSetShaderResources(0, ARRAYSIZE(views), views);
-
-		uavs[0] = { nullptr };
-		context->CSSetUnorderedAccessViews(0, ARRAYSIZE(uavs), uavs, nullptr);
-
-		cbs[0] = { nullptr };
-		context->CSSetConstantBuffers(0, ARRAYSIZE(cbs), cbs);
-
-		context->CSSetShader(nullptr, nullptr, 0);
+		DispatchHDROutput(sceneSRV, uiSRV, outputTexture->uav.get());
 	}
 
 	// Copy result to appropriate destination
@@ -1264,6 +1224,106 @@ void HDRDisplay::ApplyHDR()
 	}
 
 	state->EndPerfEvent();
+}
+
+void HDRDisplay::DispatchHDROutput(ID3D11ShaderResourceView* sceneSRV, ID3D11ShaderResourceView* uiSRV, ID3D11UnorderedAccessView* uav)
+{
+	auto context = globals::d3d::context;
+	auto computeShader = GetHDROutputCS();
+	if (!computeShader || !uav)
+		return;
+
+	ID3D11ShaderResourceView* views[2] = { sceneSRV, uiSRV };
+	context->CSSetShaderResources(0, ARRAYSIZE(views), views);
+
+	ID3D11UnorderedAccessView* uavs[1] = { uav };
+	context->CSSetUnorderedAccessViews(0, ARRAYSIZE(uavs), uavs, nullptr);
+
+	ID3D11Buffer* cbs[1] = { hdrDataCB->CB() };
+	context->CSSetConstantBuffers(0, ARRAYSIZE(cbs), cbs);
+
+	context->CSSetShader(computeShader, nullptr, 0);
+
+	auto dispatchCount = Util::GetScreenDispatchCount(false);
+	globals::profiler->BeginPass("HDRDisplay::HDROutput");
+	context->Dispatch(dispatchCount.x, dispatchCount.y, 1);
+	globals::profiler->EndPass();
+
+	views[0] = nullptr;
+	views[1] = nullptr;
+	context->CSSetShaderResources(0, ARRAYSIZE(views), views);
+
+	uavs[0] = nullptr;
+	context->CSSetUnorderedAccessViews(0, ARRAYSIZE(uavs), uavs, nullptr);
+
+	cbs[0] = nullptr;
+	context->CSSetConstantBuffers(0, ARRAYSIZE(cbs), cbs);
+
+	context->CSSetShader(nullptr, nullptr, 0);
+}
+
+void HDRDisplay::SnapshotCleanScene()
+{
+	if (!hdrTexture || !hdrTexture->resource)
+		return;
+
+	const D3D11_TEXTURE2D_DESC& sceneDesc = hdrTexture->desc;
+
+	// (Re)create on first use or when the scene texture changes.
+	if (cleanSceneCapture) {
+		const D3D11_TEXTURE2D_DESC& capDesc = cleanSceneCapture->desc;
+		if (capDesc.Width != sceneDesc.Width || capDesc.Height != sceneDesc.Height || capDesc.Format != sceneDesc.Format) {
+			cleanSceneCapture->srv = nullptr;
+			cleanSceneCapture->resource = nullptr;
+			delete cleanSceneCapture;
+			cleanSceneCapture = nullptr;
+		}
+	}
+
+	if (!cleanSceneCapture) {
+		D3D11_TEXTURE2D_DESC capDesc = sceneDesc;
+		capDesc.MipLevels = 1;
+		capDesc.ArraySize = 1;
+		capDesc.SampleDesc.Count = 1;
+		capDesc.SampleDesc.Quality = 0;
+		capDesc.Usage = D3D11_USAGE_DEFAULT;
+		capDesc.BindFlags = D3D11_BIND_SHADER_RESOURCE;
+		capDesc.CPUAccessFlags = 0;
+		capDesc.MiscFlags = 0;
+
+		cleanSceneCapture = new Texture2D(capDesc, "HDR::CleanSceneCapture");
+
+		D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc{};
+		srvDesc.Format = capDesc.Format;
+		srvDesc.ViewDimension = D3D11_SRV_DIMENSION_TEXTURE2D;
+		srvDesc.Texture2D.MipLevels = 1;
+		cleanSceneCapture->CreateSRV(srvDesc);
+	}
+
+	globals::d3d::context->CopyResource(cleanSceneCapture->resource.get(), hdrTexture->resource.get());
+}
+
+ID3D11Texture2D* HDRDisplay::ComposeCleanCapture(ID3D11ShaderResourceView* sceneSRV, bool sdrPreview)
+{
+	std::lock_guard<std::mutex> lock(settingsMutex);
+
+	if (!settings.enableHDR || !sceneSRV || !hdrDataCB || !outputTexture || !outputTexture->uav || !outputTexture->resource)
+		return nullptr;
+
+	if (!GetHDROutputCS())
+		return nullptr;
+
+	// Null UI SRV (t1 samples as 0) leaves the scene alone: no UI, menu, or blur.
+	HDRDataCB data = BuildHDRData();
+	data.previewSDR = sdrPreview ? 1.f : 0.f;
+	hdrDataCB->Update(data);
+
+	DispatchHDROutput(sceneSRV, nullptr, outputTexture->uav.get());
+
+	// Restore the canonical CB for the display composite this frame.
+	UpdateHDRData();
+
+	return outputTexture->resource.get();
 }
 
 void HDRDisplay::DestroyResources()
@@ -1292,6 +1352,13 @@ void HDRDisplay::DestroyResources()
 		uiTexture->resource = nullptr;
 		delete uiTexture;
 		uiTexture = nullptr;
+	}
+
+	if (cleanSceneCapture) {
+		cleanSceneCapture->srv = nullptr;
+		cleanSceneCapture->resource = nullptr;
+		delete cleanSceneCapture;
+		cleanSceneCapture = nullptr;
 	}
 
 	if (hdrDataCB) {
@@ -1543,11 +1610,8 @@ float4 HDRDisplay::GetSharedDataHDR() const
 	};
 }
 
-void HDRDisplay::UpdateHDRData() const
+HDRDisplay::HDRDataCB HDRDisplay::BuildHDRData() const
 {
-	if (!hdrDataCB)
-		return;
-
 	bool isMainOrLoadingMenu = globals::state->isMainMenuOpen || globals::state->isLoadingMenuOpen;
 	auto* ui = globals::game::ui;
 	bool skipUIComposite = IsFGCompositingThisFrame();
@@ -1559,7 +1623,7 @@ void HDRDisplay::UpdateHDRData() const
 	// Use user-specified peak brightness for highlights compression
 	float effectivePeakNits = static_cast<float>(settings.hdrPeakNits);
 
-	HDRDataCB data;
+	HDRDataCB data{};
 	data.enableHDR = settings.enableHDR ? 1.f : 0.f;
 	data.paperWhite = static_cast<float>(settings.hdrPaperWhite);
 	data.peakNits = effectivePeakNits;
@@ -1569,7 +1633,16 @@ void HDRDisplay::UpdateHDRData() const
 	data.pad0 = isMainOrLoadingMenu ? 1.f : 0.f;
 	// TweenMenu = pause UI. ScaleUIBrightnessForFG skips while GameIsPaused(), so HDROutputCS applies the same mid-alpha boost when compositing gamma UI.
 	data.fgTweenMenuMidAlphaBoost = (ui && ui->IsMenuOpen(RE::TweenMenu::MENU_NAME)) ? 1.f : 0.f;
-	hdrDataCB->Update(data);
+	data.previewSDR = 0.f;
+	return data;
+}
+
+void HDRDisplay::UpdateHDRData() const
+{
+	if (!hdrDataCB)
+		return;
+
+	hdrDataCB->Update(BuildHDRData());
 }
 
 void HDRDisplay::UpdateSwapChainColorSpace() const

--- a/src/Features/HDRDisplay.cpp
+++ b/src/Features/HDRDisplay.cpp
@@ -1301,6 +1301,12 @@ void HDRDisplay::SnapshotCleanScene()
 	}
 
 	globals::d3d::context->CopyResource(cleanSceneCapture->resource.get(), hdrTexture->resource.get());
+	cleanSceneCaptureFrame = globals::state->frameCount;
+}
+
+bool HDRDisplay::IsCleanSceneCaptureFresh() const
+{
+	return cleanSceneCapture && cleanSceneCapture->srv && cleanSceneCaptureFrame == globals::state->frameCount;
 }
 
 ID3D11Texture2D* HDRDisplay::ComposeCleanCapture(ID3D11ShaderResourceView* sceneSRV, bool sdrPreview)
@@ -1359,6 +1365,7 @@ void HDRDisplay::DestroyResources()
 		cleanSceneCapture->resource = nullptr;
 		delete cleanSceneCapture;
 		cleanSceneCapture = nullptr;
+		cleanSceneCaptureFrame = UINT32_MAX;
 	}
 
 	if (hdrDataCB) {

--- a/src/Features/HDRDisplay.h
+++ b/src/Features/HDRDisplay.h
@@ -97,9 +97,7 @@ public:
 	// True when the snapshot was refreshed this frame; stale means hdrTexture wasn't blurred.
 	bool IsCleanSceneCaptureFresh() const;
 
-	// HDR output transform on a clean scene with no UI buffer, into outputTexture
-	// (no vanilla UI, ImGui menu, or blur). sdrPreview emits sRGB for the crop
-	// preview; otherwise HDR10 PQ for screenshots. Null if HDR output unavailable.
+	// HDR output transform on a clean scene with no UI buffer, into outputTexture.
 	ID3D11Texture2D* ComposeCleanCapture(ID3D11ShaderResourceView* sceneSRV, bool sdrPreview);
 
 	ID3D11BlendState* GetPatchedAlphaBlendState(ID3D11BlendState* original);

--- a/src/Features/HDRDisplay.h
+++ b/src/Features/HDRDisplay.h
@@ -94,6 +94,9 @@ public:
 	// Snapshot hdrTexture before the menu blur dirties it in place.
 	void SnapshotCleanScene();
 
+	// True when the snapshot was refreshed this frame; stale means hdrTexture wasn't blurred.
+	bool IsCleanSceneCaptureFresh() const;
+
 	// HDR output transform on a clean scene with no UI buffer, into outputTexture
 	// (no vanilla UI, ImGui menu, or blur). sdrPreview emits sRGB for the crop
 	// preview; otherwise HDR10 PQ for screenshots. Null if HDR output unavailable.
@@ -143,6 +146,7 @@ public:
 	Texture2D* outputTexture = nullptr;
 	Texture2D* uiTexture = nullptr;          // Separate UI render target for proper compositing
 	Texture2D* cleanSceneCapture = nullptr;  // Pre-blur copy of hdrTexture for clean captures
+	uint cleanSceneCaptureFrame = UINT32_MAX;  // frameCount when cleanSceneCapture was last refreshed
 
 	ID3D11ComputeShader* hdrOutputCS = nullptr;
 	ID3D11ComputeShader* GetHDROutputCS();

--- a/src/Features/HDRDisplay.h
+++ b/src/Features/HDRDisplay.h
@@ -91,6 +91,14 @@ public:
 
 	void ApplyHDR();
 
+	// Snapshot hdrTexture before the menu blur dirties it in place.
+	void SnapshotCleanScene();
+
+	// HDR output transform on a clean scene with no UI buffer, into outputTexture
+	// (no vanilla UI, ImGui menu, or blur). sdrPreview emits sRGB for the crop
+	// preview; otherwise HDR10 PQ for screenshots. Null if HDR output unavailable.
+	ID3D11Texture2D* ComposeCleanCapture(ID3D11ShaderResourceView* sceneSRV, bool sdrPreview);
+
 	ID3D11BlendState* GetPatchedAlphaBlendState(ID3D11BlendState* original);
 
 	// Swap-chain Present hook (installed from Hooks::InitD3D).
@@ -118,15 +126,23 @@ public:
 		float isSceneLinear;             ///< 1.0 = Linear Lighting active, scene already linear
 		float pad0;                      ///< 1.0 = main menu/loading screen active
 		float fgTweenMenuMidAlphaBoost;  ///< 1.0 = TweenMenu (pause) open — FG UIBrightnessCS mid-alpha boost only
+		float previewSDR;                ///< 1.0 = emit sRGB SDR (crop preview) instead of PQ HDR10
+		float pad1;
+		float pad2;
+		float pad3;
 	};
 
 	static_assert((sizeof(HDRDataCB) % 16) == 0, "CB size not padded correctly");
+
+	// HDR data CB contents from current settings/game state (previewSDR=0).
+	HDRDataCB BuildHDRData() const;
 
 	ConstantBuffer* hdrDataCB = nullptr;
 
 	Texture2D* hdrTexture = nullptr;
 	Texture2D* outputTexture = nullptr;
-	Texture2D* uiTexture = nullptr;  // Separate UI render target for proper compositing
+	Texture2D* uiTexture = nullptr;          // Separate UI render target for proper compositing
+	Texture2D* cleanSceneCapture = nullptr;  // Pre-blur copy of hdrTexture for clean captures
 
 	ID3D11ComputeShader* hdrOutputCS = nullptr;
 	ID3D11ComputeShader* GetHDROutputCS();
@@ -192,6 +208,9 @@ private:
 	};
 
 	D3D12UIBufferMode GetD3D12UIBufferMode();
+
+	// Bind scene (t0), UI (t1, may be null), UAV (u0), CB (b0); dispatch the output CS; unbind.
+	void DispatchHDROutput(ID3D11ShaderResourceView* sceneSRV, ID3D11ShaderResourceView* uiSRV, ID3D11UnorderedAccessView* uav);
 
 	// True when FFX frame generation is actively compositing UI this frame.
 	bool IsFGCompositingThisFrame() const;

--- a/src/Features/ScreenshotFeature.cpp
+++ b/src/Features/ScreenshotFeature.cpp
@@ -366,9 +366,11 @@ namespace
 			// with no UI buffer so the capture/preview drops both the menu and its blur.
 			auto& hdr = globals::features::hdrDisplay;
 			if (Menu::GetSingleton()->IsEnabled && hdr.outputTexture && hdr.outputTexture->srv) {
+				// Capture uses the snapshot only when fresh; otherwise hdrTexture is
+				// unblurred. Preview always reads live hdrTexture.
 				ID3D11ShaderResourceView* sceneSRV =
-					forCapture ? (hdr.cleanSceneCapture ? hdr.cleanSceneCapture->srv.get() : nullptr) :
-								 (hdr.hdrTexture ? hdr.hdrTexture->srv.get() : nullptr);
+					(forCapture && hdr.IsCleanSceneCaptureFresh()) ? hdr.cleanSceneCapture->srv.get() :
+																	 (hdr.hdrTexture ? hdr.hdrTexture->srv.get() : nullptr);
 				if (sceneSRV) {
 					if (ID3D11Texture2D* clean = hdr.ComposeCleanCapture(sceneSRV, /*sdrPreview=*/!forCapture)) {
 						src.texture = clean;

--- a/src/Features/ScreenshotFeature.cpp
+++ b/src/Features/ScreenshotFeature.cpp
@@ -362,12 +362,9 @@ namespace
 
 
 		if (IsFlatHdrScreenshotCapture()) {
-			// CS menu open blurs the HDR scene in place; recompose from the clean scene
-			// with no UI buffer so the capture/preview drops both the menu and its blur.
+			// Recompose from the clean scene with no UI buffer.
 			auto& hdr = globals::features::hdrDisplay;
 			if (Menu::GetSingleton()->IsEnabled && hdr.outputTexture && hdr.outputTexture->srv) {
-				// Capture uses the snapshot only when fresh; otherwise hdrTexture is
-				// unblurred. Preview always reads live hdrTexture.
 				ID3D11ShaderResourceView* sceneSRV =
 					(forCapture && hdr.IsCleanSceneCaptureFresh()) ? hdr.cleanSceneCapture->srv.get() :
 																	 (hdr.hdrTexture ? hdr.hdrTexture->srv.get() : nullptr);
@@ -407,12 +404,7 @@ namespace
 		       combo[0].GetKey() == VK_SNAPSHOT;
 	}
 
-	// Blend state around the preview's ImGui::Image draw. Two regression risks:
-	//   1. BlendEnable must stay FALSE - the source carries non-1 alpha where
-	//      Skyrim composited UI plates; SRC_ALPHA blend leaks the host window bg.
-	//   2. SDR path writes RGB only, leaving the plate's pre-cleared alpha=1.
-	// HDR writes alpha too: the preview is opaque (alpha=1) so the menu blur can't
-	// bleed through it when ApplyHDR composites the UI buffer over the blurred scene.
+	// Forces BlendEnable=FALSE and opaque alpha for the preview Image draw.
 	// Paired with ImDrawCallback_ResetRenderState queued by Subrect::DrawEditor.
 	void OpaquePreviewBlendCallback(const ImDrawList*, const ImDrawCmd*)
 	{

--- a/src/Features/ScreenshotFeature.cpp
+++ b/src/Features/ScreenshotFeature.cpp
@@ -348,9 +348,11 @@ namespace
 	}
 
 	// Picks the capture source:
-	//   HDR enabled     -> swap-chain back buffer after ApplyHDR (PQ HDR10 / PQ float).
-	//   otherwise       -> kFRAMEBUFFER (tonemapped UNORM).
-	CaptureSource SelectCaptureSource(winrt::com_ptr<ID3D11Texture2D>& holder)
+	//   HDR + CS menu open -> clean HDR composite (no UI, no menu blur).
+	//   HDR enabled        -> swap-chain back buffer after ApplyHDR (PQ HDR10 / PQ float).
+	//   otherwise          -> kFRAMEBUFFER (tonemapped UNORM).
+	// forCapture: post-blur screenshot uses the snapshot; pre-blur preview uses hdrTexture.
+	CaptureSource SelectCaptureSource(winrt::com_ptr<ID3D11Texture2D>& holder, bool forCapture)
 	{
 		CaptureSource src;
 		auto* renderer = globals::game::renderer;
@@ -360,6 +362,24 @@ namespace
 
 
 		if (IsFlatHdrScreenshotCapture()) {
+			// CS menu open blurs the HDR scene in place; recompose from the clean scene
+			// with no UI buffer so the capture/preview drops both the menu and its blur.
+			auto& hdr = globals::features::hdrDisplay;
+			if (Menu::GetSingleton()->IsEnabled && hdr.outputTexture && hdr.outputTexture->srv) {
+				ID3D11ShaderResourceView* sceneSRV =
+					forCapture ? (hdr.cleanSceneCapture ? hdr.cleanSceneCapture->srv.get() : nullptr) :
+								 (hdr.hdrTexture ? hdr.hdrTexture->srv.get() : nullptr);
+				if (sceneSRV) {
+					if (ID3D11Texture2D* clean = hdr.ComposeCleanCapture(sceneSRV, /*sdrPreview=*/!forCapture)) {
+						src.texture = clean;
+						src.srv = hdr.outputTexture->srv.get();
+						src.needsPreviewCache = false;
+						src.description = "HDR clean composite (no UI, no menu blur)";
+						return src;
+					}
+				}
+			}
+
 			src.texture = ResolveDisplayedBackBuffer(holder);
 			src.needsPreviewCache = true;
 			src.description = "Swap chain back buffer (HDR display composite)";
@@ -385,30 +405,32 @@ namespace
 		       combo[0].GetKey() == VK_SNAPSHOT;
 	}
 
-	// Blend state used around the preview's ImGui::Image draw. Two regression
-	// risks if this is changed:
-	//   1. BlendEnable must stay FALSE - the source texture carries non-1 alpha
-	//      where Skyrim composited UI plates; default SRC_ALPHA blend lets the
-	//      host window background show through (visible on the desktop mirror).
-	//   2. WriteMask must exclude alpha (RGB only) to avoid compositing
-	//      artifacts. RGB-only writes leave the plate's pre-cleared alpha=1
-	//      in place.
-	// Paired with ImDrawCallback_ResetRenderState queued by Subrect::DrawEditor
-	// immediately after the image draw.
+	// Blend state around the preview's ImGui::Image draw. Two regression risks:
+	//   1. BlendEnable must stay FALSE - the source carries non-1 alpha where
+	//      Skyrim composited UI plates; SRC_ALPHA blend leaks the host window bg.
+	//   2. SDR path writes RGB only, leaving the plate's pre-cleared alpha=1.
+	// HDR writes alpha too: the preview is opaque (alpha=1) so the menu blur can't
+	// bleed through it when ApplyHDR composites the UI buffer over the blurred scene.
+	// Paired with ImDrawCallback_ResetRenderState queued by Subrect::DrawEditor.
 	void OpaquePreviewBlendCallback(const ImDrawList*, const ImDrawCmd*)
 	{
-		static winrt::com_ptr<ID3D11BlendState> opaqueBlend;
-		if (!opaqueBlend) {
+		const bool writeAlpha = IsFlatHdrScreenshotCapture() && Menu::GetSingleton()->IsEnabled;
+
+		static winrt::com_ptr<ID3D11BlendState> rgbBlend;
+		static winrt::com_ptr<ID3D11BlendState> rgbaBlend;
+		auto& blend = writeAlpha ? rgbaBlend : rgbBlend;
+		if (!blend) {
 			D3D11_BLEND_DESC desc{};
 			desc.RenderTarget[0].BlendEnable = FALSE;
 			desc.RenderTarget[0].RenderTargetWriteMask =
 				D3D11_COLOR_WRITE_ENABLE_RED |
 				D3D11_COLOR_WRITE_ENABLE_GREEN |
-				D3D11_COLOR_WRITE_ENABLE_BLUE;
-			globals::d3d::device->CreateBlendState(&desc, opaqueBlend.put());
+				D3D11_COLOR_WRITE_ENABLE_BLUE |
+				(writeAlpha ? D3D11_COLOR_WRITE_ENABLE_ALPHA : 0);
+			globals::d3d::device->CreateBlendState(&desc, blend.put());
 		}
-		if (opaqueBlend) {
-			globals::d3d::context->OMSetBlendState(opaqueBlend.get(), nullptr, 0xFFFFFFFF);
+		if (blend) {
+			globals::d3d::context->OMSetBlendState(blend.get(), nullptr, 0xFFFFFFFF);
 		}
 	}
 
@@ -683,7 +705,7 @@ void ScreenshotFeature::DrawSettings()
 
 	// Preview reflects what Capture() would save.
 	winrt::com_ptr<ID3D11Texture2D> previewTextureKeepAlive;
-	const auto src = SelectCaptureSource(previewTextureKeepAlive);
+	const auto src = SelectCaptureSource(previewTextureKeepAlive, /*forCapture=*/false);
 
 	ID3D11ShaderResourceView* previewView = src.srv;
 	if (src.texture && (src.needsPreviewCache || !previewView)) {
@@ -863,7 +885,7 @@ void ScreenshotFeature::Capture()
 		return;
 
 	winrt::com_ptr<ID3D11Texture2D> sourceTextureKeepAlive;
-	const auto src = SelectCaptureSource(sourceTextureKeepAlive);
+	const auto src = SelectCaptureSource(sourceTextureKeepAlive, /*forCapture=*/true);
 	logger::debug("Capturing from {}", src.description);
 
 	if (!src.texture) {

--- a/src/Menu/BackgroundBlur.cpp
+++ b/src/Menu/BackgroundBlur.cpp
@@ -654,6 +654,11 @@ namespace BackgroundBlur
 			CreateBlurTextures(texDesc.Width, texDesc.Height, texDesc.Format);
 		}
 
+		// Snapshot the clean scene before the in-place HDR blur, for clean captures.
+		if (hdrActive) {
+			hdr->SnapshotCleanScene();
+		}
+
 		// CS editor mode: single fullscreen blur pass (better perf than per-window)
 		if (csEditorActive) {
 			ImVec2 screenMin = { 0, 0 };


### PR DESCRIPTION
When HDR is enabled, the menu's background blur is rendered in place
into the HDR scene texture, so it leaked into screenshots and the crop
preview even though the menu itself was excluded.

Snapshot the pristine scene before the in-place blur and recompose
captures from it with no UI buffer, so screenshots and the preview drop
both the menu and its blur. Make the preview region opaque in HDR so the
live blur can't bleed through it via ApplyHDR's UI compositing, and emit
sRGB (not PQ) for the preview so the thumbnail displays correctly in the
SDR menu. Extract a shared DispatchHDROutput helper from ApplyHDR.

Closes: #2447 and #2445

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SDR preview mode for HDR output, allowing an sRGB crop-preview of HDR frames.
  * Clean HDR scene capture for screenshots that omits UI and menu blur.

* **Refactor**
  * Centralized HDR output dispatch and simplified HDR data handling.
  * Improved capture vs. preview selection and preview blending to preserve correct HDR/SDR and alpha behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->