### PR TITLE
fix(lighting-editor): missing ignorescale and CTD

### DIFF
--- a/src/CSEditor/EditorWindow.cpp
+++ b/src/CSEditor/EditorWindow.cpp
@@ -1567,8 +1567,6 @@ void EditorWindow::SaveSettings()
 void EditorWindow::LoadSettings()
 {
 	if (!j.empty()) {
-		// A hand-edited or older-format file can hold values that fail conversion
-		// (e.g. a recordMarkers color that isn't a 4-float array); keep defaults instead of crashing.
 		try {
 			settings = j;
 		} catch (const nlohmann::json::exception& e) {

--- a/src/CSEditor/EditorWindow.cpp
+++ b/src/CSEditor/EditorWindow.cpp
@@ -1566,8 +1566,15 @@ void EditorWindow::SaveSettings()
 
 void EditorWindow::LoadSettings()
 {
-	if (!j.empty())
-		settings = j;
+	if (!j.empty()) {
+		// A hand-edited or older-format file can hold values that fail conversion
+		// (e.g. a recordMarkers color that isn't a 4-float array); keep defaults instead of crashing.
+		try {
+			settings = j;
+		} catch (const nlohmann::json::exception& e) {
+			logger::warn("Failed to deserialize editor settings, using defaults: {}", e.what());
+		}
+	}
 	m_selectedCategory = settings.selectedCategory;
 	SetWidgetTypeSizesFromJson(settings.widgetTypeSizes);
 }

--- a/src/CSEditor/LightEditor.cpp
+++ b/src/CSEditor/LightEditor.cpp
@@ -2068,10 +2068,12 @@ void LightEditor::UpdateSelectedLight(RE::TESObjectREFR* refr, RE::TESObjectLIGH
 
 	if (current.data.flags.any(LightLimitFix::LightFlags::InverseSquare)) {
 		const bool isShadow = ligh && ligh->data.flags.any(RE::TES_LIGHT_FLAGS::kHemiShadow, RE::TES_LIGHT_FLAGS::kOmniShadow);
+		// Match ProcessLight, which runs on the LP-scaled runtime data (fade/size), so the readout tracks the game.
+		const float scale = GetLPRefScale();
 		current.data.radius = InverseSquareLighting::CalculateRadius(
-			current.data.fade * 4.f, isShadow,
+			current.data.fade * scale * 4.f, isShadow,
 			std::clamp(current.data.cutoffOverride, 0.01f, 1.0f),
-			std::clamp(current.data.size, 0.1f, 50.0f));
+			std::clamp(current.data.size * scale, 0.1f, 50.0f));
 	}
 
 	if (selected.isRef) {
@@ -2114,6 +2116,11 @@ void LightEditor::UpdateSelectedLight(RE::TESObjectREFR* refr, RE::TESObjectLIGH
 	displayInfo.lighEditorId = ligh ? clib_util::editorID::get_editorID(ligh) : "Unknown";
 }
 
+float LightEditor::GetLPRefScale() const
+{
+	return (lpInfo.isLPLight && activeRefr && !lpFlagSet.contains("IgnoreScale")) ? activeRefr->GetScale() : 1.0f;
+}
+
 bool LightEditor::ApplyOverrides(RE::NiLight* niLight, ISLCommon::RuntimeLightDataExt* runtimeData) const
 {
 	// Hovered (not selected) light: blink its fade so it flashes in the combo list.
@@ -2125,12 +2132,17 @@ bool LightEditor::ApplyOverrides(RE::NiLight* niLight, ISLCommon::RuntimeLightDa
 	if (niLight != activeNiLight.get())
 		return false;
 
+	// current.data holds the raw authored (JSON) values. Light Placer bakes the owner-reference scale into
+	// fade/radius/size when it packs a bulb (GetScaledFade/Radius/Size), so mirror that here or the selected
+	// bulb's preview diverges from the unselected/in-game render. Cutoff is never scaled.
+	const float scale = GetLPRefScale();
+
 	runtimeData->lighFormId = current.data.lighFormId;
 	// Use the emittance source's live color while one drives this bulb (see UpdateEmittanceColor), else the editor color.
 	runtimeData->diffuse = emittanceColorActive ? emittanceColor : current.data.diffuse;
-	runtimeData->fade = current.data.fade;
+	runtimeData->fade = current.data.fade * scale;
 	runtimeData->cutoffOverride = current.data.cutoffOverride;
-	runtimeData->size = current.data.size;
+	runtimeData->size = current.data.size * scale;
 
 	if (current.data.flags.any(LightLimitFix::LightFlags::InverseSquare)) {
 		runtimeData->flags.set(LightLimitFix::LightFlags::InverseSquare);
@@ -2138,7 +2150,7 @@ bool LightEditor::ApplyOverrides(RE::NiLight* niLight, ISLCommon::RuntimeLightDa
 		runtimeData->flags.reset(LightLimitFix::LightFlags::InverseSquare);
 		// Restore the authoritative radius: ProcessLight's IS branch writes a computed value into the shared
 		// runtimeData->radius that the non-IS branch only reads, so a stale inflated value would stick forever.
-		runtimeData->radius = current.data.radius;
+		runtimeData->radius = current.data.radius * scale;
 	}
 
 	if (current.data.flags.any(LightLimitFix::LightFlags::Linear))
@@ -2156,6 +2168,12 @@ void LightEditor::RestoreOriginal()
 
 	auto* runtimeData = ISLCommon::RuntimeLightDataExt::Get(activeNiLight.get());
 	*runtimeData = original.data;
+	// original.data is raw for LP bulbs (see RefreshLPJsonState); re-bake the owner-ref scale that Light Placer
+	// applies, symmetric with ApplyOverrides, so deselecting restores the live scaled state rather than the raw one.
+	const float scale = GetLPRefScale();
+	runtimeData->fade = original.data.fade * scale;
+	runtimeData->size = original.data.size * scale;
+	runtimeData->radius = original.data.radius * scale;
 
 	if (activeIsRef && activeRefr) {
 		activeRefr->SetPosition(original.pos);
@@ -2703,21 +2721,20 @@ void LightEditor::RefreshLPJsonState()
 
 	const auto dataIt = lightEntry->find("data");
 	if (dataIt != lightEntry->end() && dataIt->is_object()) {
-		// Base intensity from the LP JSON, not the runtime snapshot: the live fade is Flicker-modulated, so a
-		// snapshot freezes a random point. Applied to original (Reset) and current (the Intensity slider).
-		if (const auto fadeIt = dataIt->find("fade"); fadeIt != dataIt->end() && fadeIt->is_number()) {
-			const float jsonFade = fadeIt->get<float>();
-			original.data.fade = jsonFade;
-			current.data.fade = jsonFade;
-		}
+		// Read raw authored values from the JSON, not the runtime snapshot: the snapshot's size/radius are already
+		// LP-scaled by the owner ref, so reusing it would double the scale once ApplyOverrides re-applies it. Falls
+		// back to the LIGH form (like LP's GetFade/GetRadius/GetSize/GetCutoff) so original/current stay raw.
+		auto readData = [&](const char* key, float fallback) {
+			const auto it = dataIt->find(key);
+			return (it != dataIt->end() && it->is_number()) ? it->get<float>() : fallback;
+		};
 
-		// Likewise radius from JSON, not the snapshot (ProcessLight inflates runtimeData->radius for IS bulbs).
-		// JSON "radius" is the authored non-IS value; IS bulbs omit it and persist size/cutoff instead.
-		if (const auto radiusIt = dataIt->find("radius"); radiusIt != dataIt->end() && radiusIt->is_number()) {
-			const float jsonRadius = radiusIt->get<float>();
-			original.data.radius = jsonRadius;
-			current.data.radius = jsonRadius;
-		}
+		original.data.fade = current.data.fade = readData("fade", activeLigh ? activeLigh->fade : current.data.fade);
+		original.data.radius = current.data.radius = readData("radius", activeLigh ? static_cast<float>(activeLigh->data.radius) : current.data.radius);
+
+		const float fovSize = activeLigh ? (activeLigh->data.fov >= 50.f ? std::numbers::sqrt2_v<float> : activeLigh->data.fov) : current.data.size;
+		original.data.size = current.data.size = std::clamp(readData("size", fovSize), 0.01f, 50.f);
+		original.data.cutoffOverride = current.data.cutoffOverride = std::clamp(readData("cutoff", activeLigh ? activeLigh->data.fallofExponent : current.data.cutoffOverride), 0.01f, 1.f);
 
 		const auto flagsIt = dataIt->find("flags");
 		if (flagsIt != dataIt->end() && flagsIt->is_string()) {

--- a/src/CSEditor/LightEditor.h
+++ b/src/CSEditor/LightEditor.h
@@ -261,6 +261,8 @@ private:
 	bool ModifyLPFilterList(bool isWhiteList, bool add);
 	/** @brief Reloads the selected bulb's filter/flag/emittance state from its LP JSON entry. */
 	void RefreshLPJsonState();
+	/** @brief Owner-reference scale Light Placer bakes into fade/radius/size for the active LP bulb (1.0 if non-LP or IgnoreScale). */
+	float GetLPRefScale() const;
 	/** @brief Applies the LP flag set to the current runtime light flags. */
 	void SyncLPFlagsToRuntime();
 	/** @brief Mirrors the InverseSquare/Linear falloff bits of an LP flag set onto a runtime light's flags. */

--- a/src/Utils/Serialize.cpp
+++ b/src/Utils/Serialize.cpp
@@ -1,5 +1,24 @@
 #include "Serialize.h"
 
+namespace
+{
+	/** @brief Read exactly N floats from a JSON array into out; leaves out untouched (default kept)
+	 *  when the value isn't an N-element numeric array. Prevents nlohmann's array conversion from
+	 *  throwing out_of_range/type_error on hand-edited or older-format config values. */
+	template <size_t N>
+	bool ReadFloatArray(const nlohmann::json& j, std::array<float, N>& out)
+	{
+		if (!j.is_array() || j.size() < N)
+			return false;
+		for (size_t i = 0; i < N; ++i) {
+			if (!j[i].is_number())
+				return false;
+			out[i] = j[i].get<float>();
+		}
+		return true;
+	}
+}
+
 namespace nlohmann
 {
 	void to_json(json& j, const float2& v)
@@ -9,8 +28,9 @@ namespace nlohmann
 
 	void from_json(const json& j, float2& v)
 	{
-		std::array<float, 2> temp = j;
-		v = { temp[0], temp[1] };
+		std::array<float, 2> temp;
+		if (ReadFloatArray(j, temp))
+			v = { temp[0], temp[1] };
 	}
 
 	void to_json(json& j, const float3& v)
@@ -20,8 +40,9 @@ namespace nlohmann
 
 	void from_json(const json& j, float3& v)
 	{
-		std::array<float, 3> temp = j;
-		v = { temp[0], temp[1], temp[2] };
+		std::array<float, 3> temp;
+		if (ReadFloatArray(j, temp))
+			v = { temp[0], temp[1], temp[2] };
 	}
 
 	void to_json(json& j, const float4& v)
@@ -31,8 +52,9 @@ namespace nlohmann
 
 	void from_json(const json& j, float4& v)
 	{
-		std::array<float, 4> temp = j;
-		v = { temp[0], temp[1], temp[2], temp[3] };
+		std::array<float, 4> temp;
+		if (ReadFloatArray(j, temp))
+			v = { temp[0], temp[1], temp[2], temp[3] };
 	}
 
 	void to_json(json& j, const ImVec2& v)
@@ -42,8 +64,9 @@ namespace nlohmann
 
 	void from_json(const json& j, ImVec2& v)
 	{
-		std::array<float, 2> temp = j;
-		v = { temp[0], temp[1] };
+		std::array<float, 2> temp;
+		if (ReadFloatArray(j, temp))
+			v = { temp[0], temp[1] };
 	}
 
 	void to_json(json& j, const ImVec4& v)
@@ -53,8 +76,9 @@ namespace nlohmann
 
 	void from_json(const json& j, ImVec4& v)
 	{
-		std::array<float, 4> temp = j;
-		v = { temp[0], temp[1], temp[2], temp[3] };
+		std::array<float, 4> temp;
+		if (ReadFloatArray(j, temp))
+			v = { temp[0], temp[1], temp[2], temp[3] };
 	}
 
 	void to_json(json& section, const RE::NiColor& result)
@@ -91,14 +115,15 @@ namespace nlohmann
 
 	void from_json(const json& j, RE::TESWeather::FogData& fog)
 	{
-		std::array<float, 8> temp = j;
-		fog = { temp[0],
-			temp[1],
-			temp[2],
-			temp[3],
-			temp[4],
-			temp[5],
-			temp[6],
-			temp[7] };
+		std::array<float, 8> temp;
+		if (ReadFloatArray(j, temp))
+			fog = { temp[0],
+				temp[1],
+				temp[2],
+				temp[3],
+				temp[4],
+				temp[5],
+				temp[6],
+				temp[7] };
 	}
 }


### PR DESCRIPTION
this PR contains 3 fixes:
- Support for the missing ignorescale flag causing mismatched visualization
- A serialization crash fixdue to manually edited jsons
- Extra guards for serialization to prevent this from happening anywhere else too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Light Placer light preview/restore so fade, size, and radius are scaled consistently and clamping is applied where needed.
  * Ensures the Light Placer “Ignore Scale” option disables the reference scaling during adjustments.
  * Prevents malformed or older saved configuration from causing load/runtime errors by safely ignoring incompatible JSON.
  * Preserves existing/default vector and weather values when stored JSON float arrays don’t match the expected shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->