### PR TITLE
fix(skysync): base shadow fade advance on game-time delta

### DIFF
--- a/src/Features/SkySync.cpp
+++ b/src/Features/SkySync.cpp
@@ -224,6 +224,7 @@ void SkySync::Update(const RE::Sky* sky)
 			SetSkyRotation(sky, cell);
 		if (cell && prevCell && (cell->IsInteriorCell() != prevCell->IsInteriorCell() || cell->GetRuntimeData().worldSpace != prevCell->GetRuntimeData().worldSpace))
 			shadowFader.Reset();
+			lastGameHour = -1.0f;
 	}
 
 	// Exterior worldspaces always run; interior cells require the sunlight-shadows flag.

--- a/src/Features/SkySync.cpp
+++ b/src/Features/SkySync.cpp
@@ -265,7 +265,21 @@ void SkySync::Update(const RE::Sky* sky)
 	ProcessMoon(sky, Caster::Masser, directions, intensities);
 	ProcessMoon(sky, Caster::Secunda, directions, intensities);
 
-	shadowFader.Update(sky, directions, intensities, settings.ShadowTransitionDuration);
+	// Advance the shadow fade by elapsed game time so the transition stays smooth during
+	// normal play but snaps when time jumps (scrubbing, waiting, fast travel).
+	const float gameHour = sky->currentGameHour;
+	float fadeAdvance = settings.ShadowTransitionDuration;  // first frame: snap
+	if (lastGameHour >= 0.0f) {
+		float hourDelta = gameHour - lastGameHour;
+		if (hourDelta > 12.0f)
+			hourDelta -= 24.0f;
+		else if (hourDelta < -12.0f)
+			hourDelta += 24.0f;
+		fadeAdvance = std::abs(hourDelta) * SecondsPerGameHour;
+	}
+	lastGameHour = gameHour;
+
+	shadowFader.Update(sky, directions, intensities, settings.ShadowTransitionDuration, fadeAdvance);
 }
 void SkySync::SetSunAngle()
 {
@@ -415,7 +429,7 @@ void SkySync::ShadowFader::Reset()
 	transitioning = false;
 }
 
-void SkySync::ShadowFader::Update(const RE::Sky* sky, RE::NiPoint3 dirs[], float intensities[], float fadeDuration)
+void SkySync::ShadowFader::Update(const RE::Sky* sky, RE::NiPoint3 dirs[], float intensities[], float fadeDuration, float fadeAdvance)
 {
 	auto isValidDir = [](const RE::NiPoint3& d) { return d.x != 0.0f || d.y != 0.0f || d.z != 0.0f; };
 
@@ -467,10 +481,7 @@ void SkySync::ShadowFader::Update(const RE::Sky* sky, RE::NiPoint3 dirs[], float
 		return;
 	}
 
-	float timeScale = 20.0f;
-	if (const auto calendar = globals::game::calendar)
-		timeScale = calendar->GetTimescale();
-	fadeTimer = std::min(fadeTimer + *globals::game::deltaTime * 20.0f / timeScale, fadeDuration);
+	fadeTimer = std::min(fadeTimer + fadeAdvance, fadeDuration);
 	const float t = fadeDuration > 0.0f ? fadeTimer / fadeDuration : 1.0f;
 
 	RE::NiPoint3 targetDir = dirs[static_cast<int>(target)];

--- a/src/Features/SkySync.h
+++ b/src/Features/SkySync.h
@@ -106,7 +106,7 @@ private:
 		float fadeTimer = 0.0f;
 		bool transitioning = false;
 
-		void Update(const RE::Sky* sky, RE::NiPoint3 dirs[], float intensities[], float fadeDuration);
+		void Update(const RE::Sky* sky, RE::NiPoint3 dirs[], float intensities[], float fadeDuration, float fadeAdvance);
 		static void SetLighting(const RE::Sky* sky, RE::NiPoint3 dir);
 		static void ClampDirection(RE::NiPoint3& dir);
 		void Reset();
@@ -117,6 +117,7 @@ private:
 	static constexpr float SouthernSunAngle = 90.0f - 35.0f;
 	static constexpr float NorthernSunAngle = 90.0f + 35.0f;
 	static constexpr float VanillaSunAngle = 90.0f + 5.0f;
+	static constexpr float SecondsPerGameHour = 3600.0f;
 
 	inline static RE::NiPoint3* gSunPosition = nullptr;
 
@@ -124,6 +125,7 @@ private:
 	RE::TESObjectCELL* currentCell = nullptr;
 	float sunAngle = 90.0f;
 	float currentSkyRotation = D3D11_FLOAT32_MAX;
+	float lastGameHour = -1.0f;
 
 	float4 colors[3] = {};
 	float currentDim = 1.0f;


### PR DESCRIPTION
## Summary

- `ShadowFader::Update` previously advanced `fadeTimer` using `deltaTime * 20 / timescale`, 
  which normalized out timescale and made the duration effectively measured in real seconds. 
  At the default timescale of 20 a value of 100 took ~100 real seconds.
- The tooltip already documented the intended behavior: "in game-time units, 
  100 = ~5 seconds at timescale 20" but the old math didn't match that claim.
- This change computes `fadeAdvance` from the per-frame game-hour delta (`|ΔgameHour| * 3600`) before calling `Update`, 
  so `fadeDuration` is now genuinely measured in game-seconds. 
  At timescale 20, 100 game-seconds = ~5 real seconds, matching the tooltip exactly.
- As a side effect, transitions now snap automatically on time jumps (fast travel, wait menu, cell load), 
  because a large game-hour delta produces a `fadeAdvance` that exceeds `fadeDuration` in one step.
  The `±12h` wrap keeps normal midnight rollovers smooth.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Shadow fade transitions now advance based on in-game time progression, handling day-boundary wrapping and cell changes to keep visuals consistent.
  * First-frame after reset now snaps to the configured transition duration to avoid jarring fades.
  * Transition timing no longer depends on real-world frame delta, improving stability during time jumps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->