### PR TITLE
fix(cs-editor): viewport gamma and backdrop dimming

### DIFF
--- a/src/CSEditor/EditorWindow.cpp
+++ b/src/CSEditor/EditorWindow.cpp
@@ -915,6 +915,11 @@ void EditorWindow::ShowViewportWindow()
 	}
 
 	if (tempTexture && tempTexture->srv) {
+		// tempTexture is a raw copy of the framebuffer RT; its alpha is not guaranteed to be 1,
+		// so a plain ImGui::Image can show the dimmed backdrop through as a transparency cutout.
+		const ImVec2 imageMin = ImGui::GetCursorScreenPos();
+		const ImVec2 imageMax(imageMin.x + imageSize.x, imageMin.y + imageSize.y);
+		ImGui::GetWindowDrawList()->AddRectFilled(imageMin, imageMax, IM_COL32_BLACK);
 		ImGui::Image((void*)tempTexture->srv.get(), imageSize);
 	} else {
 		ImGui::TextDisabled("%s", T(TKEY("viewport_unavailable"), "Viewport unavailable"));
@@ -953,7 +958,11 @@ void EditorWindow::RenderUI()
 	ImGui::GetStyle().FontScaleMain = settings.editorUIScale;
 
 	if (IsViewportActive()) {
-		ImGui::GetBackgroundDrawList()->AddRectFilled({ 0, 0 }, io.DisplaySize, ImGui::GetColorU32(ImGuiCol_ModalWindowDimBg));
+		auto* backgroundDrawList = ImGui::GetBackgroundDrawList();
+		backgroundDrawList->AddRectFilled({ 0, 0 }, io.DisplaySize, ImGui::GetColorU32(ImGuiCol_ModalWindowDimBg));
+		backgroundDrawList->AddRectFilled(
+			{ 0, 0 }, io.DisplaySize,
+			ImGui::GetColorU32(ImVec4(0.0f, 0.0f, 0.0f, ThemeManager::Constants::EDITOR_VIEWPORT_BACKGROUND_DIM_ALPHA)));
 	}
 
 	// Check for Ctrl+Z to undo

--- a/src/Menu/ThemeManager.h
+++ b/src/Menu/ThemeManager.h
@@ -191,6 +191,7 @@ public:
 		static constexpr float SEPARATOR_THICKNESS = 3.0f;
 		static constexpr float UNDOCKED_ICON_ITEM_SPACING = 6.0f;
 		static constexpr float POPUP_BUTTON_WIDTH = 180.0f;
+		static constexpr float EDITOR_VIEWPORT_BACKGROUND_DIM_ALPHA = 0.35f;  // Extra backdrop dim while the CS Editor viewport is open
 
 		// Feature header constants
 		static constexpr float DEFAULT_FEATURE_TITLE_SCALE = 1.5f;  // Default scale for feature title text


### PR DESCRIPTION
upstreamed from: https://github.com/alandtse/open-shaders/pull/312
trimmed for CS.
<img width="2560" height="1440" alt="afbeelding" src="https://github.com/user-attachments/assets/1af65bec-c1e2-4562-ad74-bc08d702150e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved viewport display clarity by adding an opaque background behind viewport images.
  * Updated viewport overlays to apply consistent dimming, preventing unintended backdrop visibility while the viewport is active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->