### PR TITLE
fix(sky-sync): modulate VL when it's desynced

### DIFF
--- a/.github/workflows/maint-discord-notify.yaml
+++ b/.github/workflows/maint-discord-notify.yaml
@@ -1,4 +1,4 @@
-# Posts releases (full body) and dev commits (titles) to Discord.
+# Posts releases (body up to the first --- rule) and dev commits (titles) to Discord.
 # Long content is split across multiple embeds so nothing is truncated.
 name: "Maint: Discord Notifications"
 on:
@@ -39,7 +39,8 @@ jobs:
                       TITLE="${RELEASE_TITLE:-$RELEASE_TAG}"
                       URL="$RELEASE_URL"
                       COLOR=3066993  # 0x2ecc71 green
-                      description="$RELEASE_BODY"
+                      # Drop everything from the first horizontal rule on (feature audit, not feed-worthy).
+                      description="$(awk '/^-{3,}[[:space:]]*$/{exit} {print}' <<< "$RELEASE_BODY")"
                   else
                       TITLE="New commits on $REF"
                       URL="$COMPARE"

--- a/features/Hair Specular/Shaders/Features/HairSpecular.ini
+++ b/features/Hair Specular/Shaders/Features/HairSpecular.ini
@@ -1,5 +1,5 @@
 [Info]
-Version = 1-1-0
+Version = 1-1-2
 
 [Nexus]
 nexusmodid = 149011

--- a/features/Water Effects/Shaders/WaterEffects/WaterCaustics.hlsli
+++ b/features/Water Effects/Shaders/WaterEffects/WaterCaustics.hlsli
@@ -25,6 +25,7 @@ namespace WaterEffects
 
 	float3 ComputeCaustics(float4 waterData, float3 worldPosition)
 	{
+		float3 result = 1.0.xxx;
 		float causticsDistToWater = waterData.w - worldPosition.z;
 		float shoreFactorCaustics = saturate(causticsDistToWater / 64.0);
 
@@ -38,9 +39,10 @@ namespace WaterEffects
 			float2 causticsUV1 = PanCausticsUV(causticsUV, 0.5 * 0.2, 1.0);
 			float2 causticsUV2 = PanCausticsUV(causticsUV, 1.0 * 0.2, -0.5);
 
-			float3 causticsHigh = 1.0.xxx;
-			if (causticsFade > 0.0)
-				causticsHigh = min(SampleCausticsDispersion(causticsUV1, dispersionOffset), SampleCausticsDispersion(causticsUV2, dispersionOffset)) * 4.0;
+			const float3 causticsHigh =
+				(causticsFade > 0.0)
+					? (min(SampleCausticsDispersion(causticsUV1, dispersionOffset), SampleCausticsDispersion(causticsUV2, dispersionOffset)) * 4.0)
+					: 1.0.xxx;
 
 			causticsUV *= 0.5;
 			dispersionOffset *= 0.5;
@@ -48,14 +50,15 @@ namespace WaterEffects
 			causticsUV1 = PanCausticsUV(causticsUV, 0.5 * 0.1, 1.0);
 			causticsUV2 = PanCausticsUV(causticsUV, 1.0 * 0.1, -0.5);
 
-			float3 causticsLow = 1.0.xxx;
-			if (causticsFade < 1.0)
-				causticsLow = min(SampleCausticsDispersion(causticsUV1, dispersionOffset), SampleCausticsDispersion(causticsUV2, dispersionOffset)) * 4.0;
+			const float3 causticsLow =
+				(causticsFade < 1.0)
+					? (min(SampleCausticsDispersion(causticsUV1, dispersionOffset), SampleCausticsDispersion(causticsUV2, dispersionOffset)) * 4.0)
+					: 1.0.xxx;
 
-			float3 caustics = lerp(causticsLow, causticsHigh, causticsFade);
-			return lerp(1.0.xxx, caustics, shoreFactorCaustics);
+			const float3 caustics = lerp(causticsLow, causticsHigh, causticsFade);
+			result = lerp(1.0.xxx, caustics, shoreFactorCaustics);
 		}
 
-		return 1.0.xxx;
+		return result;
 	}
 }

--- a/src/CSEditor/Widget.cpp
+++ b/src/CSEditor/Widget.cpp
@@ -292,15 +292,19 @@ bool Widget::BeginWidgetWindow()
 void Widget::ForceWeatherReinit(RE::TESWeather* weather)
 {
 	auto* sky = globals::game::sky;
-	if (weather && sky && sky->currentWeather == weather)
+	if (weather && sky && sky->currentWeather == weather) {
 		sky->ForceWeather(weather, true);
+		sky->ReleaseWeatherOverride();
+	}
 }
 
 void Widget::ForceCurrentWeatherReinit()
 {
 	auto* sky = globals::game::sky;
-	if (sky && sky->currentWeather)
+	if (sky && sky->currentWeather) {
 		sky->ForceWeather(sky->currentWeather, true);
+		sky->ReleaseWeatherOverride();
+	}
 }
 
 void Widget::DrawWidgetHeader(const char* searchId, bool showApply, bool showSaveLoadRevert, bool showForceWeather, RE::TESWeather* weather)

--- a/src/Features/SkySync.cpp
+++ b/src/Features/SkySync.cpp
@@ -242,6 +242,9 @@ void SkySync::Update(const RE::Sky* sky)
 		const float sunsetMiddle = (timing.sunset.begin + timing.sunset.end) / 12.0f;
 		const float sunsetEnd = timing.sunset.end / 6.0f;
 
+		sunSetting = hour >= sunsetMiddle && hour < sunsetEnd;
+		sunRising = hour >= sunriseBegin && hour < sunriseMiddle;
+
 		if (hour >= sunsetMiddle && hour < sunsetEnd) {
 			float range = sunsetEnd - sunsetMiddle;
 			float t = range > 0.0f ? (hour - sunsetMiddle) / range : 1.0f;
@@ -257,6 +260,8 @@ void SkySync::Update(const RE::Sky* sky)
 		}
 	} else {
 		currentDim = 1.0f;
+		sunSetting = false;
+		sunRising = false;
 	}
 
 	RE::NiPoint3 directions[3] = {};
@@ -368,24 +373,6 @@ void SkySync::ProcessMoon(const RE::Sky* sky, const Caster type, RE::NiPoint3 di
 	intensities[idx] = color.w;
 }
 
-bool SkySync::IsNight(const RE::Sky* sky)
-{
-	if (!sky || !sky->currentClimate)
-		return false;
-	const auto& timing = sky->currentClimate->timing;
-	const float hour = sky->currentGameHour;
-	return hour >= timing.sunset.end / 6.0f || hour < timing.sunrise.begin / 6.0f;
-}
-
-bool SkySync::IsDaytime(const RE::Sky* sky)
-{
-	if (!sky || !sky->currentClimate)
-		return false;
-	const auto& timing = sky->currentClimate->timing;
-	const float hour = sky->currentGameHour;
-	return hour >= timing.sunrise.end / 6.0f && hour < timing.sunset.begin / 6.0f;
-}
-
 inline void SkySync::CalculateSunDirectionAndDistance(const RE::Sun* sun, RE::NiPoint3& outDir, float& outDistance)
 {
 	outDir = sun->root->local.translate;
@@ -428,6 +415,9 @@ void SkySync::ShadowFader::Reset()
 	previousTarget = Caster::Sun;
 	fadeTimer = 0.0f;
 	transitioning = false;
+	sunriseReleased = false;
+	frozenHeading = 0.0f;
+	sunsetHeadingLocked = false;
 }
 
 void SkySync::ShadowFader::Update(const RE::Sky* sky, RE::NiPoint3 dirs[], float intensities[], float fadeDuration, float fadeAdvance)
@@ -471,6 +461,8 @@ void SkySync::ShadowFader::Update(const RE::Sky* sky, RE::NiPoint3 dirs[], float
 		vlSuppressed = false;
 	}
 
+	LockSunElevation(dirs);
+
 	// If best source changed, begin a new transition
 	if (best != target) {
 		previousTarget = target;
@@ -478,16 +470,6 @@ void SkySync::ShadowFader::Update(const RE::Sky* sky, RE::NiPoint3 dirs[], float
 		startDir = currentDir;
 		fadeTimer = 0.0f;
 		transitioning = true;
-
-		// Snap instantly if transitioning to sun during daytime or to moon during full night
-		bool snap = (best == Caster::Sun && IsDaytime(sky)) ||
-		            ((best == Caster::Masser || best == Caster::Secunda) && IsNight(sky));
-		if (snap) {
-			transitioning = false;
-			currentDir = dirs[static_cast<int>(best)];
-			SetLighting(sky, currentDir);
-			return;
-		}
 	}
 
 	if (!transitioning) {
@@ -515,6 +497,37 @@ void SkySync::ShadowFader::Update(const RE::Sky* sky, RE::NiPoint3 dirs[], float
 	SetLighting(sky, currentDir);
 }
 
+void SkySync::ShadowFader::LockSunElevation(RE::NiPoint3 dirs[])
+{
+	// Dusk: lock elevation to the minimum so the shadow can't tilt back up as the sun goes under,
+	// and once dimming passes the threshold lock heading too so it stops sweeping while the VL fades.
+	// Dawn: lock at the minimum until the sun naturally rises above it, then follow it.
+	const auto& skySync = globals::features::skySync;
+	const int sunIdx = static_cast<int>(Caster::Sun);
+	const float minElev = DirectX::XMConvertToRadians(skySync.settings.MinShadowElevation);
+	if (skySync.sunSetting) {
+		if (skySync.currentDim <= SunsetHeadingLockThreshold) {
+			if (!sunsetHeadingLocked) {
+				frozenHeading = std::atan2(dirs[sunIdx].y, dirs[sunIdx].x);
+				sunsetHeadingLocked = true;
+			}
+			SetDirection(dirs[sunIdx], frozenHeading, minElev);
+		} else {
+			SetElevation(dirs[sunIdx], minElev);
+		}
+	} else if (skySync.sunRising) {
+		if (!sunriseReleased) {
+			if (DirectX::XMScalarASinEst(dirs[sunIdx].z) >= minElev)
+				sunriseReleased = true;
+			else
+				SetElevation(dirs[sunIdx], minElev);
+		}
+	} else {
+		sunriseReleased = false;
+		sunsetHeadingLocked = false;
+	}
+}
+
 void SkySync::ShadowFader::SetLighting(const RE::Sky* sky, RE::NiPoint3 dir)
 {
 	ClampDirection(dir);
@@ -528,6 +541,22 @@ void SkySync::ShadowFader::SetLighting(const RE::Sky* sky, RE::NiPoint3 dir)
 	sky->sun->light->Update(updateData);
 }
 
+inline void SkySync::ShadowFader::SetDirection(RE::NiPoint3& dir, float headingRadians, float elevRadians)
+{
+	float sinElev, cosElev, sinHeading, cosHeading;
+	DirectX::XMScalarSinCosEst(&sinElev, &cosElev, elevRadians);
+	DirectX::XMScalarSinCosEst(&sinHeading, &cosHeading, headingRadians);
+
+	dir.x = cosElev * cosHeading;
+	dir.y = cosElev * sinHeading;
+	dir.z = sinElev;
+}
+
+inline void SkySync::ShadowFader::SetElevation(RE::NiPoint3& dir, float elevRadians)
+{
+	SetDirection(dir, std::atan2(dir.y, dir.x), elevRadians);
+}
+
 inline void SkySync::ShadowFader::ClampDirection(RE::NiPoint3& dir)
 {
 	const float minDegrees = globals::features::skySync.settings.MinShadowElevation;
@@ -536,14 +565,7 @@ inline void SkySync::ShadowFader::ClampDirection(RE::NiPoint3& dir)
 	if (elev >= minElev)
 		return;
 
-	const float heading = std::atan2(dir.y, dir.x);
-	float sinElev, cosElev, sinHeading, cosHeading;
-	DirectX::XMScalarSinCosEst(&sinElev, &cosElev, minElev);
-	DirectX::XMScalarSinCosEst(&sinHeading, &cosHeading, heading);
-
-	dir.x = cosElev * cosHeading;
-	dir.y = cosElev * sinHeading;
-	dir.z = sinElev;
+	SetElevation(dir, minElev);
 }
 
 

--- a/src/Features/SkySync.cpp
+++ b/src/Features/SkySync.cpp
@@ -1,5 +1,6 @@
 #include "SkySync.h"
 #include "../I18n/I18n.h"
+#include "RE/B/BSVolumetricLightingRenderData.h"
 
 #define I18N_KEY_PREFIX "feature.sky_sync."
 
@@ -115,6 +116,7 @@ void SkySync::DrawSettings()
 
 		ImGui::Text("Shadow target: %s", CasterNames[static_cast<int>(shadowFader.target)]);
 		ImGui::Text("Shadow dir:    (%.2f, %.2f, %.2f)", shadowFader.currentDir.x, shadowFader.currentDir.y, shadowFader.currentDir.z);
+		ImGui::Text("VL intensity factor: %.3f", shadowFader.vlIntensityFactor);
 		if (shadowFader.transitioning) {
 			const float t = settings.ShadowTransitionDuration > 0.0f ? shadowFader.fadeTimer / settings.ShadowTransitionDuration : 1.0f;
 			ImGui::ProgressBar(t, { -1.0f, 0.0f }, "");
@@ -164,6 +166,9 @@ void SkySync::PostPostLoad()
 
 	gSunPosition = reinterpret_cast<RE::NiPoint3*>(REL::RelocationID(527924, 414871).address());
 
+	gVolumetricLighting = reinterpret_cast<RE::BSVolumetricLightingRenderData*>(
+		REL::RelocationID(527719, 414629).address() - offsetof(RE::BSVolumetricLightingRenderData, red));
+
 	logger::info("[Sky Sync] Installed hooks");
 }
 
@@ -184,15 +189,18 @@ void SkySync::DisableOnConflict(std::string_view conflictName)
 
 void SkySync::OnSkyUpdateColors(RE::Sky* sky)
 {
-	if (!settings.Enabled || !sky || !settings.DimSunlightUnderHorizon)
+	if (!settings.Enabled || !sky)
 		return;
 
-	if (currentDim > 0.0f && currentDim < 1.0f) {
+	if (settings.DimSunlightUnderHorizon && currentDim > 0.0f && currentDim < 1.0f) {
 		auto& dirLight = sky->skyColor[static_cast<uint>(RE::TESWeather::ColorTypes::kSunlight)];
 		dirLight.red *= currentDim;
 		dirLight.green *= currentDim;
 		dirLight.blue *= currentDim;
 	}
+
+	if (gVolumetricLighting)
+		gVolumetricLighting->intensity *= shadowFader.vlIntensityFactor;
 }
 
 void SkySync::Sky_Update::thunk(RE::Sky* sky)
@@ -424,10 +432,6 @@ void SkySync::ShadowFader::Update(const RE::Sky* sky, RE::NiPoint3 dirs[], float
 {
 	auto isValidDir = [](const RE::NiPoint3& d) { return d.x != 0.0f || d.y != 0.0f || d.z != 0.0f; };
 
-	bool* const vlEnabled = globals::game::bEnableVolumetricLighting;
-	static bool vlSuppressed = false;
-	static bool vlSavedEnabled = true;
-
 	Caster best;
 
 	if (globals::features::skySync.currentDim <= 0.0f) {
@@ -437,12 +441,8 @@ void SkySync::ShadowFader::Update(const RE::Sky* sky, RE::NiPoint3 dirs[], float
 		if (!masserValid && !secundaValid) {
 			// No valid night caster — default to directly above (shadows point down)
 			currentDir = { 0.0f, 0.0f, 1.0f };
+			vlIntensityFactor = 0.0f;
 			SetLighting(sky, currentDir);
-			if (vlEnabled && !vlSuppressed) {
-				vlSavedEnabled = *vlEnabled;
-				*vlEnabled = false;
-				vlSuppressed = true;
-			}
 			return;
 		}
 
@@ -456,12 +456,8 @@ void SkySync::ShadowFader::Update(const RE::Sky* sky, RE::NiPoint3 dirs[], float
 		best = Caster::Sun;
 	}
 
-	if (vlSuppressed && vlEnabled) {
-		*vlEnabled = vlSavedEnabled;
-		vlSuppressed = false;
-	}
-
 	LockSunElevation(dirs);
+
 
 	// If best source changed, begin a new transition
 	if (best != target) {
@@ -474,6 +470,7 @@ void SkySync::ShadowFader::Update(const RE::Sky* sky, RE::NiPoint3 dirs[], float
 
 	if (!transitioning) {
 		currentDir = dirs[static_cast<int>(target)];
+		vlIntensityFactor = 1.0f;
 		SetLighting(sky, currentDir);
 		return;
 	}
@@ -494,6 +491,7 @@ void SkySync::ShadowFader::Update(const RE::Sky* sky, RE::NiPoint3 dirs[], float
 		transitioning = false;
 	}
 
+	vlIntensityFactor = ComputeVLFactor(currentDir, targetDir);
 	SetLighting(sky, currentDir);
 }
 
@@ -555,6 +553,14 @@ inline void SkySync::ShadowFader::SetDirection(RE::NiPoint3& dir, float headingR
 inline void SkySync::ShadowFader::SetElevation(RE::NiPoint3& dir, float elevRadians)
 {
 	SetDirection(dir, std::atan2(dir.y, dir.x), elevRadians);
+}
+
+float SkySync::ShadowFader::ComputeVLFactor(const RE::NiPoint3& current, const RE::NiPoint3& target)
+{
+	const float dot = std::clamp(current.Dot(target), -1.0f, 1.0f);
+	const float angle = DirectX::XMConvertToDegrees(DirectX::XMScalarACosEst(dot));
+
+	return std::clamp((VLFadeEndAngle - angle) / (VLFadeEndAngle - VLFadeStartAngle), 0.0f, 1.0f);
 }
 
 inline void SkySync::ShadowFader::ClampDirection(RE::NiPoint3& dir)

--- a/src/Features/SkySync.cpp
+++ b/src/Features/SkySync.cpp
@@ -1,5 +1,6 @@
 #include "SkySync.h"
 #include "../I18n/I18n.h"
+#include "RE/B/BSVolumetricLightingRenderData.h"
 
 #define I18N_KEY_PREFIX "feature.sky_sync."
 
@@ -115,6 +116,7 @@ void SkySync::DrawSettings()
 
 		ImGui::Text("Shadow target: %s", CasterNames[static_cast<int>(shadowFader.target)]);
 		ImGui::Text("Shadow dir:    (%.2f, %.2f, %.2f)", shadowFader.currentDir.x, shadowFader.currentDir.y, shadowFader.currentDir.z);
+		ImGui::Text("VL intensity factor: %.3f", shadowFader.vlIntensityFactor);
 		if (shadowFader.transitioning) {
 			const float t = settings.ShadowTransitionDuration > 0.0f ? shadowFader.fadeTimer / settings.ShadowTransitionDuration : 1.0f;
 			ImGui::ProgressBar(t, { -1.0f, 0.0f }, "");
@@ -164,6 +166,9 @@ void SkySync::PostPostLoad()
 
 	gSunPosition = reinterpret_cast<RE::NiPoint3*>(REL::RelocationID(527924, 414871).address());
 
+	gVolumetricLighting = reinterpret_cast<RE::BSVolumetricLightingRenderData*>(
+		REL::RelocationID(527719, 414629).address() - offsetof(RE::BSVolumetricLightingRenderData, red));
+
 	logger::info("[Sky Sync] Installed hooks");
 }
 
@@ -184,15 +189,18 @@ void SkySync::DisableOnConflict(std::string_view conflictName)
 
 void SkySync::OnSkyUpdateColors(RE::Sky* sky)
 {
-	if (!settings.Enabled || !sky || !settings.DimSunlightUnderHorizon)
+	if (!settings.Enabled || !sky)
 		return;
 
-	if (currentDim > 0.0f && currentDim < 1.0f) {
+	if (settings.DimSunlightUnderHorizon && currentDim > 0.0f && currentDim < 1.0f) {
 		auto& dirLight = sky->skyColor[static_cast<uint>(RE::TESWeather::ColorTypes::kSunlight)];
 		dirLight.red *= currentDim;
 		dirLight.green *= currentDim;
 		dirLight.blue *= currentDim;
 	}
+
+	if (gVolumetricLighting)
+		gVolumetricLighting->intensity *= shadowFader.vlIntensityFactor;
 }
 
 void SkySync::Sky_Update::thunk(RE::Sky* sky)
@@ -434,10 +442,6 @@ void SkySync::ShadowFader::Update(const RE::Sky* sky, RE::NiPoint3 dirs[], float
 {
 	auto isValidDir = [](const RE::NiPoint3& d) { return d.x != 0.0f || d.y != 0.0f || d.z != 0.0f; };
 
-	bool* const vlEnabled = globals::game::bEnableVolumetricLighting;
-	static bool vlSuppressed = false;
-	static bool vlSavedEnabled = true;
-
 	Caster best;
 
 	if (globals::features::skySync.currentDim <= 0.0f) {
@@ -447,12 +451,8 @@ void SkySync::ShadowFader::Update(const RE::Sky* sky, RE::NiPoint3 dirs[], float
 		if (!masserValid && !secundaValid) {
 			// No valid night caster — default to directly above (shadows point down)
 			currentDir = { 0.0f, 0.0f, 1.0f };
+			vlIntensityFactor = 0.0f;
 			SetLighting(sky, currentDir);
-			if (vlEnabled && !vlSuppressed) {
-				vlSavedEnabled = *vlEnabled;
-				*vlEnabled = false;
-				vlSuppressed = true;
-			}
 			return;
 		}
 
@@ -464,11 +464,6 @@ void SkySync::ShadowFader::Update(const RE::Sky* sky, RE::NiPoint3 dirs[], float
 			best = Caster::Secunda;
 	} else {
 		best = Caster::Sun;
-	}
-
-	if (vlSuppressed && vlEnabled) {
-		*vlEnabled = vlSavedEnabled;
-		vlSuppressed = false;
 	}
 
 	// If best source changed, begin a new transition
@@ -485,6 +480,7 @@ void SkySync::ShadowFader::Update(const RE::Sky* sky, RE::NiPoint3 dirs[], float
 		if (snap) {
 			transitioning = false;
 			currentDir = dirs[static_cast<int>(best)];
+			vlIntensityFactor = 1.0f;
 			SetLighting(sky, currentDir);
 			return;
 		}
@@ -492,6 +488,7 @@ void SkySync::ShadowFader::Update(const RE::Sky* sky, RE::NiPoint3 dirs[], float
 
 	if (!transitioning) {
 		currentDir = dirs[static_cast<int>(target)];
+		vlIntensityFactor = 1.0f;
 		SetLighting(sky, currentDir);
 		return;
 	}
@@ -512,6 +509,7 @@ void SkySync::ShadowFader::Update(const RE::Sky* sky, RE::NiPoint3 dirs[], float
 		transitioning = false;
 	}
 
+	vlIntensityFactor = ComputeVLFactor(currentDir, targetDir);
 	SetLighting(sky, currentDir);
 }
 
@@ -526,6 +524,14 @@ void SkySync::ShadowFader::SetLighting(const RE::Sky* sky, RE::NiPoint3 dir)
 
 	RE::NiUpdateData updateData;
 	sky->sun->light->Update(updateData);
+}
+
+float SkySync::ShadowFader::ComputeVLFactor(const RE::NiPoint3& current, const RE::NiPoint3& target)
+{
+	const float dot = std::clamp(current.Dot(target), -1.0f, 1.0f);
+	const float angle = DirectX::XMConvertToDegrees(DirectX::XMScalarACosEst(dot));
+
+	return std::clamp((VLFadeEndAngle - angle) / (VLFadeEndAngle - VLFadeStartAngle), 0.0f, 1.0f);
 }
 
 inline void SkySync::ShadowFader::ClampDirection(RE::NiPoint3& dir)

--- a/src/Features/SkySync.h
+++ b/src/Features/SkySync.h
@@ -114,9 +114,15 @@ private:
 		Caster previousTarget = Caster::Sun;
 		float fadeTimer = 0.0f;
 		bool transitioning = false;
+		bool sunriseReleased = false;
+		float frozenHeading = 0.0f;
+		bool sunsetHeadingLocked = false;
 
 		void Update(const RE::Sky* sky, RE::NiPoint3 dirs[], float intensities[], float fadeDuration, float fadeAdvance);
+		void LockSunElevation(RE::NiPoint3 dirs[]);
 		static void SetLighting(const RE::Sky* sky, RE::NiPoint3 dir);
+		static void SetDirection(RE::NiPoint3& dir, float headingRadians, float elevRadians);
+		static void SetElevation(RE::NiPoint3& dir, float elevRadians);
 		static void ClampDirection(RE::NiPoint3& dir);
 		void Reset();
 	};
@@ -127,6 +133,7 @@ private:
 	static constexpr float NorthernSunAngle = 90.0f + 35.0f;
 	static constexpr float VanillaSunAngle = 90.0f + 5.0f;
 	static constexpr float SecondsPerGameHour = 3600.0f;
+	static constexpr float SunsetHeadingLockThreshold = 0.5f;
 
 	inline static RE::NiPoint3* gSunPosition = nullptr;
 
@@ -138,6 +145,8 @@ private:
 
 	float4 colors[3] = {};
 	float currentDim = 1.0f;
+	bool sunSetting = false;
+	bool sunRising = false;
 	ShadowFader shadowFader;
 
 	void DisableOnConflict(std::string_view conflictName);
@@ -151,9 +160,6 @@ private:
 	void ProcessSun(const RE::Sky* sky, RE::NiPoint3 dirs[], float intensities[]);
 
 	void ProcessMoon(const RE::Sky* sky, Caster type, RE::NiPoint3 dirs[], float intensities[]);
-
-	static bool IsNight(const RE::Sky* sky);
-	static bool IsDaytime(const RE::Sky* sky);
 
 	static void CalculateSunDirectionAndDistance(const RE::Sun* sun, RE::NiPoint3& outDir, float& outDistance);
 

--- a/src/Features/SkySync.h
+++ b/src/Features/SkySync.h
@@ -114,10 +114,12 @@ private:
 		Caster previousTarget = Caster::Sun;
 		float fadeTimer = 0.0f;
 		bool transitioning = false;
+		float vlIntensityFactor = 1.0f;
 
 		void Update(const RE::Sky* sky, RE::NiPoint3 dirs[], float intensities[], float fadeDuration, float fadeAdvance);
 		static void SetLighting(const RE::Sky* sky, RE::NiPoint3 dir);
 		static void ClampDirection(RE::NiPoint3& dir);
+		static float ComputeVLFactor(const RE::NiPoint3& current, const RE::NiPoint3& target);
 		void Reset();
 	};
 
@@ -127,8 +129,11 @@ private:
 	static constexpr float NorthernSunAngle = 90.0f + 35.0f;
 	static constexpr float VanillaSunAngle = 90.0f + 5.0f;
 	static constexpr float SecondsPerGameHour = 3600.0f;
+	static constexpr float VLFadeStartAngle = 2.0f;
+	static constexpr float VLFadeEndAngle = 10.0f;
 
 	inline static RE::NiPoint3* gSunPosition = nullptr;
+	RE::BSVolumetricLightingRenderData* gVolumetricLighting = nullptr;
 
 	bool moonAndStarsLoaded = false;
 	RE::TESObjectCELL* currentCell = nullptr;

--- a/src/Features/SkySync.h
+++ b/src/Features/SkySync.h
@@ -133,7 +133,7 @@ private:
 	static constexpr float VLFadeEndAngle = 10.0f;
 
 	inline static RE::NiPoint3* gSunPosition = nullptr;
-	RE::BSVolumetricLightingRenderData* gVolumetricLighting = nullptr;
+	inline static RE::BSVolumetricLightingRenderData* gVolumetricLighting = nullptr;
 
 	bool moonAndStarsLoaded = false;
 	RE::TESObjectCELL* currentCell = nullptr;

--- a/src/Features/SkySync.h
+++ b/src/Features/SkySync.h
@@ -140,7 +140,7 @@ private:
 	static constexpr float VLFadeEndAngle = 10.0f;
 
 	inline static RE::NiPoint3* gSunPosition = nullptr;
-	RE::BSVolumetricLightingRenderData* gVolumetricLighting = nullptr;
+	inline static RE::BSVolumetricLightingRenderData* gVolumetricLighting = nullptr;
 
 	bool moonAndStarsLoaded = false;
 	RE::TESObjectCELL* currentCell = nullptr;

--- a/src/Features/SkySync.h
+++ b/src/Features/SkySync.h
@@ -117,6 +117,7 @@ private:
 		bool sunriseReleased = false;
 		float frozenHeading = 0.0f;
 		bool sunsetHeadingLocked = false;
+		float vlIntensityFactor = 1.0f;
 
 		void Update(const RE::Sky* sky, RE::NiPoint3 dirs[], float intensities[], float fadeDuration, float fadeAdvance);
 		void LockSunElevation(RE::NiPoint3 dirs[]);
@@ -124,6 +125,7 @@ private:
 		static void SetDirection(RE::NiPoint3& dir, float headingRadians, float elevRadians);
 		static void SetElevation(RE::NiPoint3& dir, float elevRadians);
 		static void ClampDirection(RE::NiPoint3& dir);
+		static float ComputeVLFactor(const RE::NiPoint3& current, const RE::NiPoint3& target);
 		void Reset();
 	};
 
@@ -134,8 +136,11 @@ private:
 	static constexpr float VanillaSunAngle = 90.0f + 5.0f;
 	static constexpr float SecondsPerGameHour = 3600.0f;
 	static constexpr float SunsetHeadingLockThreshold = 0.5f;
+	static constexpr float VLFadeStartAngle = 2.0f;
+	static constexpr float VLFadeEndAngle = 10.0f;
 
 	inline static RE::NiPoint3* gSunPosition = nullptr;
+	RE::BSVolumetricLightingRenderData* gVolumetricLighting = nullptr;
 
 	bool moonAndStarsLoaded = false;
 	RE::TESObjectCELL* currentCell = nullptr;

--- a/src/Features/UnifiedWater.cpp
+++ b/src/Features/UnifiedWater.cpp
@@ -587,6 +587,12 @@ void UnifiedWater::BGSTerrainBlock_Attach::thunk(RE::BGSTerrainBlock* block)
 		return;
 	}
 
+	// Reserve up front so AddWater can't reallocate waterObjects mid-loop and free a buffer other threads may be iterating.
+	{
+		RE::BSSpinLockGuard guard(waterSystem->lock);
+		waterSystem->waterObjects.reserve(waterSystem->waterObjects.size() + static_cast<std::uint32_t>(built.size()));
+	}
+
 	for (auto& [shape, instruction] : built) {
 		waterSystem->AddWater(shape, instruction->form.ptr, instruction->waterHeight, nullptr, true, false);
 
@@ -602,9 +608,12 @@ void UnifiedWater::BGSTerrainBlock_Attach::thunk(RE::BGSTerrainBlock* block)
 			waterShaderProp->waterFlags = waterFlags;
 		}
 
-		// Remove from WaterSystem, will manage it ourselves
-		if (!waterSystem->waterObjects.empty()) {
-			waterSystem->waterObjects.pop_back();
+		// Remove from WaterSystem, will manage it ourselves. Lock: our only direct edit to the shared list.
+		{
+			RE::BSSpinLockGuard guard(waterSystem->lock);
+			if (!waterSystem->waterObjects.empty()) {
+				waterSystem->waterObjects.pop_back();
+			}
 		}
 	}
 

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -520,9 +520,11 @@ namespace Hooks
 	{
 		static void thunk(RE::BSGraphics::Renderer* This, RE::RENDER_TARGETS::RENDER_TARGET a_target, RE::BSGraphics::RenderTargetProperties* a_properties)
 		{
-			auto properties = *a_properties;
-			globals::state->ModifyRenderTarget(a_target, properties);
-			func(This, a_target, &properties);
+			// Modify in place and restore so chained hooks keep a stable pointer.
+			const auto saved = *a_properties;
+			globals::state->ModifyRenderTarget(a_target, *a_properties);
+			func(This, a_target, a_properties);
+			*a_properties = saved;
 		}
 		static inline REL::Relocation<decltype(thunk)> func;
 	};


### PR DESCRIPTION
better solution than my previous approach, less invasive and works at all times. When the shadow direction deviates too much from the target, VL gets lerped to 0 so that it's not obvious that it is desynced. This way there is never a "snap" when the VL resyncs and gets re-enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced Sky Sync’s volumetric lighting transitions with direction-angle-based fading for smoother lighting changes, including Debug UI visibility and safer early exits when Sky Sync is inactive.
* **Bug Fixes**
  * Improved weather forcing in the editor by releasing prior weather overrides when reinitializing.
  * Corrected render-target hook handling to preserve the provided properties consistently.
* **Performance**
  * Reduced shared-water list reallocations and ensured safe locked updates during water shape attachment.
* **Configuration**
  * Updated Hair Specular shader feature version to 1-1-2.
* **Chores**
  * Shortened GitHub release Discord embeds to the first horizontal-rule section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->