### PR TITLE
feat(upscaling): make DLSS sharpening opt-in

### DIFF
--- a/package/SKSE/Plugins/CommunityShaders/Translations/en.json
+++ b/package/SKSE/Plugins/CommunityShaders/Translations/en.json
@@ -1438,6 +1438,8 @@
     "feature.upscaling.dlss_model_preset_l": "Preset L",
     "feature.upscaling.dlss_model_preset_m": "Preset M",
     "feature.upscaling.dlss_model_preset_tooltip": "Choose which DLSS AI model preset to use.\nEach model offers different visual quality, performance, and motion stability.\nSet to 'Default' for automatic selection based on your Upscale Preset and hardware.\nChanging this setting requires a restart to take effect.",
+    "feature.upscaling.enable_sharpening": "Enable Sharpening",
+    "feature.upscaling.enable_sharpening_tooltip": "Applies RCAS sharpening to the DLSS output.\nOff by default; DLSS already resolves a sharp image.",
     "feature.upscaling.force_enable_frame_generation": "Force Enable Frame Generation",
     "feature.upscaling.fps_limit": "FPS Limit",
     "feature.upscaling.fps_limit_tooltip_1": "Set your frame cap target.",

--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -30,6 +30,7 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	frameGenerationAllowInMenus,
 	streamlineLogLevel,
 	sharpnessFSR,
+	sharpnessEnabledDLSS,
 	sharpnessDLSS,
 	presetDLSS,
 	reflexLowLatencyMode,
@@ -272,7 +273,15 @@ void Upscaling::DrawSettings()
 		if (upscaleMethod == UpscaleMethod::kFSR) {
 			ImGui::SliderFloat(T(TKEY("sharpness"), "Sharpness"), &settings.sharpnessFSR, 0.0f, 1.0f, "%.1f");
 		} else if (upscaleMethod == UpscaleMethod::kDLSS) {
-			ImGui::SliderFloat(T(TKEY("sharpness"), "Sharpness"), &settings.sharpnessDLSS, 0.0f, 1.0f, "%.1f");
+			ImGui::Checkbox(T(TKEY("enable_sharpening"), "Enable Sharpening"), &settings.sharpnessEnabledDLSS);
+			if (auto _tt = Util::HoverTooltipWrapper()) {
+				ImGui::Text("%s", T(TKEY("enable_sharpening_tooltip"),
+									  "Applies RCAS sharpening to the DLSS output.\n"
+									  "Off by default; DLSS already resolves a sharp image."));
+			}
+
+			if (settings.sharpnessEnabledDLSS)
+				ImGui::SliderFloat(T(TKEY("sharpness"), "Sharpness"), &settings.sharpnessDLSS, 0.0f, 1.0f, "%.1f");
 
 			const char* presets[] = {
 				T(TKEY("dlss_model_preset_default"), "Default"),
@@ -1617,12 +1626,18 @@ void Upscaling::ApplySharpening()
 	ZoneScoped;
 	TracyD3D11Zone(globals::state->tracyCtx, "Upscaling - Sharpening");
 
+	if (!settings.sharpnessEnabledDLSS)
+		return;
+
 	if (settings.sharpnessDLSS <= 0.0f)
 		return;
 
 	if (!sharpenerTexture)
 		return;
 
+	// Match FSR3's slider->RCAS conversion exactly (ffx_fsr3upscaler.cpp + FsrRcasCon):
+	//   sharpenessRemapped = -2*slider + 2   (sharpness in stops)
+	//   rcasAttenuation    = exp2(-sharpenessRemapped) = exp2(2*slider - 2)
 	float currentSharpness = (-2.0f * settings.sharpnessDLSS) + 2.0f;
 	currentSharpness = exp2(-currentSharpness);
 

--- a/src/Features/Upscaling.h
+++ b/src/Features/Upscaling.h
@@ -59,6 +59,7 @@ public:
 		bool frameGenerationAllowInMenus = false;
 		uint streamlineLogLevel = 0;  // 0=Off, 1=Default, 2=Verbose
 		float sharpnessFSR = 0.0f;
+		bool sharpnessEnabledDLSS = false;
 		float sharpnessDLSS = 0.0f;
 		uint presetDLSS = 0;  // 0=Default, 1=J, 2=K, 3=L, 4=M
 		bool reflexLowLatencyMode = false;


### PR DESCRIPTION
## What

Adds a DLSS-only **Enable Sharpening** checkbox (off by default) that gates the RCAS sharpening pass and its sharpness slider. The slider now only appears when the checkbox is ticked.

## Why

DLSS already resolves a sharp image, so the RCAS pass was redundant for most users and, more importantly, looked **harsher than FSR at the same slider value**.

Root cause (verified against the FidelityFX SDK source now vendored in `extern/FidelityFX-SDK`):

- The slider→attenuation conversion was **already** an exact replica of FSR3's (`-2*s+2` remap → `FsrRcasCon` → `exp2(-x)`), so the curve was never the problem.
- The real difference is the **domain**. FSR3 brackets its RCAS pass with auto-exposure (`fColor *= Exposure()` … `c /= Exposure()` in `ffx_fsr3upscaler_rcas.h`), keeping values in a normalized ~[0,1] range. RCAS is **not** scale-invariant — its `hitMax` limiter hardcodes a peak-white of `1.0` (`peakC = float2(1.0, -4.0)`). Our standalone `RCAS.hlsl` runs on **raw pre-tonemap HDR** from `kMAIN` (the pass executes before ISHDR), where values exceed 1.0 and that limiter breaks down, over-sharpening relative to FSR.

Rather than port FSR's auto-exposure into the DLSS path, this makes sharpening opt-in: the default experience no longer over-sharpens, and users who still want it get an FSR-matched response curve.

## Changes

- `Upscaling::Settings`: new `bool sharpnessEnabledDLSS = false`, added to JSON serialization.
- `DrawSettings`: DLSS branch shows the checkbox + tooltip; slider gated behind it.
- `ApplySharpening`: early-returns unless the checkbox is enabled.
- Documented the FSR-matching `exp2(2*slider - 2)` conversion inline.
- Regenerated `en.json` (two new strings); `extract-i18n --check` and `sort-i18n --check` pass.

## Reviewer notes

- The slider→RCAS conversion is unchanged in behavior vs. the base branch (only a clarifying comment added).
- Known limitation: even when the checkbox is enabled, the HDR-domain difference vs. FSR's exposure-bracketed RCAS remains. Exact parity in the enabled case would require adding an exposure source to the DLSS path — out of scope here.
- Built (`BuildDev`) and smoke-tested via local AIO deployment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Enable Sharpening" toggle for DLSS output (disabled by default)
  * Sharpness slider now conditionally displays only when sharpening is enabled

* **Documentation**
  * Added localization strings explaining the sharpening toggle and RCAS behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->