### PR TITLE
fix(cs-editor): throttle hover and suppress logs

### DIFF
--- a/src/CSEditor/LightPicker.cpp
+++ b/src/CSEditor/LightPicker.cpp
@@ -123,7 +123,7 @@ LightPicker::PickedMesh LightPicker::ResolveUnderCursor(bool logResult)
 	return out;
 }
 
-LightPicker::PickedMesh LightPicker::ResolveNearestToCursor()
+LightPicker::PickedMesh LightPicker::ResolveNearestToCursor(bool logResult)
 {
 	PickedMesh out;
 
@@ -192,8 +192,9 @@ LightPicker::PickedMesh LightPicker::ResolveNearestToCursor()
 
 	PopulateFromRef(out, bestRef, baseObj);
 
-	logger::info("[LightPicker] Effect-pick ref 0x{:08X} '{}' model '{}' plugin '{}'",
-		bestRef->GetFormID(), out.editorId, out.modelPath, out.sourcePlugin);
+	if (logResult)
+		logger::info("[LightPicker] Effect-pick ref 0x{:08X} '{}' model '{}' plugin '{}'",
+			bestRef->GetFormID(), out.editorId, out.modelPath, out.sourcePlugin);
 	return out;
 }
 
@@ -238,12 +239,17 @@ void LightPicker::Update()
 		return;
 	}
 
-	// Update hover mesh when the cursor moves.
+	// Refresh the hover mesh when the cursor moves, throttled so a fast drag doesn't run a raycast
+	// (or, in effect mode, a full cell scan) every frame.
+	static constexpr double kHoverRefreshSeconds = 0.05;
 	const ImVec2 mouse = ImGui::GetMousePos();
-	if (mouse.x != lastMouseX || mouse.y != lastMouseY) {
-		lastMouseX = mouse.x;
-		lastMouseY = mouse.y;
-		hoverMesh = (pickMode == PickMode::kEffect) ? ResolveNearestToCursor() : ResolveUnderCursor(false);
+	const double now = ImGui::GetTime();
+	const bool moved = mouse.x != lastMouseX || mouse.y != lastMouseY;
+	lastMouseX = mouse.x;
+	lastMouseY = mouse.y;
+	if (moved && now - lastHoverTime >= kHoverRefreshSeconds) {
+		lastHoverTime = now;
+		hoverMesh = (pickMode == PickMode::kEffect) ? ResolveNearestToCursor(false) : ResolveUnderCursor(false);
 	}
 
 	if (hoverMesh.valid) {
@@ -261,10 +267,12 @@ void LightPicker::Update()
 	}
 
 	if (ImGui::IsMouseClicked(ImGuiMouseButton_Left)) {
-		// Reuse the hover result if the mouse didn't move between the last hover update and click.
-		PickedMesh hit = hoverMesh.valid ? hoverMesh :
-		                                   (pickMode == PickMode::kEffect ? ResolveNearestToCursor() : ResolveUnderCursor());
+		// Resolve fresh at the click position; the throttled hover hit may lag the cursor.
+		PickedMesh hit = (pickMode == PickMode::kEffect) ? ResolveNearestToCursor(false) : ResolveUnderCursor(false);
 		if (hit.valid) {
+			// Log only the committed pick (hover resolves run silently to keep the log quiet).
+			logger::info("[LightPicker] Picked base 0x{:08X} '{}' model '{}' ref '{}' plugin '{}'",
+				hit.baseFormId, hit.editorId, hit.modelPath, hit.refFormEntry, hit.sourcePlugin);
 			result = hit;
 			picking = false;
 			hoverMesh = {};

--- a/src/CSEditor/LightPicker.cpp
+++ b/src/CSEditor/LightPicker.cpp
@@ -218,6 +218,7 @@ void LightPicker::InvalidateHover()
 	hoverMesh = {};
 	lastMouseX = -1.f;
 	lastMouseY = -1.f;
+	hoverDirty = false;
 }
 
 void LightPicker::Update()
@@ -247,8 +248,10 @@ void LightPicker::Update()
 	const bool moved = mouse.x != lastMouseX || mouse.y != lastMouseY;
 	lastMouseX = mouse.x;
 	lastMouseY = mouse.y;
-	if (moved && now - lastHoverTime >= kHoverRefreshSeconds) {
+	hoverDirty |= moved;
+	if (hoverDirty && now - lastHoverTime >= kHoverRefreshSeconds) {
 		lastHoverTime = now;
+		hoverDirty = false;
 		hoverMesh = (pickMode == PickMode::kEffect) ? ResolveNearestToCursor(false) : ResolveUnderCursor(false);
 	}
 

--- a/src/CSEditor/LightPicker.h
+++ b/src/CSEditor/LightPicker.h
@@ -63,7 +63,7 @@ private:
 	/** @brief Raycasts through the cursor and resolves the collision mesh/ref under it. */
 	static PickedMesh ResolveUnderCursor(bool logResult = true);
 	/** @brief Resolves the on-screen ref nearest the cursor (effect-mesh pick), skipping collision-reachable ones. */
-	static PickedMesh ResolveNearestToCursor();
+	static PickedMesh ResolveNearestToCursor(bool logResult = true);
 	/** @brief Fills out's identifying fields (handle, FormID, EditorID, model, plugin) from a ref. */
 	static void PopulateFromRef(PickedMesh& out, RE::TESObjectREFR* refr, RE::TESBoundObject* baseObj);
 
@@ -72,4 +72,5 @@ private:
 	PickedMesh hoverMesh;  // last raycast hit under the cursor (updated per frame)
 	float lastMouseX = -1.f;
 	float lastMouseY = -1.f;
+	double lastHoverTime = 0.0;  // throttles the hover raycast/cell-scan during cursor movement
 };

--- a/src/CSEditor/LightPicker.h
+++ b/src/CSEditor/LightPicker.h
@@ -73,4 +73,5 @@ private:
 	float lastMouseX = -1.f;
 	float lastMouseY = -1.f;
 	double lastHoverTime = 0.0;  // throttles the hover raycast/cell-scan during cursor movement
+	bool hoverDirty = false;     // set on movement, cleared once hoverMesh is recomputed; survives a throttled frame
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hover selection performance and smoothness by throttling cursor-move recalculations.
  * Left-click now performs a fresh selection at the current cursor position rather than reusing the prior hover result.
  * Updated logging so hover computations are quieter, while committed picks still report normally.
  * Hover invalidation now reliably resets the internal hover refresh state to ensure correct recomputation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->