### PR TITLE
chore(screenshot): default to PNG

### DIFF
--- a/src/Features/ScreenshotFeature.h
+++ b/src/Features/ScreenshotFeature.h
@@ -42,7 +42,7 @@ struct ScreenshotFeature : public Feature
 	// HDR PNG quantization (7-16); used when HDR Display captures the back buffer.
 	unsigned int hdrPngBitDepth = 11;
 	// SDR output (HDR captures always use PNG).
-	bool sdrUsePng = false;
+	bool sdrUsePng = true;
 	// After save, put the file path on the clipboard (CF_HDROP).
 	bool copyToClipboard = false;
 


### PR DESCRIPTION
people dislike the bmp function

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SDR screenshots now default to PNG format output instead of the previous default format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->