### PR TITLE
fix(terrain-blending): transparent terrain

### DIFF
--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -3381,7 +3381,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 
 	// Stored as 1 - vertexAO so the cleared default (0) means no occlusion
 	// for pixels that do not write to this RT (sky, water, grass, effects).
-	psout.Masks2 = float4(1.0 - vertexAO, 0, 0, 0);
+	psout.Masks2 = float4(1.0 - vertexAO, 0, 0, psout.Diffuse.w);
 
 	float stochasticBlend = (screenNoise * screenNoise) < psout.Diffuse.w ? 1.0 : 0.0;
 	psout.NormalGlossiness.w = stochasticBlend;


### PR DESCRIPTION
fixes #2548

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the lighting output so one render target channel now preserves the diffuse alpha value instead of always being set to zero. This helps keep the rendered data consistent in affected scenes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->