### PR TITLE
fix(water): guard history blend against NaN/Inf values

### DIFF
--- a/package/Shaders/ISWaterBlend.hlsl
+++ b/package/Shaders/ISWaterBlend.hlsl
@@ -58,7 +58,7 @@ PS_OUTPUT main(PS_INPUT input)
 
 	float3 finalColor = sourceColor;
 	if (motionScreenPosition.x >= 0 && motionScreenPosition.y >= 0 && motionScreenPosition.x <= 1 &&
-		motionScreenPosition.y <= 1 && waterHistory.w > 0.0) {
+		motionScreenPosition.y <= 1 && waterHistory.w > 0.0 && all(isfinite(waterHistory))) {
 		float historyFactor = 0.95;
 		if (NearFar_Menu_DistanceFactor.z == 0) {
 			float depth = depthBufferTex.Sample(depthBufferSampler, adjustedScreenPosition).x;


### PR DESCRIPTION
fixes the black water bug people reported on nexus

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced water rendering robustness by adding stricter validation checks during the blending process, reducing potential visual artifacts in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->