### PR TITLE
fix(unified-water): fix cache regenerating on each load

### DIFF
--- a/src/Features/UnifiedWater.cpp
+++ b/src/Features/UnifiedWater.cpp
@@ -277,6 +277,68 @@ bool UnifiedWater::MenuOpenCloseEventHandler::Register()
 	return true;
 }
 
+namespace
+{
+	// Permissive sharing so a lingering handle on UWLoadOrder.hash never blocks a
+	// later attempt with ERROR_SHARING_VIOLATION - reproduced directly: writes to
+	// Data/ root failed while the game was running. The retry only helps a
+	// transient locker (AV/indexer), not a persistent one.
+	constexpr int kShareRetries = 3;
+	constexpr DWORD kShareRetryDelayMs = 50;
+
+	bool ReadHashFile(const std::filesystem::path& path, uint64_t& outHash)
+	{
+		for (int attempt = 0; attempt < kShareRetries; ++attempt) {
+			winrt::file_handle handle{ CreateFileW(path.c_str(), GENERIC_READ,
+				FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, nullptr,
+				OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr) };
+			if (handle) {
+				DWORD bytesRead = 0;
+				const bool ok = ReadFile(handle.get(), &outHash, sizeof(outHash), &bytesRead, nullptr) &&
+				                bytesRead == sizeof(outHash);
+				if (!ok)
+					logger::warn("[Unified Water] '{}' exists but could not be fully read; treating as no persisted hash", path.string());
+				return ok;
+			}
+			const DWORD err = GetLastError();
+			if (err == ERROR_FILE_NOT_FOUND || err == ERROR_PATH_NOT_FOUND)
+				return false;
+			if ((err == ERROR_SHARING_VIOLATION || err == ERROR_LOCK_VIOLATION) && attempt + 1 < kShareRetries) {
+				Sleep(kShareRetryDelayMs);
+				continue;
+			}
+			logger::warn("[Unified Water] Failed to open '{}' for reading (error {})", path.string(), err);
+			return false;
+		}
+		return false;
+	}
+
+	bool WriteHashFile(const std::filesystem::path& path, uint64_t hash)
+	{
+		for (int attempt = 0; attempt < kShareRetries; ++attempt) {
+			winrt::file_handle handle{ CreateFileW(path.c_str(), GENERIC_WRITE,
+				FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, nullptr,
+				CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr) };
+			if (handle) {
+				DWORD bytesWritten = 0;
+				const bool ok = WriteFile(handle.get(), &hash, sizeof(hash), &bytesWritten, nullptr) &&
+				                bytesWritten == sizeof(hash);
+				if (!ok)
+					logger::error("[Unified Water] Failed to persist load-order hash to '{}'; cache will regenerate again next launch", path.string());
+				return ok;
+			}
+			const DWORD err = GetLastError();
+			if ((err == ERROR_SHARING_VIOLATION || err == ERROR_LOCK_VIOLATION) && attempt + 1 < kShareRetries) {
+				Sleep(kShareRetryDelayMs);
+				continue;
+			}
+			logger::error("[Unified Water] Failed to open '{}' for writing (error {}); cache will regenerate again next launch", path.string(), err);
+			return false;
+		}
+		return false;
+	}
+}
+
 bool UnifiedWater::LoadOrderChanged()
 {
 	auto* dataHandler = RE::TESDataHandler::GetSingleton();
@@ -312,26 +374,25 @@ bool UnifiedWater::LoadOrderChanged()
 
 	addBytes(reinterpret_cast<const unsigned char*>(Plugin::VERSION.string().c_str()));
 
-	namespace fs = std::filesystem;
-	const fs::path path = Util::PathHelpers::GetDataPath() / "UWLoadOrder.hash";
+	// Data/ root is subject to a persistent external lock while the game runs (writes
+	// fail with ERROR_SHARING_VIOLATION for the whole session). Our plugin's own
+	// subfolder isn't - SettingsUser.json writes there every session without issue -
+	// so the hash lives there instead of directly under Data/.
+	const std::filesystem::path path = Util::PathHelpers::GetCommunityShaderPath() / "UWLoadOrder.hash";
 
 	uint64_t existingHash = 0;
-	if (fs::exists(path)) {
-		std::ifstream file(path, std::ios::binary);
-		if (file.is_open()) {
-			file.read(reinterpret_cast<char*>(&existingHash), sizeof(existingHash));
-			file.close();
-		}
+	ReadHashFile(path, existingHash);
+
+	const bool changed = hash != existingHash;
+	logger::debug("[Unified Water] Load order hash: computed={:#x} persisted={:#x} changed={}", hash, existingHash, changed);
+
+	if (changed) {
+		std::error_code ec;
+		std::filesystem::create_directories(path.parent_path(), ec);
+		WriteHashFile(path, hash);
 	}
 
-	if (hash != existingHash) {
-		std::ofstream file(path, std::ios::binary | std::ios::trunc);
-		if (file.is_open()) {
-			file.write(reinterpret_cast<const char*>(&hash), sizeof(hash));
-		}
-	}
-
-	return hash != existingHash;
+	return changed;
 }
 
 void UnifiedWater::SetFlowmapTex() const


### PR DESCRIPTION
upstreamed from OS:https://github.com/alandtse/open-shaders/pull/316
adjusted for CS.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved load-order detection reliability by handling temporary file access conflicts and sharing restrictions.
  * Persisted load-order information in the appropriate Community Shaders location.
  * Automatically creates the required directory when it does not exist.
  * Added logging to clarify the computed and stored load-order values and whether a change was detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->