### PR TITLE
fix(build): prevent third-party deps from leaking into archives

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -415,8 +415,11 @@ set(FEATURE_PATHS_SLASH ${FEATURE_PATHS})
 list(TRANSFORM FEATURE_PATHS_SLASH APPEND /)
 
 # Install logic for AIO package
-# To copy AIO package at a folder do `${CMAKE_COMMAND} --install ${CMAKE_BINARY_DIR} --prefix ${AIO_DIR}`
-install(CODE "file(REMOVE_RECURSE \${CMAKE_INSTALL_PREFIX})")
+# Always use --component to avoid installing third-party FetchContent dependencies (e.g. tuplet).
+# To copy AIO package at a folder do:
+#   ${CMAKE_COMMAND} --install ${CMAKE_BINARY_DIR} --prefix ${AIO_DIR} --component SKSE
+#   ${CMAKE_COMMAND} --install ${CMAKE_BINARY_DIR} --prefix ${AIO_DIR} --component Shaders
+install(CODE "file(REMOVE_RECURSE \${CMAKE_INSTALL_PREFIX})" COMPONENT SKSE)
 install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION SKSE/Plugins COMPONENT SKSE)
 install(
     FILES $<TARGET_PDB_FILE:${PROJECT_NAME}>
@@ -1077,7 +1080,12 @@ else()
     add_custom_command(
         OUTPUT ${AIO_DIR}/SKSE/Plugins/${PROJECT_NAME}.dll
         DEPENDS ${PROJECT_NAME} ${CORE_SOURCES}
-        COMMAND ${CMAKE_COMMAND} --install ${CMAKE_BINARY_DIR} --config $<CONFIG> --prefix ${AIO_DIR}
+        COMMAND
+            ${CMAKE_COMMAND} --install ${CMAKE_BINARY_DIR} --config $<CONFIG>
+            --prefix ${AIO_DIR} --component SKSE
+        COMMAND
+            ${CMAKE_COMMAND} --install ${CMAKE_BINARY_DIR} --config $<CONFIG>
+            --prefix ${AIO_DIR} --component Shaders
         COMMENT "Installing to AIO folder"
     )
     add_custom_target("AIO" DEPENDS ${AIO_DIR}/SKSE/Plugins/${PROJECT_NAME}.dll)
@@ -1102,7 +1110,12 @@ else()
         OUTPUT ${AIO_PACKAGE}
         DEPENDS ${PROJECT_NAME} ${CORE_SOURCES}
         COMMAND ${CMAKE_COMMAND} -E make_directory ${AIO_DIR}
-        COMMAND ${CMAKE_COMMAND} --install ${CMAKE_BINARY_DIR} --config $<CONFIG> --prefix ${AIO_DIR}
+        COMMAND
+            ${CMAKE_COMMAND} --install ${CMAKE_BINARY_DIR} --config $<CONFIG>
+            --prefix ${AIO_DIR} --component SKSE
+        COMMAND
+            ${CMAKE_COMMAND} --install ${CMAKE_BINARY_DIR} --config $<CONFIG>
+            --prefix ${AIO_DIR} --component Shaders
         COMMAND
             ${CMAKE_COMMAND} -E chdir ${AIO_DIR} ${CMAKE_COMMAND} -E tar cfv
             ${AIO_PACKAGE} --format=zip -- .

--- a/cmake/CleanupStaleEntries.cmake
+++ b/cmake/CleanupStaleEntries.cmake
@@ -60,6 +60,21 @@ if(MODE STREQUAL "AIO")
         file(REMOVE "${_stale}")
     endforeach()
 
+    # Remove empty directories left behind (e.g. from third-party install rules
+    # like tuplet's include/ and share/ that leaked into the AIO folder).
+    # Walk bottom-up so nested empties are removed before their parents.
+    file(GLOB_RECURSE _all_aio_dirs LIST_DIRECTORIES TRUE "${AIO_DIR}/*")
+    list(SORT _all_aio_dirs ORDER DESCENDING)
+    foreach(_dir IN LISTS _all_aio_dirs)
+        if(IS_DIRECTORY "${_dir}" AND NOT "${_dir}" MATCHES "/SKSE/Plugins")
+            file(GLOB _children "${_dir}/*")
+            list(LENGTH _children _n)
+            if(_n EQUAL 0)
+                file(REMOVE_RECURSE "${_dir}")
+            endif()
+        endif()
+    endforeach()
+
 elseif(MODE STREQUAL "SHADERS")
     if(NOT DEFINED FEATURE_SHADER_PATHS)
         set(FEATURE_SHADER_PATHS "")


### PR DESCRIPTION
## Summary

- FetchContent dependencies (e.g. `tuplet` from `ShaderTestFramework`) have their own `install()` rules that fire during unfiltered `cmake --install`, placing `include/` and `share/` directories into the AIO folder and ultimately into distribution zip archives
- Scope all `cmake --install` calls to `--component SKSE` and `--component Shaders` so only project-owned content is installed
- Add empty directory cleanup in `CleanupStaleEntries.cmake` as a safety net for stale directories already present from previous builds

## Changes

- **CMakeLists.txt**: Move the install-prefix wipe (`REMOVE_RECURSE`) into `COMPONENT SKSE` so it doesn't run for third-party components. Add `--component` flags to the two fallback `cmake --install` calls (AIO target and Package-AIO-Manual target) that previously installed everything unfiltered.
- **cmake/CleanupStaleEntries.cmake**: Add bottom-up empty directory removal after stale file cleanup, so directories like `include/tuplet/` and `share/tuplet/` that were created by leaked install rules get cleaned up.

## Test plan

- [ ] Build with `BuildRelease.bat` and verify the AIO zip contains only expected content (no `include/`, `share/`, or `tuplet/` directories)
- [ ] Run `Package-AIO-Manual` target and verify the same
- [ ] Verify `Package-Core` still works (already used `--component SKSE`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined All-In-One installation workflow with enhanced component separation and installation sequencing.
  * Improved post-cleanup maintenance by automatically removing empty directories left behind after file removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->