### PR TITLE
chore(sss): set burley as default

### DIFF
--- a/src/Features/SubsurfaceScattering.h
+++ b/src/Features/SubsurfaceScattering.h
@@ -26,7 +26,7 @@ public:
 	{
 		uint EnableCharacterLighting = false;
 		float CharacterLightingStrength = 1.0f;
-		int SSMode = 0;
+		int SSMode = 1;
 		int ScatterMode = kPreAndPostScatter;
 		DiffusionProfile BaseProfile{ 1.0f, 1.0f, { 0.48f, 0.41f, 0.28f }, { 0.56f, 0.56f, 0.56f } };
 		DiffusionProfile HumanProfile{ 1.0f, 1.0f, { 0.48f, 0.41f, 0.28f }, { 1.0f, 0.37f, 0.3f } };


### PR DESCRIPTION
separable causes issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Changed the default subsurface scattering rendering mode selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->