### PR TITLE
fix(cs-editor): guard against stuck weather

### DIFF
--- a/src/CSEditor/Widget.cpp
+++ b/src/CSEditor/Widget.cpp
@@ -292,15 +292,21 @@ bool Widget::BeginWidgetWindow()
 void Widget::ForceWeatherReinit(RE::TESWeather* weather)
 {
 	auto* sky = globals::game::sky;
-	if (weather && sky && sky->currentWeather == weather)
+	if (weather && sky && sky->currentWeather == weather) {
 		sky->ForceWeather(weather, true);
+		// Release the engine override so edits apply without halting natural transitions.
+		sky->ReleaseWeatherOverride();
+	}
 }
 
 void Widget::ForceCurrentWeatherReinit()
 {
 	auto* sky = globals::game::sky;
-	if (sky && sky->currentWeather)
+	if (sky && sky->currentWeather) {
 		sky->ForceWeather(sky->currentWeather, true);
+		// Release the engine override so edits apply without halting natural transitions.
+		sky->ReleaseWeatherOverride();
+	}
 }
 
 void Widget::DrawWidgetHeader(const char* searchId, bool showApply, bool showSaveLoadRevert, bool showForceWeather, RE::TESWeather* weather)

--- a/src/CSEditor/Widget.cpp
+++ b/src/CSEditor/Widget.cpp
@@ -294,7 +294,6 @@ void Widget::ForceWeatherReinit(RE::TESWeather* weather)
 	auto* sky = globals::game::sky;
 	if (weather && sky && sky->currentWeather == weather) {
 		sky->ForceWeather(weather, true);
-		// Release the engine override so edits apply without halting natural transitions.
 		sky->ReleaseWeatherOverride();
 	}
 }
@@ -304,7 +303,6 @@ void Widget::ForceCurrentWeatherReinit()
 	auto* sky = globals::game::sky;
 	if (sky && sky->currentWeather) {
 		sky->ForceWeather(sky->currentWeather, true);
-		// Release the engine override so edits apply without halting natural transitions.
 		sky->ReleaseWeatherOverride();
 	}
 }


### PR DESCRIPTION
prevents weather locks for sticking

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved weather system reliability by ensuring weather override states are properly released when weather is forced to change, preventing potential issues from incomplete cleanup that could cause unexpected behavior or interfere with subsequent weather modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->