### PR TITLE
fix(hooks): keep render target pointer stable for chained hooks

### DIFF
--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -520,7 +520,7 @@ namespace Hooks
 	{
 		static void thunk(RE::BSGraphics::Renderer* This, RE::RENDER_TARGETS::RENDER_TARGET a_target, RE::BSGraphics::RenderTargetProperties* a_properties)
 		{
-			// Modify in place and restore so chained hooks (e.g. HD Local Map) keep a stable pointer.
+			// Modify in place and restore so chained hooks keep a stable pointer.
 			const auto saved = *a_properties;
 			globals::state->ModifyRenderTarget(a_target, *a_properties);
 			func(This, a_target, a_properties);

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -520,9 +520,11 @@ namespace Hooks
 	{
 		static void thunk(RE::BSGraphics::Renderer* This, RE::RENDER_TARGETS::RENDER_TARGET a_target, RE::BSGraphics::RenderTargetProperties* a_properties)
 		{
-			auto properties = *a_properties;
-			globals::state->ModifyRenderTarget(a_target, properties);
-			func(This, a_target, &properties);
+			// Modify in place and restore so chained hooks (e.g. HD Local Map) keep a stable pointer.
+			const auto saved = *a_properties;
+			globals::state->ModifyRenderTarget(a_target, *a_properties);
+			func(This, a_target, a_properties);
+			*a_properties = saved;
 		}
 		static inline REL::Relocation<decltype(thunk)> func;
 	};


### PR DESCRIPTION
fixes missing local map when using HD local map

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of render target operations by ensuring consistent property handling across rendering cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->