### PR TITLE
fix(sky-sync): modulate VL when it's desynced

### DIFF
--- a/src/Features/SkySync.cpp
+++ b/src/Features/SkySync.cpp
@@ -1,5 +1,6 @@
 #include "SkySync.h"
 #include "../I18n/I18n.h"
+#include "RE/B/BSVolumetricLightingRenderData.h"
 
 #define I18N_KEY_PREFIX "feature.sky_sync."
 
@@ -115,6 +116,7 @@ void SkySync::DrawSettings()
 
 		ImGui::Text("Shadow target: %s", CasterNames[static_cast<int>(shadowFader.target)]);
 		ImGui::Text("Shadow dir:    (%.2f, %.2f, %.2f)", shadowFader.currentDir.x, shadowFader.currentDir.y, shadowFader.currentDir.z);
+		ImGui::Text("VL intensity factor: %.3f", shadowFader.vlIntensityFactor);
 		if (shadowFader.transitioning) {
 			const float t = settings.ShadowTransitionDuration > 0.0f ? shadowFader.fadeTimer / settings.ShadowTransitionDuration : 1.0f;
 			ImGui::ProgressBar(t, { -1.0f, 0.0f }, "");
@@ -164,6 +166,9 @@ void SkySync::PostPostLoad()
 
 	gSunPosition = reinterpret_cast<RE::NiPoint3*>(REL::RelocationID(527924, 414871).address());
 
+	gVolumetricLighting = reinterpret_cast<RE::BSVolumetricLightingRenderData*>(
+		REL::RelocationID(527719, 414629).address() - offsetof(RE::BSVolumetricLightingRenderData, red));
+
 	logger::info("[Sky Sync] Installed hooks");
 }
 
@@ -184,15 +189,18 @@ void SkySync::DisableOnConflict(std::string_view conflictName)
 
 void SkySync::OnSkyUpdateColors(RE::Sky* sky)
 {
-	if (!settings.Enabled || !sky || !settings.DimSunlightUnderHorizon)
+	if (!settings.Enabled || !sky)
 		return;
 
-	if (currentDim > 0.0f && currentDim < 1.0f) {
+	if (settings.DimSunlightUnderHorizon && currentDim > 0.0f && currentDim < 1.0f) {
 		auto& dirLight = sky->skyColor[static_cast<uint>(RE::TESWeather::ColorTypes::kSunlight)];
 		dirLight.red *= currentDim;
 		dirLight.green *= currentDim;
 		dirLight.blue *= currentDim;
 	}
+
+	if (gVolumetricLighting)
+		gVolumetricLighting->intensity *= shadowFader.vlIntensityFactor;
 }
 
 void SkySync::Sky_Update::thunk(RE::Sky* sky)
@@ -424,10 +432,6 @@ void SkySync::ShadowFader::Update(const RE::Sky* sky, RE::NiPoint3 dirs[], float
 {
 	auto isValidDir = [](const RE::NiPoint3& d) { return d.x != 0.0f || d.y != 0.0f || d.z != 0.0f; };
 
-	bool* const vlEnabled = globals::game::bEnableVolumetricLighting;
-	static bool vlSuppressed = false;
-	static bool vlSavedEnabled = true;
-
 	Caster best;
 
 	if (globals::features::skySync.currentDim <= 0.0f) {
@@ -437,12 +441,8 @@ void SkySync::ShadowFader::Update(const RE::Sky* sky, RE::NiPoint3 dirs[], float
 		if (!masserValid && !secundaValid) {
 			// No valid night caster — default to directly above (shadows point down)
 			currentDir = { 0.0f, 0.0f, 1.0f };
+			vlIntensityFactor = 0.0f;
 			SetLighting(sky, currentDir);
-			if (vlEnabled && !vlSuppressed) {
-				vlSavedEnabled = *vlEnabled;
-				*vlEnabled = false;
-				vlSuppressed = true;
-			}
 			return;
 		}
 
@@ -456,12 +456,8 @@ void SkySync::ShadowFader::Update(const RE::Sky* sky, RE::NiPoint3 dirs[], float
 		best = Caster::Sun;
 	}
 
-	if (vlSuppressed && vlEnabled) {
-		*vlEnabled = vlSavedEnabled;
-		vlSuppressed = false;
-	}
-
 	LockSunElevation(dirs);
+
 
 	// If best source changed, begin a new transition
 	if (best != target) {
@@ -474,6 +470,7 @@ void SkySync::ShadowFader::Update(const RE::Sky* sky, RE::NiPoint3 dirs[], float
 
 	if (!transitioning) {
 		currentDir = dirs[static_cast<int>(target)];
+		vlIntensityFactor = 1.0f;
 		SetLighting(sky, currentDir);
 		return;
 	}
@@ -494,6 +491,7 @@ void SkySync::ShadowFader::Update(const RE::Sky* sky, RE::NiPoint3 dirs[], float
 		transitioning = false;
 	}
 
+	vlIntensityFactor = ComputeVLFactor(currentDir, targetDir);
 	SetLighting(sky, currentDir);
 }
 
@@ -555,6 +553,14 @@ inline void SkySync::ShadowFader::SetDirection(RE::NiPoint3& dir, float headingR
 inline void SkySync::ShadowFader::SetElevation(RE::NiPoint3& dir, float elevRadians)
 {
 	SetDirection(dir, std::atan2(dir.y, dir.x), elevRadians);
+}
+
+float SkySync::ShadowFader::ComputeVLFactor(const RE::NiPoint3& current, const RE::NiPoint3& target)
+{
+	const float dot = std::clamp(current.Dot(target), -1.0f, 1.0f);
+	const float angle = DirectX::XMConvertToDegrees(DirectX::XMScalarACosEst(dot));
+
+	return std::clamp((VLFadeEndAngle - angle) / (VLFadeEndAngle - VLFadeStartAngle), 0.0f, 1.0f);
 }
 
 inline void SkySync::ShadowFader::ClampDirection(RE::NiPoint3& dir)

--- a/src/Features/SkySync.cpp
+++ b/src/Features/SkySync.cpp
@@ -1,5 +1,6 @@
 #include "SkySync.h"
 #include "../I18n/I18n.h"
+#include "RE/B/BSVolumetricLightingRenderData.h"
 
 #define I18N_KEY_PREFIX "feature.sky_sync."
 
@@ -115,6 +116,7 @@ void SkySync::DrawSettings()
 
 		ImGui::Text("Shadow target: %s", CasterNames[static_cast<int>(shadowFader.target)]);
 		ImGui::Text("Shadow dir:    (%.2f, %.2f, %.2f)", shadowFader.currentDir.x, shadowFader.currentDir.y, shadowFader.currentDir.z);
+		ImGui::Text("VL intensity factor: %.3f", shadowFader.vlIntensityFactor);
 		if (shadowFader.transitioning) {
 			const float t = settings.ShadowTransitionDuration > 0.0f ? shadowFader.fadeTimer / settings.ShadowTransitionDuration : 1.0f;
 			ImGui::ProgressBar(t, { -1.0f, 0.0f }, "");
@@ -164,6 +166,9 @@ void SkySync::PostPostLoad()
 
 	gSunPosition = reinterpret_cast<RE::NiPoint3*>(REL::RelocationID(527924, 414871).address());
 
+	gVolumetricLighting = reinterpret_cast<RE::BSVolumetricLightingRenderData*>(
+		REL::RelocationID(527719, 414629).address() - offsetof(RE::BSVolumetricLightingRenderData, red));
+
 	logger::info("[Sky Sync] Installed hooks");
 }
 
@@ -184,15 +189,18 @@ void SkySync::DisableOnConflict(std::string_view conflictName)
 
 void SkySync::OnSkyUpdateColors(RE::Sky* sky)
 {
-	if (!settings.Enabled || !sky || !settings.DimSunlightUnderHorizon)
+	if (!settings.Enabled || !sky)
 		return;
 
-	if (currentDim > 0.0f && currentDim < 1.0f) {
+	if (settings.DimSunlightUnderHorizon && currentDim > 0.0f && currentDim < 1.0f) {
 		auto& dirLight = sky->skyColor[static_cast<uint>(RE::TESWeather::ColorTypes::kSunlight)];
 		dirLight.red *= currentDim;
 		dirLight.green *= currentDim;
 		dirLight.blue *= currentDim;
 	}
+
+	if (gVolumetricLighting)
+		gVolumetricLighting->intensity *= shadowFader.vlIntensityFactor;
 }
 
 void SkySync::Sky_Update::thunk(RE::Sky* sky)
@@ -434,10 +442,6 @@ void SkySync::ShadowFader::Update(const RE::Sky* sky, RE::NiPoint3 dirs[], float
 {
 	auto isValidDir = [](const RE::NiPoint3& d) { return d.x != 0.0f || d.y != 0.0f || d.z != 0.0f; };
 
-	bool* const vlEnabled = globals::game::bEnableVolumetricLighting;
-	static bool vlSuppressed = false;
-	static bool vlSavedEnabled = true;
-
 	Caster best;
 
 	if (globals::features::skySync.currentDim <= 0.0f) {
@@ -447,12 +451,8 @@ void SkySync::ShadowFader::Update(const RE::Sky* sky, RE::NiPoint3 dirs[], float
 		if (!masserValid && !secundaValid) {
 			// No valid night caster — default to directly above (shadows point down)
 			currentDir = { 0.0f, 0.0f, 1.0f };
+			vlIntensityFactor = 0.0f;
 			SetLighting(sky, currentDir);
-			if (vlEnabled && !vlSuppressed) {
-				vlSavedEnabled = *vlEnabled;
-				*vlEnabled = false;
-				vlSuppressed = true;
-			}
 			return;
 		}
 
@@ -464,11 +464,6 @@ void SkySync::ShadowFader::Update(const RE::Sky* sky, RE::NiPoint3 dirs[], float
 			best = Caster::Secunda;
 	} else {
 		best = Caster::Sun;
-	}
-
-	if (vlSuppressed && vlEnabled) {
-		*vlEnabled = vlSavedEnabled;
-		vlSuppressed = false;
 	}
 
 	// If best source changed, begin a new transition
@@ -485,6 +480,7 @@ void SkySync::ShadowFader::Update(const RE::Sky* sky, RE::NiPoint3 dirs[], float
 		if (snap) {
 			transitioning = false;
 			currentDir = dirs[static_cast<int>(best)];
+			vlIntensityFactor = 1.0f;
 			SetLighting(sky, currentDir);
 			return;
 		}
@@ -492,6 +488,7 @@ void SkySync::ShadowFader::Update(const RE::Sky* sky, RE::NiPoint3 dirs[], float
 
 	if (!transitioning) {
 		currentDir = dirs[static_cast<int>(target)];
+		vlIntensityFactor = 1.0f;
 		SetLighting(sky, currentDir);
 		return;
 	}
@@ -512,6 +509,7 @@ void SkySync::ShadowFader::Update(const RE::Sky* sky, RE::NiPoint3 dirs[], float
 		transitioning = false;
 	}
 
+	vlIntensityFactor = ComputeVLFactor(currentDir, targetDir);
 	SetLighting(sky, currentDir);
 }
 
@@ -526,6 +524,14 @@ void SkySync::ShadowFader::SetLighting(const RE::Sky* sky, RE::NiPoint3 dir)
 
 	RE::NiUpdateData updateData;
 	sky->sun->light->Update(updateData);
+}
+
+float SkySync::ShadowFader::ComputeVLFactor(const RE::NiPoint3& current, const RE::NiPoint3& target)
+{
+	const float dot = std::clamp(current.Dot(target), -1.0f, 1.0f);
+	const float angle = DirectX::XMConvertToDegrees(DirectX::XMScalarACosEst(dot));
+
+	return std::clamp((VLFadeEndAngle - angle) / (VLFadeEndAngle - VLFadeStartAngle), 0.0f, 1.0f);
 }
 
 inline void SkySync::ShadowFader::ClampDirection(RE::NiPoint3& dir)

--- a/src/Features/SkySync.h
+++ b/src/Features/SkySync.h
@@ -114,10 +114,12 @@ private:
 		Caster previousTarget = Caster::Sun;
 		float fadeTimer = 0.0f;
 		bool transitioning = false;
+		float vlIntensityFactor = 1.0f;
 
 		void Update(const RE::Sky* sky, RE::NiPoint3 dirs[], float intensities[], float fadeDuration, float fadeAdvance);
 		static void SetLighting(const RE::Sky* sky, RE::NiPoint3 dir);
 		static void ClampDirection(RE::NiPoint3& dir);
+		static float ComputeVLFactor(const RE::NiPoint3& current, const RE::NiPoint3& target);
 		void Reset();
 	};
 
@@ -127,8 +129,11 @@ private:
 	static constexpr float NorthernSunAngle = 90.0f + 35.0f;
 	static constexpr float VanillaSunAngle = 90.0f + 5.0f;
 	static constexpr float SecondsPerGameHour = 3600.0f;
+	static constexpr float VLFadeStartAngle = 2.0f;
+	static constexpr float VLFadeEndAngle = 10.0f;
 
 	inline static RE::NiPoint3* gSunPosition = nullptr;
+	RE::BSVolumetricLightingRenderData* gVolumetricLighting = nullptr;
 
 	bool moonAndStarsLoaded = false;
 	RE::TESObjectCELL* currentCell = nullptr;

--- a/src/Features/SkySync.h
+++ b/src/Features/SkySync.h
@@ -133,7 +133,7 @@ private:
 	static constexpr float VLFadeEndAngle = 10.0f;
 
 	inline static RE::NiPoint3* gSunPosition = nullptr;
-	RE::BSVolumetricLightingRenderData* gVolumetricLighting = nullptr;
+	inline static RE::BSVolumetricLightingRenderData* gVolumetricLighting = nullptr;
 
 	bool moonAndStarsLoaded = false;
 	RE::TESObjectCELL* currentCell = nullptr;

--- a/src/Features/SkySync.h
+++ b/src/Features/SkySync.h
@@ -140,7 +140,7 @@ private:
 	static constexpr float VLFadeEndAngle = 10.0f;
 
 	inline static RE::NiPoint3* gSunPosition = nullptr;
-	RE::BSVolumetricLightingRenderData* gVolumetricLighting = nullptr;
+	inline static RE::BSVolumetricLightingRenderData* gVolumetricLighting = nullptr;
 
 	bool moonAndStarsLoaded = false;
 	RE::TESObjectCELL* currentCell = nullptr;

--- a/src/Features/SkySync.h
+++ b/src/Features/SkySync.h
@@ -117,6 +117,7 @@ private:
 		bool sunriseReleased = false;
 		float frozenHeading = 0.0f;
 		bool sunsetHeadingLocked = false;
+		float vlIntensityFactor = 1.0f;
 
 		void Update(const RE::Sky* sky, RE::NiPoint3 dirs[], float intensities[], float fadeDuration, float fadeAdvance);
 		void LockSunElevation(RE::NiPoint3 dirs[]);
@@ -124,6 +125,7 @@ private:
 		static void SetDirection(RE::NiPoint3& dir, float headingRadians, float elevRadians);
 		static void SetElevation(RE::NiPoint3& dir, float elevRadians);
 		static void ClampDirection(RE::NiPoint3& dir);
+		static float ComputeVLFactor(const RE::NiPoint3& current, const RE::NiPoint3& target);
 		void Reset();
 	};
 
@@ -134,8 +136,11 @@ private:
 	static constexpr float VanillaSunAngle = 90.0f + 5.0f;
 	static constexpr float SecondsPerGameHour = 3600.0f;
 	static constexpr float SunsetHeadingLockThreshold = 0.5f;
+	static constexpr float VLFadeStartAngle = 2.0f;
+	static constexpr float VLFadeEndAngle = 10.0f;
 
 	inline static RE::NiPoint3* gSunPosition = nullptr;
+	RE::BSVolumetricLightingRenderData* gVolumetricLighting = nullptr;
 
 	bool moonAndStarsLoaded = false;
 	RE::TESObjectCELL* currentCell = nullptr;


### PR DESCRIPTION
better solution than my previous approach, less invasive and works at all times. When the shadow direction deviates too much from the target, VL gets lerped to 0 so that it's not obvious that it is desynced. This way there is never a "snap" when the VL resyncs and gets re-enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Volumetric lighting now dynamically scales in intensity based on sun position during shadow transitions, providing smoother visual transitions
  * Debug display added to monitor volumetric lighting intensity levels

<!-- end of auto-generated comment: release notes by coderabbit.ai -->