### PR TITLE
fix(unified-water): invalidate cache on ver bump, move folder

### DIFF
--- a/src/Features/UnifiedWater.cpp
+++ b/src/Features/UnifiedWater.cpp
@@ -209,7 +209,7 @@ void UnifiedWater::DataLoaded()
 	waterCache = new WaterCache();
 
 	if (LoadOrderChanged()) {
-		logger::info("[Unified Water] Load order changed, regenerating flowmap and caches");
+		logger::info("[Unified Water] Load order or plugin version changed, regenerating flowmap and caches");
 
 		if (flowmap->RegenerateAndLoadFlowmap())
 			SetFlowmapTex();
@@ -285,13 +285,17 @@ bool UnifiedWater::LoadOrderChanged()
 
 	uint64_t hash = 14695981039346656037ull;
 
-	auto addToHash = [&](const RE::TESFile* file) {
-		if (!file || !file->fileName)
-			return;
-		for (auto p = reinterpret_cast<const unsigned char*>(file->fileName); *p; ++p) {
+	auto addBytes = [&](const unsigned char* p) {
+		for (; *p; ++p) {
 			hash ^= *p;
 			hash *= 1099511628211ull;
 		}
+	};
+
+	auto addToHash = [&](const RE::TESFile* file) {
+		if (!file || !file->fileName)
+			return;
+		addBytes(reinterpret_cast<const unsigned char*>(file->fileName));
 	};
 
 	if (const auto mods = dataHandler->GetLoadedMods()) {
@@ -305,6 +309,8 @@ bool UnifiedWater::LoadOrderChanged()
 		for (uint32_t i = 0, n = count; i < n; ++i)
 			addToHash(lightMods[i]);
 	}
+
+	addBytes(reinterpret_cast<const unsigned char*>(Plugin::VERSION.string().c_str()));
 
 	namespace fs = std::filesystem;
 	const fs::path path = Util::PathHelpers::GetDataPath() / "UWLoadOrder.hash";

--- a/src/Features/UnifiedWater/WaterCache.cpp
+++ b/src/Features/UnifiedWater/WaterCache.cpp
@@ -149,7 +149,7 @@ bool WaterCache::RegenerateCaches()
 	logger::info("[Unified Water] [Cache] Clearing and regenerating caches...");
 
 	namespace fs = std::filesystem;
-	const fs::path dir = Util::PathHelpers::GetDataPath() / "UnifiedWaterCache";
+	const fs::path dir = Util::PathHelpers::GetUnifiedWaterCachePath();
 
 	std::error_code ec;
 	fs::create_directories(dir, ec);
@@ -251,7 +251,7 @@ bool WaterCache::GenerateCaches()
 	{
 		namespace fs = std::filesystem;
 		std::error_code ec;
-		fs::create_directories(Util::PathHelpers::GetDataPath() / "UnifiedWaterCache", ec);
+		fs::create_directories(Util::PathHelpers::GetUnifiedWaterCachePath(), ec);
 		if (ec) {
 			logger::error("[Unified Water] [Cache] Failed to ensure output directory: {}", ec.message());
 			return false;
@@ -857,7 +857,7 @@ template <typename T>
 bool WaterCache::TryWriteCacheToFile(const std::string& name, const WorldSpaceHeader& header, const std::vector<T>& vec)
 {
 	namespace fs = std::filesystem;
-	const fs::path path = Util::PathHelpers::GetDataPath() / "UnifiedWaterCache" / name;
+	const fs::path path = Util::PathHelpers::GetUnifiedWaterCachePath() / name;
 
 	std::ofstream ofs(path, std::ios::binary | std::ios::trunc);
 	if (!ofs) {
@@ -879,7 +879,7 @@ template <typename T>
 bool WaterCache::TryReadCacheFromFile(const std::string& name, WorldSpaceHeader& header, std::vector<T>& vec)
 {
 	namespace fs = std::filesystem;
-	const fs::path path = Util::PathHelpers::GetDataPath() / "UnifiedWaterCache" / name;
+	const fs::path path = Util::PathHelpers::GetUnifiedWaterCachePath() / name;
 	if (!fs::exists(path))
 		return false;
 

--- a/src/Utils/FileSystem.cpp
+++ b/src/Utils/FileSystem.cpp
@@ -112,6 +112,11 @@ namespace Util
 			return GetCommunityShaderPath() / "SceneSettings";
 		}
 
+		std::filesystem::path GetUnifiedWaterCachePath()
+		{
+			return GetCommunityShaderPath() / "UnifiedWaterCache";
+		}
+
 		std::filesystem::path GetShadersPath()
 		{
 			return GetDataPath() / "Shaders";

--- a/src/Utils/FileSystem.h
+++ b/src/Utils/FileSystem.h
@@ -128,6 +128,12 @@ namespace Util
 		std::filesystem::path GetSceneSettingsPath();
 
 		/**
+		 * Gets the UnifiedWaterCache directory path
+		 * @return CommunityShaderPath / "UnifiedWaterCache"
+		 */
+		std::filesystem::path GetUnifiedWaterCachePath();
+
+		/**
 		 * Gets the main Shaders directory path
 		 * @return Data / "Shaders"
 		 */


### PR DESCRIPTION
mostly helps with UX and prevents users from running around with faulty caches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unified water cache regeneration now detects plugin version changes in addition to load-order changes.
  * Cache files are now stored in the correct shared shader cache location.
  * Updated cache cleanup, reading, writing, and generation to use the new location consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->