### PR TITLE
fix(hooks): add extra guards to prevent null deref

### DIFF
--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -536,9 +536,10 @@ namespace Hooks
 	{
 		static void thunk(RE::BSGraphics::Renderer* This, RE::RENDER_TARGETS::RENDER_TARGET a_target, RE::BSGraphics::RenderTargetProperties* a_properties)
 		{
-			auto properties = *a_properties;
-			properties.format.set(RE::BSGraphics::Format::kR16G16B16A16_FLOAT);
-			func(This, a_target, &properties);
+			const auto saved = *a_properties;
+			a_properties->format.set(RE::BSGraphics::Format::kR16G16B16A16_FLOAT);
+			func(This, a_target, a_properties);
+			*a_properties = saved;
 		}
 		static inline REL::Relocation<decltype(thunk)> func;
 	};
@@ -547,9 +548,10 @@ namespace Hooks
 	{
 		static void thunk(RE::BSGraphics::Renderer* This, RE::RENDER_TARGETS::RENDER_TARGET a_target, RE::BSGraphics::RenderTargetProperties* a_properties)
 		{
-			auto properties = *a_properties;
-			properties.format.set(RE::BSGraphics::Format::kR16G16B16A16_FLOAT);
-			func(This, a_target, &properties);
+			const auto saved = *a_properties;
+			a_properties->format.set(RE::BSGraphics::Format::kR16G16B16A16_FLOAT);
+			func(This, a_target, a_properties);
+			*a_properties = saved;
 		}
 		static inline REL::Relocation<decltype(thunk)> func;
 	};
@@ -563,9 +565,10 @@ namespace Hooks
 	{
 		static void thunk(RE::BSGraphics::Renderer* This, RE::RENDER_TARGETS::RENDER_TARGET a_target, RE::BSGraphics::RenderTargetProperties* a_properties)
 		{
-			auto properties = *a_properties;
-			globals::state->ModifyRenderTarget(a_target, properties);
-			func(This, a_target, &properties);
+			const auto saved = *a_properties;
+			globals::state->ModifyRenderTarget(a_target, *a_properties);
+			func(This, a_target, a_properties);
+			*a_properties = saved;
 		}
 		static inline REL::Relocation<decltype(thunk)> func;
 	};
@@ -574,9 +577,10 @@ namespace Hooks
 	{
 		static void thunk(RE::BSGraphics::Renderer* This, RE::RENDER_TARGETS::RENDER_TARGET a_target, RE::BSGraphics::RenderTargetProperties* a_properties)
 		{
-			auto properties = *a_properties;
-			globals::state->ModifyRenderTarget(a_target, properties);
-			func(This, a_target, &properties);
+			const auto saved = *a_properties;
+			globals::state->ModifyRenderTarget(a_target, *a_properties);
+			func(This, a_target, a_properties);
+			*a_properties = saved;
 		}
 		static inline REL::Relocation<decltype(thunk)> func;
 	};
@@ -585,9 +589,10 @@ namespace Hooks
 	{
 		static void thunk(RE::BSGraphics::Renderer* This, RE::RENDER_TARGETS::RENDER_TARGET a_target, RE::BSGraphics::RenderTargetProperties* a_properties)
 		{
-			auto properties = *a_properties;
-			globals::state->ModifyRenderTarget(a_target, properties);
-			func(This, a_target, &properties);
+			const auto saved = *a_properties;
+			globals::state->ModifyRenderTarget(a_target, *a_properties);
+			func(This, a_target, a_properties);
+			*a_properties = saved;
 		}
 		static inline REL::Relocation<decltype(thunk)> func;
 	};
@@ -596,9 +601,10 @@ namespace Hooks
 	{
 		static void thunk(RE::BSGraphics::Renderer* This, RE::RENDER_TARGETS::RENDER_TARGET a_target, RE::BSGraphics::RenderTargetProperties* a_properties)
 		{
-			auto properties = *a_properties;
-			properties.copyable = true;
-			func(This, a_target, &properties);
+			const auto saved = *a_properties;
+			a_properties->copyable = true;
+			func(This, a_target, a_properties);
+			*a_properties = saved;
 		}
 		static inline REL::Relocation<decltype(thunk)> func;
 	};
@@ -607,9 +613,10 @@ namespace Hooks
 	{
 		static void thunk(RE::BSGraphics::Renderer* This, RE::RENDER_TARGETS::RENDER_TARGET a_target, RE::BSGraphics::RenderTargetProperties* a_properties)
 		{
-			auto properties = *a_properties;
-			properties.copyable = true;
-			func(This, a_target, &properties);
+			const auto saved = *a_properties;
+			a_properties->copyable = true;
+			func(This, a_target, a_properties);
+			*a_properties = saved;
 		}
 		static inline REL::Relocation<decltype(thunk)> func;
 	};


### PR DESCRIPTION
the new hooks never restore the pointers, causing other dlls to crash with CS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal rendering hook management to enhance stability and consistency of render-target property handling across multiple graphical elements (snow, normals, motion vectors, refraction, underwater effects).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->