### PR TITLE
fix(wetness): clamp GetRainIntensity to [0, 1]

### DIFF
--- a/src/Features/WetnessEffects.cpp
+++ b/src/Features/WetnessEffects.cpp
@@ -738,7 +738,7 @@ float WetnessEffects::GetRainIntensity(RE::NiPointer<RE::BSGeometry> precipObjec
 	auto maxDensity = weather->precipitationData->GetSettingValue(RE::BGSShaderParticleGeometryData::DataID::kParticleDensity).f;  // Use weather particle density as authoritative source for rain intensity
 	// This provides consistent intensity scaling based on weather type (1-3 scale)
 	// Note: rain->density equals maxDensity when fully active
-	return (maxDensity > 0.0f) ? (maxDensity / MAX_RAIN_PARTICLE_DENSITY) : 0.0f;
+	return (maxDensity > 0.0f) ? std::min(1.0f, maxDensity / MAX_RAIN_PARTICLE_DENSITY) : 0.0f;
 }
 
 WetnessEffects::WeatherWetnessResult WetnessEffects::CalculateWeatherWetness(RE::TESWeather* weather, float weatherPct, bool isCurrentWeather) const


### PR DESCRIPTION
## Summary

- `GetRainIntensity` divides the weather record's particle density by `MAX_RAIN_PARTICLE_DENSITY` (3.0f) to produce a [0, 1] rain intensity, but no upper-bound clamp existed
- A collaborator confirmed vanilla weather records with particle density 90 exist, causing `GetRainIntensity` to return 30.0 instead of 1.0
- This flows into `data.Raining`, and `data.settings.RaindropChance *= data.Raining * data.Raining` then applies a 900x multiplier to raindrop chance -- any downstream consumer expecting a [0, 1] value is equally broken
- Fix: wrap the return value with `std::min(1.0f, ...)` so extreme-density weather records saturate at 1.0; normal density 1-3 records are unaffected

## Why this matters

Fixes #2137 -- users with weather mods (or vanilla weathers) that set particle density above 3 get severely amplified wetness effects including raindrop chance multiplied by up to 900x.

`std::min` is already used at lines 903-904 of the same file for identical clamping on wetness values; this change applies the same pattern to the intensity source.

Fixes #2137


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rain intensity calculation to properly cap at maximum level, preventing excessive values in certain weather conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->