### PR TITLE
fix(menu): scope font-preview atlas to active tab

### DIFF
--- a/src/Menu/SettingsTabRenderer.cpp
+++ b/src/Menu/SettingsTabRenderer.cpp
@@ -1009,6 +1009,11 @@ void SettingsTabRenderer::RenderFontsTab()
 		}
 
 		ImGui::EndTabItem();
+	} else if (auto* menuInstance = globals::menu; menuInstance->wantsFontPreviewAtlas) {
+		// Fonts tab not active: drop the preview-font atlas so it is not rebaked into every
+		// later atlas rebuild for the rest of the session.
+		menuInstance->wantsFontPreviewAtlas = false;
+		menuInstance->pendingFontReload = true;
 	}
 }
 


### PR DESCRIPTION
cherrypicked from open shaders

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Fonts tab behavior so preview atlases are cleared when the tab is no longer active.
  * Prevents font preview data from persisting unexpectedly during later atlas rebuilds, making font updates more consistent during the session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->