### PR TITLE
ci: bump Node-20 actions to Node-24 majors

### DIFF
--- a/.github/actions/prepare-shaders/action.yml
+++ b/.github/actions/prepare-shaders/action.yml
@@ -18,7 +18,7 @@ runs:
               buildPresetAdditionalArgs: "['--target prepare_shaders']"
 
         - name: Setup Python
-          uses: actions/setup-python@v5
+          uses: actions/setup-python@v6
           with:
               python-version: "3.11"
 

--- a/.github/workflows/pr-i18n.yaml
+++ b/.github/workflows/pr-i18n.yaml
@@ -20,11 +20,11 @@ jobs:
         if: ${{ !github.event.pull_request.draft }}
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
               with:
                   ref: ${{ github.event.pull_request.head.sha }}
 
-            - uses: actions/setup-python@v5
+            - uses: actions/setup-python@v6
               with:
                   python-version: "3.11"
 

--- a/.github/workflows/pr-i18n.yaml
+++ b/.github/workflows/pr-i18n.yaml
@@ -23,6 +23,7 @@ jobs:
             - uses: actions/checkout@v6
               with:
                   ref: ${{ github.event.pull_request.head.sha }}
+                  persist-credentials: false
 
             - uses: actions/setup-python@v6
               with:


### PR DESCRIPTION
upstreamed from open shaders

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflows to use newer stable GitHub Actions versions for checking out code and setting up Python, keeping the same PR head ref and Python version.
  * Refreshed the shader preparation composite action to align with the updated Python setup action version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->