### PR TITLE
fix(unified-water): guard cache against concurrent access

### DIFF
--- a/src/Features/UnifiedWater.cpp
+++ b/src/Features/UnifiedWater.cpp
@@ -508,6 +508,8 @@ void UnifiedWater::BGSTerrainBlock_Attach::thunk(RE::BGSTerrainBlock* block)
 	std::vector<std::pair<RE::BSTriShape*, const WaterCache::Instruction*>> built;
 	bool attaching = false;
 	RE::NiPointer<RE::BSMultiBoundNode> water;
+	// Keeps the backing RuntimeCache alive for as long as `built` holds pointers into it.
+	WaterCache::InstructionResult instructionResult;
 
 	if (block && block->loaded && !block->attached && block->chunk && block->water) {
 		// Keep terrain water alive while moving it out of its owning node
@@ -522,7 +524,8 @@ void UnifiedWater::BGSTerrainBlock_Attach::thunk(RE::BGSTerrainBlock* block)
 		const auto lodLevel = node->GetLODLevel();
 		const auto worldSpace = block->node->manager->worldSpace;
 
-		const auto instructions = singleton.waterCache->GetInstructions(worldSpace, lodLevel, node->baseCellX, node->baseCellY);
+		instructionResult = singleton.waterCache->GetInstructions(worldSpace, lodLevel, node->baseCellX, node->baseCellY);
+		const auto instructions = instructionResult.instructions;
 		if (!instructions) {
 			logger::warn("[Unified Water] No instructions found for {} chunk at {}, {}", worldSpace->GetFormEditorID(), node->baseCellX, node->baseCellY);
 			// Reattach the saved node before falling back to vanilla

--- a/src/Features/UnifiedWater/WaterCache.cpp
+++ b/src/Features/UnifiedWater/WaterCache.cpp
@@ -78,16 +78,20 @@ bool WaterCache::SetCurrentWorldSpaceLocked(const RE::TESWorldSpace* worldSpace)
 	return true;
 }
 
-std::vector<WaterCache::Instruction>* WaterCache::GetInstructions(const RE::TESWorldSpace* worldSpace, const uint32_t lodLevel, const uint32_t x, const uint32_t y)
+WaterCache::InstructionResult WaterCache::GetInstructions(const RE::TESWorldSpace* worldSpace, const uint32_t lodLevel, const uint32_t x, const uint32_t y)
 {
 	std::scoped_lock lock(currentCacheMutex);
 
 	if (!SetCurrentWorldSpaceLocked(worldSpace)) {
 		logger::error("[Unified Water] [Cache] Failed to set current cache to {} while getting instructions", worldSpace->GetFormEditorID());
-		return nullptr;
+		return {};
 	}
 
-	return currentCache->GetInstructions(lodLevel, x, y);
+	// Held alongside the pointer so a concurrent LoadCaches can't free it mid-use.
+	InstructionResult result;
+	result.cache = currentCache;
+	result.instructions = currentCache->GetInstructions(lodLevel, x, y);
+	return result;
 }
 
 std::vector<WaterCache::Instruction>* WaterCache::RuntimeCache::GetInstructions(const int32_t lodLevel, const int32_t x, const int32_t y)
@@ -238,6 +242,10 @@ bool WaterCache::LoadCaches()
 			if (const auto snap = std::atomic_load_explicit(&cacheMap, std::memory_order_acquire)) {
 				if (const auto it = snap->find(currentWorldSpace); it != snap->end()) {
 					currentCache = it->second;
+				} else {
+					// Dropped from the reloaded map - clear so a name match can't fast-return stale.
+					currentCache.reset();
+					currentWorldSpace.clear();
 				}
 			}
 		}

--- a/src/Features/UnifiedWater/WaterCache.cpp
+++ b/src/Features/UnifiedWater/WaterCache.cpp
@@ -34,6 +34,12 @@ namespace
 
 bool WaterCache::SetCurrentWorldSpace(const RE::TESWorldSpace* worldSpace)
 {
+	std::scoped_lock lock(currentCacheMutex);
+	return SetCurrentWorldSpaceLocked(worldSpace);
+}
+
+bool WaterCache::SetCurrentWorldSpaceLocked(const RE::TESWorldSpace* worldSpace)
+{
 	if (!worldSpace) {
 		currentCache.reset();
 		currentWorldSpace.clear();
@@ -74,7 +80,9 @@ bool WaterCache::SetCurrentWorldSpace(const RE::TESWorldSpace* worldSpace)
 
 std::vector<WaterCache::Instruction>* WaterCache::GetInstructions(const RE::TESWorldSpace* worldSpace, const uint32_t lodLevel, const uint32_t x, const uint32_t y)
 {
-	if (!SetCurrentWorldSpace(worldSpace)) {
+	std::scoped_lock lock(currentCacheMutex);
+
+	if (!SetCurrentWorldSpaceLocked(worldSpace)) {
 		logger::error("[Unified Water] [Cache] Failed to set current cache to {} while getting instructions", worldSpace->GetFormEditorID());
 		return nullptr;
 	}
@@ -224,10 +232,13 @@ bool WaterCache::LoadCaches()
 
 	std::atomic_store_explicit(&cacheMap, std::const_pointer_cast<const CacheMap>(newCacheMap), std::memory_order_release);
 
-	if (!currentWorldSpace.empty()) {
-		if (const auto snap = std::atomic_load_explicit(&cacheMap, std::memory_order_acquire)) {
-			if (const auto it = snap->find(currentWorldSpace); it != snap->end()) {
-				currentCache = it->second;
+	{
+		std::scoped_lock lock(currentCacheMutex);
+		if (!currentWorldSpace.empty()) {
+			if (const auto snap = std::atomic_load_explicit(&cacheMap, std::memory_order_acquire)) {
+				if (const auto it = snap->find(currentWorldSpace); it != snap->end()) {
+					currentCache = it->second;
+				}
 			}
 		}
 	}

--- a/src/Features/UnifiedWater/WaterCache.h
+++ b/src/Features/UnifiedWater/WaterCache.h
@@ -6,6 +6,9 @@
 /** @brief Manages cached water placement instructions for all worldspaces and LOD levels. */
 class WaterCache
 {
+private:
+	struct RuntimeCache;
+
 public:
 	/** @brief Describes a single water tile placement with position, size, and water form data. */
 	struct Instruction
@@ -22,6 +25,13 @@ public:
 		int32_t y{};
 		uint32_t size{};
 		float waterHeight{};
+	};
+
+	/** @brief Instruction list for a LOD chunk, plus the runtime cache instance backing it so the caller can keep it alive. */
+	struct InstructionResult
+	{
+		std::shared_ptr<RuntimeCache> cache;
+		std::vector<Instruction>* instructions = nullptr;
 	};
 
 	/** @brief Thread-safe snapshot of asynchronous cache build progress. */
@@ -47,9 +57,9 @@ public:
 	 * @param lodLevel The LOD level (0 = closest).
 	 * @param x The chunk X coordinate.
 	 * @param y The chunk Y coordinate.
-	 * @return Pointer to the instruction list, or nullptr if unavailable.
+	 * @return Result with a null instructions pointer if unavailable; otherwise the cache keeps the instructions alive for as long as the result is held.
 	 */
-	std::vector<Instruction>* GetInstructions(const RE::TESWorldSpace* worldSpace, uint32_t lodLevel, uint32_t x, uint32_t y);
+	InstructionResult GetInstructions(const RE::TESWorldSpace* worldSpace, uint32_t lodLevel, uint32_t x, uint32_t y);
 
 	/** @brief Generates precache height data for Tamriel using extended data sets. */
 	static void GenerateTamrielPrecache();

--- a/src/Features/UnifiedWater/WaterCache.h
+++ b/src/Features/UnifiedWater/WaterCache.h
@@ -1,4 +1,6 @@
 ﻿#pragma once
+#include <mutex>
+
 #include <BS_thread_pool.hpp>
 
 /** @brief Manages cached water placement instructions for all worldspaces and LOD levels. */
@@ -186,8 +188,13 @@ private:
 
 	std::atomic<std::shared_ptr<const CacheMap>> cacheMap{ std::make_shared<CacheMap>() };
 
+	// Guards currentCache/currentWorldSpace against concurrent terrain-streaming and cache-reload threads.
+	std::mutex currentCacheMutex;
 	std::shared_ptr<RuntimeCache> currentCache;
 	std::string currentWorldSpace;
+
+	/** @brief Same as SetCurrentWorldSpace, but assumes currentCacheMutex is already held. */
+	bool SetCurrentWorldSpaceLocked(const RE::TESWorldSpace* worldSpace);
 
 	bool LoadCaches();
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when switching between world spaces.
  * Prevented race conditions while loading and accessing cached water data.
  * Ensured the active cache stays synchronized during runtime updates.
  * Improved safety of water instruction retrieval by keeping the underlying cache data alive for the duration of terrain rebuild.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->