### PR TITLE
feat: Horizon Fix compat

### DIFF
--- a/features/HorizonFix/Shaders/Features/HorizonFix.ini
+++ b/features/HorizonFix/Shaders/Features/HorizonFix.ini
@@ -1,0 +1,2 @@
+[Info]
+Version = 1-0-0

--- a/package/Shaders/Water.hlsl
+++ b/package/Shaders/Water.hlsl
@@ -1,5 +1,5 @@
-#if defined(FAR_WATER)
-namespace FarWater
+#if defined(HORIZON_FIX)
+namespace HorizonFix
 {
 	// Depth (z/w) that water folded back from beyond the far clip plane lands at: eight
 	// depth quanta inside the far plane, exactly representable in both D24 and D32F
@@ -178,8 +178,8 @@ VS_OUTPUT main(VS_INPUT input)
 	vsout.HPosition.z = heightMult * 0.5 + worldViewPos.z;
 	vsout.HPosition.w = worldViewPos.w;
 
-#	if defined(FAR_WATER)
-	vsout.HPosition.z = min(vsout.HPosition.z, vsout.HPosition.w * FarWater::FoldedDepth);
+#	if defined(HORIZON_FIX)
+	vsout.HPosition.z = min(vsout.HPosition.z, vsout.HPosition.w * HorizonFix::FoldedDepth);
 #	endif
 
 #		if defined(STENCIL)
@@ -912,8 +912,8 @@ DiffuseOutput GetWaterDiffuseColor(PS_INPUT input, float3 normal, float3 viewDir
 		refractionWorldPosition.xyz /= refractionWorldPosition.w;
 	}
 
-#					if defined(FAR_WATER)
-	if (DepthTex.Load(float3(refractionScreenPosition, 0)).x >= FarWater::EmptyDepthThreshold)
+#					if defined(HORIZON_FIX)
+	if (DepthTex.Load(float3(refractionScreenPosition, 0)).x >= HorizonFix::EmptyDepthThreshold)
 		distanceMul = 1.0.xxxx;
 #					endif
 #				endif
@@ -1021,8 +1021,8 @@ PS_OUTPUT main(PS_INPUT input)
 		planeMul * float4(length(depthAdjustedViewDirection).xx, abs(viewSurfaceAngle).xx) /
 		FogParam.z);
 
-#					if defined(FAR_WATER)
-	if (DepthTex.Load(float3(screenPosition, 0)).x >= FarWater::EmptyDepthThreshold)
+#					if defined(HORIZON_FIX)
+	if (DepthTex.Load(float3(screenPosition, 0)).x >= HorizonFix::EmptyDepthThreshold)
 		distanceMul = 1.0.xxxx;
 #					endif
 #				endif

--- a/package/Shaders/Water.hlsl
+++ b/package/Shaders/Water.hlsl
@@ -1,3 +1,19 @@
+#if defined(FAR_WATER)
+namespace FarWater
+{
+	// Depth (z/w) that water folded back from beyond the far clip plane lands at: eight
+	// depth quanta inside the far plane, exactly representable in both D24 and D32F
+	// buffers - behind everything the scene rendered, in front of the depth clear.
+	static const float FoldedDepth = 1.0 - 8.0 / 16777216.0;
+
+	// Scene depth at or beyond this counts as "nothing rendered behind the water": the
+	// clear value, folded far water (FoldedDepth), or an external plugin's depth-clamped
+	// far-water backdrop a few quanta inside that. The margin is a few world units at the
+	// far plane, where no real surface can render.
+	static const float EmptyDepthThreshold = 1.0 - 64.0 / 16777216.0;
+}
+#endif
+
 #if defined(UNDERWATERMASK)
 
 struct VS_INPUT
@@ -161,6 +177,10 @@ VS_OUTPUT main(VS_INPUT input)
 	vsout.HPosition.xy = worldViewPos.xy;
 	vsout.HPosition.z = heightMult * 0.5 + worldViewPos.z;
 	vsout.HPosition.w = worldViewPos.w;
+
+#	if defined(FAR_WATER)
+	vsout.HPosition.z = min(vsout.HPosition.z, vsout.HPosition.w * FarWater::FoldedDepth);
+#	endif
 
 #		if defined(STENCIL)
 	vsout.WorldPosition = worldPos;
@@ -891,6 +911,11 @@ DiffuseOutput GetWaterDiffuseColor(PS_INPUT input, float3 normal, float3 viewDir
 		refractionWorldPosition = mul(FrameBuffer::CameraViewProjInverse, float4((refractionUvRaw * 2 - 1) * float2(1, -1), DepthTex.Load(float3(refractionScreenPosition, 0)).x, 1));
 		refractionWorldPosition.xyz /= refractionWorldPosition.w;
 	}
+
+#					if defined(FAR_WATER)
+	if (DepthTex.Load(float3(refractionScreenPosition, 0)).x >= FarWater::EmptyDepthThreshold)
+		distanceMul = 1.0.xxxx;
+#					endif
 #				endif
 
 	float2 refractionUV = FrameBuffer::GetDynamicResolutionAdjustedScreenPosition(refractionUvRaw);
@@ -995,6 +1020,11 @@ PS_OUTPUT main(PS_INPUT input)
 	distanceMul = saturate(
 		planeMul * float4(length(depthAdjustedViewDirection).xx, abs(viewSurfaceAngle).xx) /
 		FogParam.z);
+
+#					if defined(FAR_WATER)
+	if (DepthTex.Load(float3(screenPosition, 0)).x >= FarWater::EmptyDepthThreshold)
+		distanceMul = 1.0.xxxx;
+#					endif
 #				endif
 #			endif
 

--- a/src/Feature.cpp
+++ b/src/Feature.cpp
@@ -12,6 +12,7 @@
 #include "Features/GrassLighting.h"
 #include "Features/HDRDisplay.h"
 #include "Features/HairSpecular.h"
+#include "Features/HorizonFix.h"
 #include "Features/IBL.h"
 #include "Features/InteriorSun.h"
 #include "Features/InverseSquareLighting.h"
@@ -251,6 +252,7 @@ const std::vector<Feature*>& Feature::GetFeatureList()
 		&globals::features::screenshotFeature,
 		&globals::features::linearLighting,
 		&globals::features::unifiedWater,
+		&globals::features::horizonFix,
 		&globals::features::exponentialHeightFog,
 		&globals::features::hdrDisplay,
 		&globals::features::skin

--- a/src/Features/HorizonFix.cpp
+++ b/src/Features/HorizonFix.cpp
@@ -17,7 +17,9 @@ void HorizonFix::PostPostLoad()
 	// regular feature validation.
 	if (loaded && GetModuleHandleW(L"HorizonFix.dll") == nullptr) {
 		loaded = false;
-		failedLoadedMessage = "HorizonFix is not installed; water keeps vanilla far clip behavior";
+		failedLoadedMessage = "HorizonFix is not installed, compatibility is disabled.";
 		logger::info("[Horizon Fix] HorizonFix plugin not detected, compatibility disabled");
+	} else {
+		logger::info("[Horizon Fix] HorizonFix plugin detected, compatibility enabled");
 	}
 }

--- a/src/Features/HorizonFix.cpp
+++ b/src/Features/HorizonFix.cpp
@@ -1,0 +1,23 @@
+#include "HorizonFix.h"
+
+#include <imgui.h>
+
+void HorizonFix::DrawSettings()
+{
+	ImGui::TextWrapped(
+		"This feature provides compatibility with the Horizon Fix SKSE plugin, which extends the water far clip plane to allow water to be rendered beyond the vanilla far clip distance. This feature is only active when the Horizon Fix plugin is installed.");
+}
+
+void HorizonFix::PostPostLoad()
+{
+	// The shader-side far-water support is only wanted while the HorizonFix plugin is
+	// actually installed; without it water keeps the vanilla far-clip look. Checked here
+	// because every SKSE plugin has loaded by now and the shader disk cache has not been
+	// validated yet, so installing or removing the plugin invalidates the cache through
+	// regular feature validation.
+	if (loaded && GetModuleHandleW(L"HorizonFix.dll") == nullptr) {
+		loaded = false;
+		failedLoadedMessage = "HorizonFix is not installed; water keeps vanilla far clip behavior";
+		logger::info("[Horizon Fix] HorizonFix plugin not detected, compatibility disabled");
+	}
+}

--- a/src/Features/HorizonFix.h
+++ b/src/Features/HorizonFix.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "Feature.h"
+
+/**
+ * @brief Core feature enabling water rendering beyond the far clip plane for HorizonFix.
+ *
+ * HorizonFix (an SKSE plugin) fills the horizon gap between the farthest visible water and the
+ * sky with a skirt of distant water tiles. Those tiles need shader-side support: the HORIZON_FIX
+ * define in Water.hlsl folds beyond-far-plane water back onto the far plane and shades it as
+ * bottomless where nothing rendered behind it.
+ *
+ * This feature's only job is to enable that define while the HorizonFix plugin is installed. It
+ * self-disables in PostPostLoad when the plugin is absent, so water keeps exact vanilla
+ * far-clip behavior without it - and because that runs before shader cache validation, regular
+ * feature validation recompiles the water shaders whenever HorizonFix is installed or removed.
+ */
+struct HorizonFix : Feature
+{
+	virtual inline std::string GetName() override { return "Horizon Fix"; }
+	virtual inline std::string GetShortName() override { return "HorizonFix"; }
+	virtual inline std::string_view GetShaderDefineName() override { return "HORIZON_FIX"; }
+	virtual inline bool HasShaderDefine(RE::BSShader::Type t) override { return t == RE::BSShader::Type::Water; }
+	virtual std::string_view GetCategory() const override { return FeatureCategories::kWater; }
+
+	/** @brief Returns a summary description for the UI. */
+	virtual std::pair<std::string, std::vector<std::string>> GetFeatureSummary() override
+	{
+		return { "Enables water rendering beyond the far clip plane in support of the HorizonFix plugin, which fills the horizon gap between the farthest visible water and the sky.",
+			{ "Active only while the HorizonFix SKSE plugin is installed.",
+				"Without HorizonFix, water keeps exact vanilla far clip behavior." } };
+	}
+
+	virtual void DrawSettings() override;
+
+	/** @brief Disables the feature when the HorizonFix plugin is not installed. */
+	virtual void PostPostLoad() override;
+
+	virtual bool IsCore() const override { return true; }
+};

--- a/src/Globals.cpp
+++ b/src/Globals.cpp
@@ -10,6 +10,7 @@
 #include "Features/GrassLighting.h"
 #include "Features/HDRDisplay.h"
 #include "Features/HairSpecular.h"
+#include "Features/HorizonFix.h"
 #include "Features/IBL.h"
 #include "Features/InteriorSun.h"
 #include "Features/InverseSquareLighting.h"
@@ -67,6 +68,7 @@ namespace globals
 		LinearLighting linearLighting{};
 		LODBlending lodBlending{};
 		HairSpecular hairSpecular{};
+		HorizonFix horizonFix{};
 		InteriorSun interiorSun{};
 		InverseSquareLighting inverseSquareLighting{};
 		ScreenSpaceGI screenSpaceGI{};

--- a/src/Globals.h
+++ b/src/Globals.h
@@ -9,6 +9,7 @@ struct ExtendedMaterials;
 struct GrassCollision;
 struct GrassLighting;
 struct HairSpecular;
+struct HorizonFix;
 struct IBL;
 struct LightLimitFix;
 struct LinearLighting;
@@ -96,6 +97,7 @@ namespace globals
 		extern GrassCollision grassCollision;
 		extern GrassLighting grassLighting;
 		extern HairSpecular hairSpecular;
+		extern HorizonFix horizonFix;
 		extern IBL ibl;
 		extern LightLimitFix lightLimitFix;
 		extern LinearLighting linearLighting;

--- a/src/ShaderCache.cpp
+++ b/src/ShaderCache.cpp
@@ -18,6 +18,27 @@
 
 namespace SIE
 {
+	namespace
+	{
+		// Extended far water: set when an installed plugin known to render water geometry
+		// beyond the far clip plane (a horizon-filling water skirt) is detected. When set,
+		// water shaders are compiled with the FAR_WATER define, which folds beyond-far-plane
+		// water back onto the far plane and shades it as bottomless where nothing rendered
+		// behind it. Without a detected provider the water pipeline keeps exact vanilla
+		// far-clip behavior: water clips at the far plane and terminates against the sky.
+		// Detection happens once, in ShaderCache::ValidateDiskCache, after every SKSE plugin
+		// has loaded and before any water shader is compiled.
+		std::atomic_bool extendedFarWater{ false };
+
+		// Plugins whose presence means water geometry will exist beyond the far clip plane
+		constexpr const wchar_t* farWaterProviderDlls[] = { L"HorizonFix.dll" };
+	}
+
+	bool IsExtendedFarWaterEnabled()
+	{
+		return extendedFarWater.load(std::memory_order_acquire);
+	}
+
 	// Custom include handler to track all includes during shader compilation
 	class TrackingIncludeHandler : public ID3DInclude
 	{
@@ -495,6 +516,10 @@ namespace SIE
 					"5", "6", "7" } };
 				defines[lastIndex++] = { "SPECULAR", nullptr };
 				defines[lastIndex++] = { "NUM_SPECULAR_LIGHTS", numLightDefines[technique] };
+			}
+
+			if (SIE::IsExtendedFarWaterEnabled()) {
+				defines[lastIndex++] = { "FAR_WATER", nullptr };
 			}
 
 			for (auto* feature : Feature::GetFeatureList()) {
@@ -2418,6 +2443,29 @@ namespace SIE
 			valid = false;
 		}
 
+		// Detect installed providers of water geometry beyond the far clip plane. This runs
+		// at kPostPostLoad - every SKSE plugin is loaded, no water shader is compiled yet.
+		// The result changes the water shader defines, so a provider appearing or
+		// disappearing between sessions must invalidate the disk cache below.
+		{
+			bool farWaterDetected = false;
+			for (const auto* provider : farWaterProviderDlls) {
+				if (GetModuleHandleW(provider) != nullptr) {
+					logger::info("Extended far water provider detected ({}); water shaders will support geometry beyond the far clip plane",
+						Util::WStringToString(provider));
+					farWaterDetected = true;
+				}
+			}
+			extendedFarWater.store(farWaterDetected, std::memory_order_release);
+
+			const bool cachedFarWater = ini.GetBoolValue("Cache", "ExtendedFarWater", false);
+			if (cachedFarWater != farWaterDetected) {
+				logger::info("Disk cache outdated: extended far water changed (current: {}, cached: {})",
+					farWaterDetected, cachedFarWater);
+				valid = false;
+			}
+		}
+
 		if (valid) {
 			logger::info("Using disk cache");
 		} else {
@@ -2430,6 +2478,7 @@ namespace SIE
 		CSimpleIniA ini;
 		ini.SetUnicode();
 		ini.SetValue("Cache", "PluginVersion", Plugin::VERSION.string().c_str());
+		ini.SetBoolValue("Cache", "ExtendedFarWater", IsExtendedFarWaterEnabled());
 		globals::state->WriteDiskCacheInfo(ini);
 		ini.SaveFile(L"Data\\ShaderCache\\Info.ini");
 		logger::info("Saved disk cache info (plugin version: {})", Plugin::VERSION.string());

--- a/src/ShaderCache.cpp
+++ b/src/ShaderCache.cpp
@@ -2985,7 +2985,7 @@ namespace SIE
 		// still reads high briefly, which would otherwise underflow uint64_t (logs as ~2^64-1).
 		const uint64_t total = compilationSet.totalTasks.load(std::memory_order_relaxed);
 		const uint64_t done = compilationSet.completedTasks.load(std::memory_order_relaxed) +
-		                      compilationSet.failedTasks.load(std::memory_order_relaxed);
+		                     compilationSet.failedTasks.load(std::memory_order_relaxed);
 		// This task has already finished running, but Complete(task) has not yet updated the counters.
 		// Include the current task in the local progress snapshot so the logged remaining count is accurate.
 		const uint64_t doneIncludingCurrent = (done < total) ? (done + 1) : total;

--- a/src/ShaderCache.cpp
+++ b/src/ShaderCache.cpp
@@ -18,27 +18,6 @@
 
 namespace SIE
 {
-	namespace
-	{
-		// Extended far water: set when an installed plugin known to render water geometry
-		// beyond the far clip plane (a horizon-filling water skirt) is detected. When set,
-		// water shaders are compiled with the FAR_WATER define, which folds beyond-far-plane
-		// water back onto the far plane and shades it as bottomless where nothing rendered
-		// behind it. Without a detected provider the water pipeline keeps exact vanilla
-		// far-clip behavior: water clips at the far plane and terminates against the sky.
-		// Detection happens once, in ShaderCache::ValidateDiskCache, after every SKSE plugin
-		// has loaded and before any water shader is compiled.
-		std::atomic_bool extendedFarWater{ false };
-
-		// Plugins whose presence means water geometry will exist beyond the far clip plane
-		constexpr const wchar_t* farWaterProviderDlls[] = { L"HorizonFix.dll" };
-	}
-
-	bool IsExtendedFarWaterEnabled()
-	{
-		return extendedFarWater.load(std::memory_order_acquire);
-	}
-
 	// Custom include handler to track all includes during shader compilation
 	class TrackingIncludeHandler : public ID3DInclude
 	{
@@ -516,10 +495,6 @@ namespace SIE
 					"5", "6", "7" } };
 				defines[lastIndex++] = { "SPECULAR", nullptr };
 				defines[lastIndex++] = { "NUM_SPECULAR_LIGHTS", numLightDefines[technique] };
-			}
-
-			if (SIE::IsExtendedFarWaterEnabled()) {
-				defines[lastIndex++] = { "FAR_WATER", nullptr };
 			}
 
 			for (auto* feature : Feature::GetFeatureList()) {
@@ -2443,29 +2418,6 @@ namespace SIE
 			valid = false;
 		}
 
-		// Detect installed providers of water geometry beyond the far clip plane. This runs
-		// at kPostPostLoad - every SKSE plugin is loaded, no water shader is compiled yet.
-		// The result changes the water shader defines, so a provider appearing or
-		// disappearing between sessions must invalidate the disk cache below.
-		{
-			bool farWaterDetected = false;
-			for (const auto* provider : farWaterProviderDlls) {
-				if (GetModuleHandleW(provider) != nullptr) {
-					logger::info("Extended far water provider detected ({}); water shaders will support geometry beyond the far clip plane",
-						Util::WStringToString(provider));
-					farWaterDetected = true;
-				}
-			}
-			extendedFarWater.store(farWaterDetected, std::memory_order_release);
-
-			const bool cachedFarWater = ini.GetBoolValue("Cache", "ExtendedFarWater", false);
-			if (cachedFarWater != farWaterDetected) {
-				logger::info("Disk cache outdated: extended far water changed (current: {}, cached: {})",
-					farWaterDetected, cachedFarWater);
-				valid = false;
-			}
-		}
-
 		if (valid) {
 			logger::info("Using disk cache");
 		} else {
@@ -2478,7 +2430,6 @@ namespace SIE
 		CSimpleIniA ini;
 		ini.SetUnicode();
 		ini.SetValue("Cache", "PluginVersion", Plugin::VERSION.string().c_str());
-		ini.SetBoolValue("Cache", "ExtendedFarWater", IsExtendedFarWaterEnabled());
 		globals::state->WriteDiskCacheInfo(ini);
 		ini.SaveFile(L"Data\\ShaderCache\\Info.ini");
 		logger::info("Saved disk cache info (plugin version: {})", Plugin::VERSION.string());
@@ -3034,7 +2985,7 @@ namespace SIE
 		// still reads high briefly, which would otherwise underflow uint64_t (logs as ~2^64-1).
 		const uint64_t total = compilationSet.totalTasks.load(std::memory_order_relaxed);
 		const uint64_t done = compilationSet.completedTasks.load(std::memory_order_relaxed) +
-		                     compilationSet.failedTasks.load(std::memory_order_relaxed);
+		                      compilationSet.failedTasks.load(std::memory_order_relaxed);
 		// This task has already finished running, but Complete(task) has not yet updated the counters.
 		// Include the current task in the local progress snapshot so the logged remaining count is accurate.
 		const uint64_t doneIncludingCurrent = (done < total) ? (done + 1) : total;


### PR DESCRIPTION
Tested with:
* UW ON - Horizon Fix OFF (Normal vanilla farclip works correctly)
* UW ON - Horizon Fix ON (Vanilla farclip no longer cuts off horizon fix water)
* UW OFF - Horizon Fix OFF (Normal vanilla farclip works correctly)
* UW OFF - Horizon Fix ON (Works as it always did in nexus CS, maybe because water.hlsl not used when UW is disabled?)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional Horizon Fix compatibility for water rendering.
  - Reduces far-distance water depth and horizon artifacts when the Horizon Fix plugin is installed.
  - Added feature settings information and automatic compatibility detection.

- **Bug Fixes**
  - Improved water refraction and depth handling against empty background areas.
  - Automatically preserves default behavior when the required compatibility plugin is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->