### PR TITLE
feat(stages): add alpha/beta pre-release markers to features

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -334,6 +334,41 @@ Modular ImGui-based configuration interface with specialized renderers for diffe
 
 Feature versions are automatically extracted from `.ini` files and compiled into `FeatureVersions.h` at build time for backward compatibility checking.
 
+### Release Stages (Alpha / Beta)
+
+Features can declare a release-maturity stage in their `.ini` `[Info]` section. This drives the default-enabled state, a UI marker, and the version-audit policy.
+
+**Declaring a stage** (in `features/<Feature>/Shaders/Features/<Feature>.ini`):
+
+```ini
+[Info]
+Version = 0-2-0
+Beta = True
+```
+
+-   Flags: `Alpha` or `Beta`. Truthy values are `true`, `1`, `yes`, `on` (case-insensitive). Absent or non-truthy means full **Release**.
+-   `Alpha` takes precedence over `Beta` when both are set.
+-   The flag line must start the line (after optional whitespace). The CMake parser in `CMakeLists.txt` and the Python parser in `tools/feature_version_audit.py` are both line-anchored; **keep these two regexes in sync** so build-time classification and audit enforcement agree.
+
+**Build-time baking**: `CMakeLists.txt` collects flagged features into `FEATURE_ALPHA_NAMES` / `FEATURE_BETA_NAMES` in the generated `FeatureVersions.h` (same mechanism as `FEATURE_CORE_NAMES`).
+
+**Runtime API** (`src/Feature.h`):
+
+-   `Feature::GetReleaseStage()` returns `ReleaseStage::{Release, Beta, Alpha}` by looking the short name up in the baked sets. Resolve it once and pass it around; it is not cached.
+-   `IsAlpha()` / `IsBeta()` convenience predicates.
+-   `static GetReleaseStageTag(ReleaseStage)` returns the localized `[ALPHA]` / `[BETA]` marker (empty for Release). It takes the stage so callers that already resolved it avoid a redundant lookup.
+-   `IsDisabledByDefault()` returns `true` for any non-Release stage, so **Alpha/Beta features start disabled on first install**. Users can still enable them via the "Disable at Boot" menu. Do not add a redundant `IsDisabledByDefault` override on a feature that already carries a stage flag.
+
+**UI**: `FeatureListRenderer` draws the stage tag next to the feature name. Alpha uses the theme `StatusPalette.Error` color, Beta uses `StatusPalette.Warning`.
+
+**Versioning convention** (enforced by `tools/feature_version_audit.py`):
+
+-   Pre-release features use `0.x` versions. Entering pre-release from a release/fresh baseline: Beta starts at `0-2-0`, Alpha at `0-1-0`.
+-   `alpha -> beta` bumps the minor and resets the patch.
+-   Within the same pre-release stage, normal semver applies inside `0.x`.
+-   A breaking change (`feat!:` / `BREAKING CHANGE:`) on a pre-release feature **promotes it to release `1-0-0` and strips the Alpha/Beta flag**. `--apply-bumps` performs both the version bump and the flag removal automatically.
+-   Stage transitions are exact-match enforced (they may legitimately lower the version, e.g. release `1.x` -> beta `0-2-0`), unlike the lenient `>` check used within a stage.
+
 ## Key Development Patterns
 
 ### Memory Management

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,6 +233,31 @@ foreach(FEATURE_PATH ${FEATURE_CONFIG_FILES})
         )
     endif()
 
+    # Detect release stage from Alpha/Beta flags. Alpha takes precedence when
+    # both are set. A truthy value is required; absent or non-truthy means the
+    # feature is a full Release.
+    # Anchor to a line start ((^|[\r\n]); CMake regex has no multiline mode) so a
+    # settings key ending in "alpha"/"beta" (e.g. WaterAlpha = 1) is not mistaken
+    # for a stage flag. Keep in sync with the line-anchored match in
+    # tools/feature_version_audit.py.
+    # NOTE: guard on the match-result variable because CMAKE_MATCH_2 (the value)
+    # retains its prior value (the version major, above) when a REGEX MATCH misses.
+    set(_STAGE_ALPHA "")
+    set(_STAGE_BETA "")
+    string(REGEX MATCH "(^|[\r\n])[ \t]*[Aa]lpha[ \t]*=[ \t]*([A-Za-z0-9]+)" _STAGE_ALPHA_MATCH "${CONFIG_VALUE}")
+    if(_STAGE_ALPHA_MATCH)
+        string(TOLOWER "${CMAKE_MATCH_2}" _STAGE_ALPHA)
+    endif()
+    string(REGEX MATCH "(^|[\r\n])[ \t]*[Bb]eta[ \t]*=[ \t]*([A-Za-z0-9]+)" _STAGE_BETA_MATCH "${CONFIG_VALUE}")
+    if(_STAGE_BETA_MATCH)
+        string(TOLOWER "${CMAKE_MATCH_2}" _STAGE_BETA)
+    endif()
+    if(_STAGE_ALPHA MATCHES "^(true|1|yes|on)$")
+        list(APPEND FEATURE_ALPHA_NAMES "\t\t\"${FEATURE}\"sv")
+    elseif(_STAGE_BETA MATCHES "^(true|1|yes|on)$")
+        list(APPEND FEATURE_BETA_NAMES "\t\t\"${FEATURE}\"sv")
+    endif()
+
     # Detect core features by checking for the CORE marker file in the
     # feature root (features/<Folder>/CORE). FEATURE_PATH is
     # features/<Folder>/Shaders/Features/<ShortName>.ini, so the feature
@@ -253,6 +278,8 @@ set_property(
 
 string(REPLACE ";" ",\n" FEATURE_VERSIONS "${FEATURE_VERSIONS}")
 string(REPLACE ";" ",\n" FEATURE_CORE_NAMES "${FEATURE_CORE_NAMES}")
+string(REPLACE ";" ",\n" FEATURE_ALPHA_NAMES "${FEATURE_ALPHA_NAMES}")
+string(REPLACE ";" ",\n" FEATURE_BETA_NAMES "${FEATURE_BETA_NAMES}")
 
 configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/cmake/FeatureVersions.h.in

--- a/cmake/FeatureVersions.h.in
+++ b/cmake/FeatureVersions.h.in
@@ -15,4 +15,14 @@ namespace FeatureVersions
 	{
 @FEATURE_CORE_NAMES@
 	};
+
+	static const std::unordered_set<std::string_view> FEATURE_ALPHA_NAMES
+	{
+@FEATURE_ALPHA_NAMES@
+	};
+
+	static const std::unordered_set<std::string_view> FEATURE_BETA_NAMES
+	{
+@FEATURE_BETA_NAMES@
+	};
 }

--- a/features/Unified Water/Shaders/Features/UnifiedWater.ini
+++ b/features/Unified Water/Shaders/Features/UnifiedWater.ini
@@ -1,3 +1,3 @@
 [Info]
-Version = 1-0-2
-
+Version = 0-2-0
+Beta = True

--- a/package/SKSE/Plugins/CommunityShaders/Translations/en.json
+++ b/package/SKSE/Plugins/CommunityShaders/Translations/en.json
@@ -1715,6 +1715,8 @@
     "menu.features.setting_change_warning_title": "Setting Change Warning",
     "menu.features.settings_adjusted_warning": "Some of your settings have been automatically adjusted due to feature incompatibilities.",
     "menu.features.settings_hidden_disabled": "Feature settings are hidden because this feature is disabled at boot.",
+    "menu.features.tag_alpha": "[ALPHA]",
+    "menu.features.tag_beta": "[BETA]",
     "menu.features.unloaded_features": "Unloaded Features",
     "menu.footer.d3d12_swap_chain": "D3D12 Swap Chain: {status}",
     "menu.footer.game_version": "Game Version: {runtime} {version}",

--- a/src/Feature.cpp
+++ b/src/Feature.cpp
@@ -338,6 +338,18 @@ std::string Feature::GetDisplayCategory() const
 	return std::string(category);
 }
 
+std::string Feature::GetReleaseStageTag(ReleaseStage stage)
+{
+	switch (stage) {
+	case ReleaseStage::Alpha:
+		return T("menu.features.tag_alpha", "[ALPHA]");
+	case ReleaseStage::Beta:
+		return T("menu.features.tag_beta", "[BETA]");
+	default:
+		return {};
+	}
+}
+
 void Feature::DrawUnloadedUI()
 {
 	// Prioritize detailed failure message if available

--- a/src/Feature.h
+++ b/src/Feature.h
@@ -68,11 +68,42 @@ public:
 	virtual std::string_view GetCategory() const { return FeatureCategories::kOther; }
 
 	/**
-	 * Whether the feature is disabled at boot by default (before any user override).
-	 * Features that override this to return true will start disabled on first install;
-	 * users can still enable them via the "Disable at Boot" menu.
+	 * Release maturity stage, declared via the feature .ini (Alpha/Beta flags) and
+	 * baked into FeatureVersions.h at build time. Alpha takes precedence over Beta.
 	 */
-	virtual bool IsDisabledByDefault() const { return false; }
+	enum class ReleaseStage
+	{
+		Release,
+		Beta,
+		Alpha
+	};
+
+	virtual ReleaseStage GetReleaseStage() const
+	{
+		const auto name = const_cast<Feature*>(this)->GetShortName();
+		if (FeatureVersions::FEATURE_ALPHA_NAMES.contains(name))
+			return ReleaseStage::Alpha;
+		if (FeatureVersions::FEATURE_BETA_NAMES.contains(name))
+			return ReleaseStage::Beta;
+		return ReleaseStage::Release;
+	}
+
+	bool IsAlpha() const { return GetReleaseStage() == ReleaseStage::Alpha; }
+	bool IsBeta() const { return GetReleaseStage() == ReleaseStage::Beta; }
+
+	/**
+	 * Localized stage marker shown after the feature name ("[ALPHA]", "[BETA]"),
+	 * empty for release features. Takes the stage so callers that already resolved
+	 * it (see GetReleaseStage) avoid a redundant lookup.
+	 */
+	static std::string GetReleaseStageTag(ReleaseStage stage);
+
+	/**
+	 * Whether the feature is disabled at boot by default (before any user override).
+	 * Alpha and Beta features start disabled on first install; users can still enable
+	 * them via the "Disable at Boot" menu.
+	 */
+	virtual bool IsDisabledByDefault() const { return GetReleaseStage() != ReleaseStage::Release; }
 
 	/**
 	 * Whether the feature will show up in the GUI menu

--- a/src/Features/UnifiedWater.h
+++ b/src/Features/UnifiedWater.h
@@ -105,7 +105,6 @@ struct UnifiedWater : OverlayFeature
 	virtual void RestoreDefaultSettings() override;
 
 	virtual bool IsCore() const override { return true; }
-	virtual bool IsDisabledByDefault() const override { return true; }
 
 	virtual void PostPostLoad() override;
 

--- a/src/Menu/FeatureListRenderer.cpp
+++ b/src/Menu/FeatureListRenderer.cpp
@@ -55,6 +55,14 @@ namespace
 		return std::find(CORE_MENU_NAMES.begin(), CORE_MENU_NAMES.end(), menuName) != CORE_MENU_NAMES.end();
 	}
 
+	// Color for the [ALPHA]/[BETA] stage marker. Alpha (less stable) reads as an error,
+	// Beta as a warning.
+	ImVec4 StageTagColor(Feature::ReleaseStage stage)
+	{
+		const auto& statusPalette = globals::menu->GetTheme().StatusPalette;
+		return stage == Feature::ReleaseStage::Alpha ? statusPalette.Error : statusPalette.Warning;
+	}
+
 	/**
 	 * @brief Determines if the left feature panel should be visible based on auto-hide settings and mouse position
 	 * @return true if panel should be visible, false if it should be hidden
@@ -166,7 +174,7 @@ namespace
 	 * @param description Short description shown below the title (single line, truncated if too long)
 	 * @return The height of just the title line (for button alignment)
 	 */
-	float DrawFeatureHeader(const std::string& featureName, const std::string& version, const std::string& description = "")
+	float DrawFeatureHeader(const std::string& featureName, const std::string& version, const std::string& description = "", const std::string& stageTag = "", ImVec4 stageColor = {})
 	{
 		auto& themeSettings = globals::menu->GetTheme();
 		auto& palette = themeSettings.Palette;
@@ -197,6 +205,31 @@ namespace
 		// Store the title-only height for return value
 		float titleOnlyHeight = titleSize.y;
 
+		// Running x for bottom-aligned annotations (stage tag, then version) to the right of the title
+		float annotationX = startPos.x + titleSize.x + ImGui::GetStyle().ItemSpacing.x;
+
+		// Draw stage marker ([ALPHA]/[BETA]) on same line, bottom-aligned
+		if (!stageTag.empty()) {
+			ImVec2 tagSize;
+			{
+				MenuFonts::FontRoleGuard bodyGuard(Menu::FontRole::Body);
+				tagSize = ImGui::CalcTextSize(stageTag.c_str());
+				tagSize.x *= titleScale;
+				tagSize.y *= titleScale;
+			}
+
+			ImGui::SetCursorScreenPos(ImVec2(annotationX, startPos.y + titleSize.y - tagSize.y));
+			{
+				MenuFonts::FontRoleGuard bodyGuard(Menu::FontRole::Body);
+				ImGui::SetWindowFontScale(titleScale);
+				ImGui::TextColored(stageColor, "%s", stageTag.c_str());
+				ImGui::SetWindowFontScale(1.0f);
+			}
+
+			annotationX += tagSize.x + ImGui::GetStyle().ItemSpacing.x;
+			ImGui::SetCursorScreenPos(ImVec2(startPos.x, startPos.y + titleSize.y + ImGui::GetStyle().ItemSpacing.y * 0.25f));
+		}
+
 		// Draw version on same line with Body font, bottom-aligned if version exists
 		if (!version.empty()) {
 			// Format version: replace dashes with dots for consistency
@@ -212,8 +245,8 @@ namespace
 				versionSize.y *= titleScale;
 			}
 
-			// Position version text: right of title, bottom-aligned
-			float versionX = startPos.x + titleSize.x + ImGui::GetStyle().ItemSpacing.x;
+			// Position version text: right of the stage tag (or title), bottom-aligned
+			float versionX = annotationX;
 			float versionY = startPos.y + titleSize.y - versionSize.y;
 
 			ImGui::SetCursorScreenPos(ImVec2(versionX, versionY));
@@ -582,6 +615,12 @@ void FeatureListRenderer::ListMenuVisitor::operator()(Feature* feat)
 	}
 	ImGui::PopStyleColor();
 
+	// Display the stage marker behind the name, regardless of loaded state
+	if (const auto stage = feat->GetReleaseStage(); stage != Feature::ReleaseStage::Release) {
+		ImGui::SameLine();
+		ImGui::TextColored(StageTagColor(stage), "%s", Feature::GetReleaseStageTag(stage).c_str());
+	}
+
 	// Display version if loaded
 	if (isLoaded) {
 		ImGui::SameLine();
@@ -682,7 +721,9 @@ void FeatureListRenderer::DrawMenuVisitor::RenderFeatureHeader(Feature* feat, bo
 
 	// Draw feature title, version, and description on the left
 	// Returns title-only height for button alignment
-	float titleOnlyHeight = DrawFeatureHeader(feat->GetDisplayName(), isLoaded ? feat->version : "", description);
+	const auto stage = feat->GetReleaseStage();
+	const std::string stageTag = Feature::GetReleaseStageTag(stage);  // empty for Release; color unused when tag is empty
+	float titleOnlyHeight = DrawFeatureHeader(feat->GetDisplayName(), isLoaded ? feat->version : "", description, stageTag, StageTagColor(stage));
 
 	// Save cursor position after header (for restoring after buttons are drawn)
 	ImVec2 cursorPosAfterHeader = ImGui::GetCursorScreenPos();

--- a/src/Menu/FeatureListRenderer.cpp
+++ b/src/Menu/FeatureListRenderer.cpp
@@ -60,7 +60,14 @@ namespace
 	ImVec4 StageTagColor(Feature::ReleaseStage stage)
 	{
 		const auto& statusPalette = globals::menu->GetTheme().StatusPalette;
-		return stage == Feature::ReleaseStage::Alpha ? statusPalette.Error : statusPalette.Warning;
+		switch (stage) {
+		case Feature::ReleaseStage::Alpha:
+			return statusPalette.Error;
+		case Feature::ReleaseStage::Beta:
+		case Feature::ReleaseStage::Release:
+			return statusPalette.Warning;
+		}
+		return statusPalette.Warning;
 	}
 
 	/**

--- a/src/Menu/FeatureListRenderer.cpp
+++ b/src/Menu/FeatureListRenderer.cpp
@@ -60,14 +60,7 @@ namespace
 	ImVec4 StageTagColor(Feature::ReleaseStage stage)
 	{
 		const auto& statusPalette = globals::menu->GetTheme().StatusPalette;
-		switch (stage) {
-		case Feature::ReleaseStage::Alpha:
-			return statusPalette.Error;
-		case Feature::ReleaseStage::Beta:
-		case Feature::ReleaseStage::Release:
-			return statusPalette.Warning;
-		}
-		return statusPalette.Warning;
+		return stage == Feature::ReleaseStage::Alpha ? statusPalette.Error : statusPalette.Warning;
 	}
 
 	/**

--- a/tools/feature_version_audit.py
+++ b/tools/feature_version_audit.py
@@ -36,6 +36,14 @@ RE_IS_CORE = re.compile(r"IsCore\s*\(.*\)\s*const\s*override\s*\{\s*return true;
 RE_VERSION = re.compile(r"(?i)version\s*=\s*([0-9]+)-([0-9]+)-([0-9]+)")
 RE_BUMP_SUGGESTION = re.compile(r"- \*\*(.+?)\.ini\*\*: bump to `([\d-]+)`.*\[link\]\([^)]+\) ?(?:\(([^)]+)\))?")
 
+# Release-stage flags (parsed from the feature .ini [Info] section). Alpha wins over Beta.
+RE_STAGE_ALPHA = re.compile(r"(?im)^[ \t]*alpha[ \t]*=[ \t]*(\w+)")
+RE_STAGE_BETA = re.compile(r"(?im)^[ \t]*beta[ \t]*=[ \t]*(\w+)")
+STAGE_TRUTHY = {"true", "1", "yes", "on"}
+STAGE_RELEASE = "release"
+STAGE_BETA = "beta"
+STAGE_ALPHA = "alpha"
+
 # Commit type regexes
 RE_COMMIT_FEAT = re.compile(r"^feat(\(|:|\s)", re.IGNORECASE)
 RE_COMMIT_FIX = re.compile(r"^fix(\(|:|\s)", re.IGNORECASE)
@@ -257,6 +265,58 @@ def get_prior_version(ini_path, base_ref):
         return get_version_from_ini(ini_path, content)
     except Exception:
         return None
+
+def stage_from_content(content):
+    """Resolve the release stage (alpha/beta/release) from .ini text. Alpha wins."""
+    m = RE_STAGE_ALPHA.search(content)
+    if m and m.group(1).strip().lower() in STAGE_TRUTHY:
+        return STAGE_ALPHA
+    m = RE_STAGE_BETA.search(content)
+    if m and m.group(1).strip().lower() in STAGE_TRUTHY:
+        return STAGE_BETA
+    return STAGE_RELEASE
+
+def get_stage_from_ini(ini_path, content=None):
+    if content is None:
+        if HEAD_REF != "HEAD":
+            rel_path = os.path.relpath(ini_path, PROJECT_ROOT).replace("\\", "/")
+            try:
+                content = subprocess.check_output(
+                    ["git", "show", f"{HEAD_REF}:{rel_path}"], stderr=subprocess.DEVNULL
+                ).decode("utf-8")
+            except Exception:
+                return STAGE_RELEASE
+        else:
+            try:
+                with open(ini_path, "r", encoding="utf-8") as f:
+                    content = f.read()
+            except Exception:
+                return STAGE_RELEASE
+    return stage_from_content(content)
+
+def get_prior_stage(ini_path, base_ref):
+    rel_path = os.path.relpath(ini_path, PROJECT_ROOT).replace("\\", "/")
+    try:
+        content = subprocess.check_output(
+            ["git", "show", f"{base_ref}:{rel_path}"], stderr=subprocess.DEVNULL
+        ).decode("utf-8")
+        return stage_from_content(content)
+    except Exception:
+        return STAGE_RELEASE
+
+def remove_stage_flag(ini_path):
+    """Strip the Alpha/Beta flag line(s) from an .ini (used on release promotion)."""
+    try:
+        with open(ini_path, "r", encoding="utf-8") as f:
+            lines = f.readlines()
+        new_lines = [ln for ln in lines if not (RE_STAGE_ALPHA.match(ln) or RE_STAGE_BETA.match(ln))]
+        if new_lines != lines:
+            with open(ini_path, "w", encoding="utf-8") as f:
+                f.writelines(new_lines)
+            return True
+    except Exception as e:
+        print(f"Error removing stage flag from {ini_path}: {e}", file=sys.stderr)
+    return False
 
 def get_changed_files(feature_path, base_ref, file_types=None):
     if file_types is None:
@@ -560,10 +620,30 @@ def detect_pr_base():
     print(f"Falling back to {DEFAULT_PR_BASE_REF} for PR base.", file=sys.stderr)
     return DEFAULT_PR_BASE_REF
 
-def propose_new_version(prior_version, commits):
+def propose_new_version(prior_version, commits, prior_stage=STAGE_RELEASE, current_stage=STAGE_RELEASE):
     if not prior_version:
         return None
     major, minor, patch = prior_version
+
+    has_breaking = any(RE_COMMIT_BREAKING.search(c) for c in commits) if commits else False
+
+    # Promotion to release: either the flag was removed (prior pre-release, now
+    # release) or a breaking commit auto-promotes a still-pre-release feature.
+    promoted_by_flag = prior_stage in (STAGE_ALPHA, STAGE_BETA) and current_stage == STAGE_RELEASE
+    promoted_by_breaking = current_stage in (STAGE_ALPHA, STAGE_BETA) and has_breaking
+    if promoted_by_flag or promoted_by_breaking:
+        return (1, 0, 0)
+
+    # Pre-release stage transitions take precedence over commit-based bumps.
+    if current_stage in (STAGE_ALPHA, STAGE_BETA):
+        if prior_stage == STAGE_RELEASE:
+            # Entering pre-release from release/fresh: fixed baselines.
+            return (0, 1, 0) if current_stage == STAGE_ALPHA else (0, 2, 0)
+        if prior_stage == STAGE_ALPHA and current_stage == STAGE_BETA:
+            # alpha -> beta: extra minor bump, patch reset.
+            return (0, minor + 1, 0)
+        # Same stage (alpha->alpha / beta->beta): fall through to normal semver within 0.x.
+
     if not commits:
         return None
 
@@ -680,12 +760,29 @@ def analyze_features(FEATURES_DIR, feature_meta_map, base_ref, only_changed=Fals
                 bump_commit = any_commit
                 bump_author = get_commit_author(any_commit)
 
-        proposed_ver = propose_new_version(prior_ver, all_commits) if ini_path else None
+        # Release stage at the version baseline vs. at HEAD; drives stage-aware proposals.
+        prior_stage = get_prior_stage(ini_path, version_ref) if ini_path else STAGE_RELEASE
+        current_stage = get_stage_from_ini(ini_path) if ini_path else STAGE_RELEASE
+        has_breaking = any(RE_COMMIT_BREAKING.search(c) for c in all_commits)
+        # A transition is a change of stage between the baseline and HEAD.
+        stage_transition = prior_stage != current_stage
+        # A breaking commit on a still-pre-release feature must also strip the flag.
+        needs_flag_removal = current_stage != STAGE_RELEASE and has_breaking
+
+        proposed_ver = propose_new_version(prior_ver, all_commits, prior_stage, current_stage) if ini_path else None
         # Use max(new_ver, pr_prior_ver) as the effective current version so that a version
         # bump already on base_ref (e.g. from a parallel PR) satisfies the check even when
         # the PR branch has not been rebased.
         effective_new_ver = max(new_ver, pr_prior_ver) if (new_ver and pr_prior_ver) else (new_ver or pr_prior_ver)
-        needs_bump = (proposed_ver is not None and effective_new_ver is not None and proposed_ver > effective_new_ver)
+        if stage_transition:
+            # Transitions are exact-match enforced because they may legitimately lower the
+            # version (e.g. release 1.x -> beta 0.2.0), which the lenient '>' check below
+            # would never apply. Compare against the HEAD ini directly.
+            needs_bump = (proposed_ver is not None and new_ver is not None and proposed_ver != new_ver)
+        else:
+            # Within-stage (release OR pre-release) mirrors existing release handling:
+            # lenient, so --apply-bumps at release time never downgrades a feature.
+            needs_bump = (proposed_ver is not None and effective_new_ver is not None and proposed_ver > effective_new_ver)
         proposed_ver_str = "-".join(map(str, proposed_ver)) if proposed_ver else "-"
         prior_ver_str = "-".join(map(str, prior_ver)) if prior_ver else "-"
         new_ver_str = "-".join(map(str, new_ver)) if new_ver else "-"
@@ -736,7 +833,7 @@ def analyze_features(FEATURES_DIR, feature_meta_map, base_ref, only_changed=Fals
                     except Exception:
                         pass
 
-        if needs_bump:
+        if needs_bump or needs_flag_removal:
             is_attention = True
         if is_attention:
             actionable = True
@@ -759,6 +856,7 @@ def analyze_features(FEATURES_DIR, feature_meta_map, base_ref, only_changed=Fals
             'commit_link': commit_link,
             'is_attention': is_attention,
             'ini_path': str(ini_path) if ini_path else None,
+            'needs_flag_removal': needs_flag_removal,
             'author': bump_author
         })
         if needs_bump:
@@ -769,6 +867,8 @@ def analyze_features(FEATURES_DIR, feature_meta_map, base_ref, only_changed=Fals
                 feat_act["actions"].append(note)
             if needs_bump:
                 feat_act["actions"].append(f"Needs version bump to {proposed_ver_str}")
+            if needs_flag_removal:
+                feat_act["actions"].append("Breaking change: promote to release (set 1-0-0, remove Alpha/Beta flag)")
 
     return feature_analysis, bump_suggestions, new_features, new_code_features, actionable, feature_actions
 
@@ -1244,12 +1344,18 @@ def main():
 
                     fa['needs_bump'] = False
 
+            # Breaking-change auto-promotion: strip the Alpha/Beta flag from the ini.
+            if fa.get('needs_flag_removal') and fa['ini_path']:
+                if remove_stage_flag(fa['ini_path']):
+                    print(f"Removed Alpha/Beta flag from {fa['name']} (promoted to release)", file=sys.stderr)
+                fa['needs_flag_removal'] = False
+
         print(f"\nSuccessfully applied {applied_count} version bumps." if applied_count > 0 else "\nNo version bumps applied.", file=sys.stderr)
 
         # Remove stale bump actions from feature_actions
         for fname in list(feature_actions.keys()):
             info = feature_actions[fname]
-            info["actions"] = [a for a in info["actions"] if not a.startswith("Needs version bump")]
+            info["actions"] = [a for a in info["actions"] if not a.startswith("Needs version bump") and not a.startswith("Breaking change: promote")]
             if not info["actions"]:
                 del feature_actions[fname]
 
@@ -1265,7 +1371,7 @@ def main():
         ]
 
         # Recompute actionable after applying bumps
-        actionable = any(fa.get('needs_bump') or "missing" in fa.get('note', '').lower() for fa in feature_analysis)
+        actionable = any(fa.get('needs_bump') or fa.get('needs_flag_removal') or "missing" in fa.get('note', '').lower() for fa in feature_analysis)
         if new_features:
             actionable = True
 

--- a/tools/feature_version_audit.py
+++ b/tools/feature_version_audit.py
@@ -1348,7 +1348,7 @@ def main():
             if fa.get('needs_flag_removal') and fa['ini_path']:
                 if remove_stage_flag(fa['ini_path']):
                     print(f"Removed Alpha/Beta flag from {fa['name']} (promoted to release)", file=sys.stderr)
-                fa['needs_flag_removal'] = False
+                    fa['needs_flag_removal'] = False
 
         print(f"\nSuccessfully applied {applied_count} version bumps." if applied_count > 0 else "\nNo version bumps applied.", file=sys.stderr)
 


### PR DESCRIPTION
## Summary

Introduces a release-maturity stage system for features. A feature can now declare itself `Alpha` or `Beta` in its `.ini` `[Info]` section; the stage is baked into `FeatureVersions.h` at build time alongside the existing core-feature list, and is used at runtime to auto-disable pre-release features, show colored `[ALPHA]`/`[BETA]` tags in the feature list and header, and drive stage-aware versioning in the version-audit tool.

UnifiedWater is the first feature to use this: it is marked `Beta = True` and versioned `0-2-0` accordingly.

## Changes

### Build (CMakeLists.txt / cmake/FeatureVersions.h.in)

- Scans each feature `.ini` for `Alpha`/`Beta` flags (line-anchored regex to avoid false positives from settings keys like `WaterAlpha = 1` or Nexus metadata keys like `nexusbeta = on`). Truthy values are `true`, `1`, `yes`, `on` (case-insensitive); `Alpha` takes precedence over `Beta`.
- Populates `FEATURE_ALPHA_NAMES` and `FEATURE_BETA_NAMES` lists and substitutes them into the new `std::unordered_set<std::string_view>` constants in `FeatureVersions.h`, following the same pattern as `FEATURE_CORE_NAMES`.

### Runtime C++ API (src/Feature.h / src/Feature.cpp)

- `ReleaseStage` enum (`Release`, `Beta`, `Alpha`) added to `Feature`.
- `GetReleaseStage()` looks the short name up in the baked sets. Virtual so features can override if needed.
- `IsAlpha()` / `IsBeta()` convenience predicates.
- `static GetReleaseStageTag(ReleaseStage)` returns the localized `[ALPHA]` / `[BETA]` string (empty for Release). Static and takes the already-resolved stage so callers avoid a redundant hash-set lookup.
- `IsDisabledByDefault()` now returns `true` for any non-Release stage; the `UnifiedWater` override that manually returned `true` is removed.

### UI (src/Menu/FeatureListRenderer.cpp)

- `StageTagColor()` helper maps stages to `StatusPalette.Error` (Alpha) and `StatusPalette.Warning` (Beta).
- The feature list shows the tag via `ImGui::SameLine` after the selectable name; the feature header draws it bottom-aligned to the right of the feature title, before the version string.
- Both sites resolve `GetReleaseStage()` once and pass the result through, so no redundant lookup occurs.

### Translations (package/SKSE/Plugins/CommunityShaders/Translations/en.json)

- `menu.features.tag_alpha`: `"[ALPHA]"`
- `menu.features.tag_beta`: `"[BETA]"`

### UnifiedWater (features/Unified Water / src/Features/UnifiedWater.h)

- Version `1-0-2` → `0-2-0` (entering Beta baseline per the versioning convention).
- `Beta = True` flag added to the ini.
- Redundant `IsDisabledByDefault() override { return true; }` removed.

### Version audit tool (tools/feature_version_audit.py)

- Parses `Alpha`/`Beta` flags from ini content (`stage_from_content`, `get_stage_from_ini`, `get_prior_stage`).
- `propose_new_version` is now stage-aware:
  - Entering Alpha from release/fresh: proposes `0-1-0`; entering Beta: `0-2-0`.
  - `alpha → beta` transition: minor bump, patch reset.
  - Breaking commit on a pre-release feature promotes to `1-0-0` and sets `needs_flag_removal`.
  - Within the same stage, normal semver applies inside `0.x`.
- Stage transitions use exact-match enforcement (a legitimate version decrease like `1.x → 0-2-0` would never satisfy the existing `>` check).
- `remove_stage_flag()` strips the flag line from the ini; `--apply-bumps` calls it automatically on breaking-change promotion.
- Actionable-state and stale-action cleanup extended to cover `needs_flag_removal`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a release-stage system for features (Release / Alpha / Beta) with localized menu tag strings
  * Stage indicators (e.g., `[ALPHA]`, `[BETA]`) now render in the Features UI with theme-colored styling
  * Alpha/Beta features start disabled by default; Release remains enabled
  * Unified Water is now marked as a core Beta feature (including updated version metadata)
* **Documentation**
  * Documented release-stage declaration, parsing, and stage-transition rules
* **Chores / Tools**
  * Made feature version auditing and bumping stage-aware, including automatic promotion to Release and stage-flag removal
<!-- end of auto-generated comment: release notes by coderabbit.ai -->