### PR TITLE
fix: bump hair spec to fix version desync

### DIFF
--- a/features/Hair Specular/Shaders/Features/HairSpecular.ini
+++ b/features/Hair Specular/Shaders/Features/HairSpecular.ini
@@ -1,5 +1,5 @@
 [Info]
-Version = 1-1-0
+Version = 1-1-2
 
 [Nexus]
 nexusmodid = 149011


### PR DESCRIPTION
due to the release of 1.7 not having bumped hair spec versioning, this change will ensure that hair spec versioning is in sync with the nexus version again for the next update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Hair Specular feature version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->