### PR TITLE
fix(skysync): hide VL when no moon present

### DIFF
--- a/src/Features/SkySync.cpp
+++ b/src/Features/SkySync.cpp
@@ -419,6 +419,14 @@ void SkySync::ShadowFader::Update(const RE::Sky* sky, RE::NiPoint3 dirs[], float
 {
 	auto isValidDir = [](const RE::NiPoint3& d) { return d.x != 0.0f || d.y != 0.0f || d.z != 0.0f; };
 
+	bool* const vlEnabled = globals::game::bEnableVolumetricLighting;
+	static bool vlSuppressed = false;
+	static bool vlSavedEnabled = true;
+	if (vlSuppressed && vlEnabled) {
+		*vlEnabled = vlSavedEnabled;
+		vlSuppressed = false;
+	}
+
 	Caster best;
 
 	if (globals::features::skySync.currentDim <= 0.0f) {
@@ -429,6 +437,11 @@ void SkySync::ShadowFader::Update(const RE::Sky* sky, RE::NiPoint3 dirs[], float
 			// No valid night caster — default to directly above (shadows point down)
 			currentDir = { 0.0f, 0.0f, 1.0f };
 			SetLighting(sky, currentDir);
+			if (vlEnabled && !vlSuppressed) {
+				vlSavedEnabled = *vlEnabled;
+				*vlEnabled = false;
+				vlSuppressed = true;
+			}
 			return;
 		}
 

--- a/src/Features/SkySync.cpp
+++ b/src/Features/SkySync.cpp
@@ -422,10 +422,6 @@ void SkySync::ShadowFader::Update(const RE::Sky* sky, RE::NiPoint3 dirs[], float
 	bool* const vlEnabled = globals::game::bEnableVolumetricLighting;
 	static bool vlSuppressed = false;
 	static bool vlSavedEnabled = true;
-	if (vlSuppressed && vlEnabled) {
-		*vlEnabled = vlSavedEnabled;
-		vlSuppressed = false;
-	}
 
 	Caster best;
 
@@ -453,6 +449,11 @@ void SkySync::ShadowFader::Update(const RE::Sky* sky, RE::NiPoint3 dirs[], float
 			best = Caster::Secunda;
 	} else {
 		best = Caster::Sun;
+	}
+
+	if (vlSuppressed && vlEnabled) {
+		*vlEnabled = vlSavedEnabled;
+		vlSuppressed = false;
 	}
 
 	// If best source changed, begin a new transition

--- a/src/Features/VolumetricLighting.cpp
+++ b/src/Features/VolumetricLighting.cpp
@@ -154,7 +154,6 @@ void VolumetricLighting::DataLoaded()
 
 void VolumetricLighting::PostPostLoad()
 {
-	bEnableVolumetricLighting = reinterpret_cast<bool*>(REL::RelocationID(527940, 414913).address());
 	gVolumetricLightingSizeLow = reinterpret_cast<TextureSize*>(REL::RelocationID(527970, 414916).address());
 	gVolumetricLightingSizeMedium = reinterpret_cast<TextureSize*>(REL::RelocationID(527973, 414919).address());
 	gVolumetricLightingSizeHigh = reinterpret_cast<TextureSize*>(REL::RelocationID(527976, 414922).address());
@@ -204,11 +203,11 @@ void VolumetricLighting::EarlyPrepass()
 void VolumetricLighting::SetupVL()
 {
 	if (inInterior) {
-		*bEnableVolumetricLighting = settings.InteriorEnabled && inInteriorWithSun;
+		*globals::game::bEnableVolumetricLighting = settings.InteriorEnabled && inInteriorWithSun;
 		*gVolumetricLightingSizeHigh = static_cast<Quality>(settings.InteriorQuality) == Quality::Custom ? settings.InteriorCustomSize : defaultSizeHigh;
 		SetVLQuality(GetVLDescriptor(), settings.InteriorQuality);
 	} else {
-		*bEnableVolumetricLighting = settings.ExteriorEnabled;
+		*globals::game::bEnableVolumetricLighting = settings.ExteriorEnabled;
 		*gVolumetricLightingSizeHigh = static_cast<Quality>(settings.ExteriorQuality) == Quality::Custom ? settings.ExteriorCustomSize : defaultSizeHigh;
 		SetVLQuality(GetVLDescriptor(), settings.ExteriorQuality);
 	}

--- a/src/Features/VolumetricLighting.h
+++ b/src/Features/VolumetricLighting.h
@@ -83,7 +83,6 @@ private:
 	TextureSize interiorSizeInUnits;
 	TextureSize defaultSizeHigh;
 
-	bool* bEnableVolumetricLighting = nullptr;
 	TextureSize* gVolumetricLightingSizeHigh = nullptr;
 	TextureSize* gVolumetricLightingSizeMedium = nullptr;
 	TextureSize* gVolumetricLightingSizeLow = nullptr;

--- a/src/Globals.cpp
+++ b/src/Globals.cpp
@@ -115,6 +115,7 @@ namespace globals
 		RE::UI* ui = nullptr;
 		RE::Calendar* calendar = nullptr;
 		RE::ImageSpaceManager* imageSpaceManager = nullptr;
+		bool* bEnableVolumetricLighting = nullptr;
 		std::atomic<bool> quitGame{ false };
 
 		RE::BSGraphics::PixelShader** currentPixelShader = nullptr;
@@ -219,6 +220,7 @@ namespace globals
 		sky = RE::Sky::GetSingleton();
 		utilityShader = RE::BSUtilityShader::GetSingleton();
 		imageSpaceManager = RE::ImageSpaceManager::GetSingleton();
+		bEnableVolumetricLighting = reinterpret_cast<bool*>(REL::RelocationID(527940, 414913).address());
 
 		bEnableLandFade = iniSettingCollection->GetSetting("bEnableLandFade:Display");
 

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -160,6 +160,7 @@ namespace globals
 		extern RE::UI* ui;
 		extern RE::Calendar* calendar;
 		extern RE::ImageSpaceManager* imageSpaceManager;
+		extern bool* bEnableVolumetricLighting;
 		extern std::atomic<bool> quitGame;
 
 		extern RE::BSGraphics::PixelShader** currentPixelShader;


### PR DESCRIPTION
hides the VL when there is no moon present and the lighting direction is set to straight up.
prevents silliness like in the image.
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/c0da99e9-529b-446d-973f-44a95185d6e5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents visual artifacts at night by temporarily suppressing volumetric lighting when a valid night shadow direction cannot be determined, then restoring previous lighting state.

* **Refactor**
  * Centralized volumetric lighting control for more consistent enable/disable behavior and cleaner internal handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->