### PR TITLE
fix(sky-sync): drifting sun at dawn and dusk

### DIFF
--- a/src/Features/SkySync.cpp
+++ b/src/Features/SkySync.cpp
@@ -415,6 +415,9 @@ void SkySync::ShadowFader::Reset()
 	previousTarget = Caster::Sun;
 	fadeTimer = 0.0f;
 	transitioning = false;
+	sunriseReleased = false;
+	frozenHeading = 0.0f;
+	sunsetHeadingLocked = false;
 }
 
 void SkySync::ShadowFader::Update(const RE::Sky* sky, RE::NiPoint3 dirs[], float intensities[], float fadeDuration, float fadeAdvance)

--- a/src/Features/SkySync.cpp
+++ b/src/Features/SkySync.cpp
@@ -242,6 +242,9 @@ void SkySync::Update(const RE::Sky* sky)
 		const float sunsetMiddle = (timing.sunset.begin + timing.sunset.end) / 12.0f;
 		const float sunsetEnd = timing.sunset.end / 6.0f;
 
+		sunSetting = hour >= sunsetMiddle && hour < sunsetEnd;
+		sunRising = hour >= sunriseBegin && hour < sunriseMiddle;
+
 		if (hour >= sunsetMiddle && hour < sunsetEnd) {
 			float range = sunsetEnd - sunsetMiddle;
 			float t = range > 0.0f ? (hour - sunsetMiddle) / range : 1.0f;
@@ -257,6 +260,8 @@ void SkySync::Update(const RE::Sky* sky)
 		}
 	} else {
 		currentDim = 1.0f;
+		sunSetting = false;
+		sunRising = false;
 	}
 
 	RE::NiPoint3 directions[3] = {};
@@ -368,24 +373,6 @@ void SkySync::ProcessMoon(const RE::Sky* sky, const Caster type, RE::NiPoint3 di
 	intensities[idx] = color.w;
 }
 
-bool SkySync::IsNight(const RE::Sky* sky)
-{
-	if (!sky || !sky->currentClimate)
-		return false;
-	const auto& timing = sky->currentClimate->timing;
-	const float hour = sky->currentGameHour;
-	return hour >= timing.sunset.end / 6.0f || hour < timing.sunrise.begin / 6.0f;
-}
-
-bool SkySync::IsDaytime(const RE::Sky* sky)
-{
-	if (!sky || !sky->currentClimate)
-		return false;
-	const auto& timing = sky->currentClimate->timing;
-	const float hour = sky->currentGameHour;
-	return hour >= timing.sunrise.end / 6.0f && hour < timing.sunset.begin / 6.0f;
-}
-
 inline void SkySync::CalculateSunDirectionAndDistance(const RE::Sun* sun, RE::NiPoint3& outDir, float& outDistance)
 {
 	outDir = sun->root->local.translate;
@@ -471,6 +458,8 @@ void SkySync::ShadowFader::Update(const RE::Sky* sky, RE::NiPoint3 dirs[], float
 		vlSuppressed = false;
 	}
 
+	LockSunElevation(dirs);
+
 	// If best source changed, begin a new transition
 	if (best != target) {
 		previousTarget = target;
@@ -478,16 +467,6 @@ void SkySync::ShadowFader::Update(const RE::Sky* sky, RE::NiPoint3 dirs[], float
 		startDir = currentDir;
 		fadeTimer = 0.0f;
 		transitioning = true;
-
-		// Snap instantly if transitioning to sun during daytime or to moon during full night
-		bool snap = (best == Caster::Sun && IsDaytime(sky)) ||
-		            ((best == Caster::Masser || best == Caster::Secunda) && IsNight(sky));
-		if (snap) {
-			transitioning = false;
-			currentDir = dirs[static_cast<int>(best)];
-			SetLighting(sky, currentDir);
-			return;
-		}
 	}
 
 	if (!transitioning) {
@@ -515,6 +494,37 @@ void SkySync::ShadowFader::Update(const RE::Sky* sky, RE::NiPoint3 dirs[], float
 	SetLighting(sky, currentDir);
 }
 
+void SkySync::ShadowFader::LockSunElevation(RE::NiPoint3 dirs[])
+{
+	// Dusk: lock elevation to the minimum so the shadow can't tilt back up as the sun goes under,
+	// and once dimming passes the threshold lock heading too so it stops sweeping while the VL fades.
+	// Dawn: lock at the minimum until the sun naturally rises above it, then follow it.
+	const auto& skySync = globals::features::skySync;
+	const int sunIdx = static_cast<int>(Caster::Sun);
+	const float minElev = DirectX::XMConvertToRadians(skySync.settings.MinShadowElevation);
+	if (skySync.sunSetting) {
+		if (skySync.currentDim <= SunsetHeadingLockThreshold) {
+			if (!sunsetHeadingLocked) {
+				frozenHeading = std::atan2(dirs[sunIdx].y, dirs[sunIdx].x);
+				sunsetHeadingLocked = true;
+			}
+			SetDirection(dirs[sunIdx], frozenHeading, minElev);
+		} else {
+			SetElevation(dirs[sunIdx], minElev);
+		}
+	} else if (skySync.sunRising) {
+		if (!sunriseReleased) {
+			if (DirectX::XMScalarASinEst(dirs[sunIdx].z) >= minElev)
+				sunriseReleased = true;
+			else
+				SetElevation(dirs[sunIdx], minElev);
+		}
+	} else {
+		sunriseReleased = false;
+		sunsetHeadingLocked = false;
+	}
+}
+
 void SkySync::ShadowFader::SetLighting(const RE::Sky* sky, RE::NiPoint3 dir)
 {
 	ClampDirection(dir);
@@ -528,6 +538,22 @@ void SkySync::ShadowFader::SetLighting(const RE::Sky* sky, RE::NiPoint3 dir)
 	sky->sun->light->Update(updateData);
 }
 
+inline void SkySync::ShadowFader::SetDirection(RE::NiPoint3& dir, float headingRadians, float elevRadians)
+{
+	float sinElev, cosElev, sinHeading, cosHeading;
+	DirectX::XMScalarSinCosEst(&sinElev, &cosElev, elevRadians);
+	DirectX::XMScalarSinCosEst(&sinHeading, &cosHeading, headingRadians);
+
+	dir.x = cosElev * cosHeading;
+	dir.y = cosElev * sinHeading;
+	dir.z = sinElev;
+}
+
+inline void SkySync::ShadowFader::SetElevation(RE::NiPoint3& dir, float elevRadians)
+{
+	SetDirection(dir, std::atan2(dir.y, dir.x), elevRadians);
+}
+
 inline void SkySync::ShadowFader::ClampDirection(RE::NiPoint3& dir)
 {
 	const float minDegrees = globals::features::skySync.settings.MinShadowElevation;
@@ -536,14 +562,7 @@ inline void SkySync::ShadowFader::ClampDirection(RE::NiPoint3& dir)
 	if (elev >= minElev)
 		return;
 
-	const float heading = std::atan2(dir.y, dir.x);
-	float sinElev, cosElev, sinHeading, cosHeading;
-	DirectX::XMScalarSinCosEst(&sinElev, &cosElev, minElev);
-	DirectX::XMScalarSinCosEst(&sinHeading, &cosHeading, heading);
-
-	dir.x = cosElev * cosHeading;
-	dir.y = cosElev * sinHeading;
-	dir.z = sinElev;
+	SetElevation(dir, minElev);
 }
 
 

--- a/src/Features/SkySync.h
+++ b/src/Features/SkySync.h
@@ -114,9 +114,15 @@ private:
 		Caster previousTarget = Caster::Sun;
 		float fadeTimer = 0.0f;
 		bool transitioning = false;
+		bool sunriseReleased = false;
+		float frozenHeading = 0.0f;
+		bool sunsetHeadingLocked = false;
 
 		void Update(const RE::Sky* sky, RE::NiPoint3 dirs[], float intensities[], float fadeDuration, float fadeAdvance);
+		void LockSunElevation(RE::NiPoint3 dirs[]);
 		static void SetLighting(const RE::Sky* sky, RE::NiPoint3 dir);
+		static void SetDirection(RE::NiPoint3& dir, float headingRadians, float elevRadians);
+		static void SetElevation(RE::NiPoint3& dir, float elevRadians);
 		static void ClampDirection(RE::NiPoint3& dir);
 		void Reset();
 	};
@@ -127,6 +133,7 @@ private:
 	static constexpr float NorthernSunAngle = 90.0f + 35.0f;
 	static constexpr float VanillaSunAngle = 90.0f + 5.0f;
 	static constexpr float SecondsPerGameHour = 3600.0f;
+	static constexpr float SunsetHeadingLockThreshold = 0.5f;
 
 	inline static RE::NiPoint3* gSunPosition = nullptr;
 
@@ -138,6 +145,8 @@ private:
 
 	float4 colors[3] = {};
 	float currentDim = 1.0f;
+	bool sunSetting = false;
+	bool sunRising = false;
 	ShadowFader shadowFader;
 
 	void DisableOnConflict(std::string_view conflictName);
@@ -151,9 +160,6 @@ private:
 	void ProcessSun(const RE::Sky* sky, RE::NiPoint3 dirs[], float intensities[]);
 
 	void ProcessMoon(const RE::Sky* sky, Caster type, RE::NiPoint3 dirs[], float intensities[]);
-
-	static bool IsNight(const RE::Sky* sky);
-	static bool IsDaytime(const RE::Sky* sky);
 
 	static void CalculateSunDirectionAndDistance(const RE::Sun* sun, RE::NiPoint3& outDir, float& outDistance);
 


### PR DESCRIPTION
reworks how the sun shadow fader is handled at dawn and dusk:
- removed snapping logic
- at dawn the shadow fader elevation will be locked to the minshadowelevation value until the sun comes up past this elevation.
- at dusk the shadow fader will be locked when the sun goes below the minshadowelevation value, and halfway through the shadow dimming cycle the horizonal movement is also locked.

This ensures that the VL and shadows properly stay at the horizon until the sun goes up and never bounce back up after the sun goes down.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved sun shadow fading by refining how sun direction and elevation are constrained during sunrise and sunset transitions for more natural-looking lighting.
  * Updated sunrise/sunset detection to track setting/rising state when climate timing is available, and clear it when timing data is missing.
  * Enhanced shadow behavior stability when climate data is unavailable, removing earlier snap-to-target behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->