### PR TITLE
fix(cs-editor): refactor time lock and robust guards

### DIFF
--- a/src/CSEditor/EditorWindow.cpp
+++ b/src/CSEditor/EditorWindow.cpp
@@ -1931,6 +1931,9 @@ void EditorWindow::SetTimeRunningForMenu(bool a_needsRunningTime)
 		// Only re-pause afterwards if the pause is ours; a zero timescale we did not set (stale
 		// save, console, other mod) stays restored so it cannot freeze the game again.
 		wasPausedBeforeMenu = timePaused;
+		// A non-positive snapshot would restore straight back to frozen time.
+		if (savedTimeScale <= 0.0f)
+			savedTimeScale = kVanillaTimeScale;
 		if (timePaused)
 			ResumeTime();
 		else

--- a/src/CSEditor/EditorWindow.cpp
+++ b/src/CSEditor/EditorWindow.cpp
@@ -17,6 +17,8 @@
 
 #define I18N_KEY_PREFIX "cs_editor."
 
+#include <algorithm>
+
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(EditorWindow::Settings::PaletteColorEntry, r, g, b, useCount, lastUsedTime, isFavorite)
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(EditorWindow::Settings::PaletteValueEntry, name, value, useCount, lastUsedTime, isFavorite)
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(EditorWindow::Settings::PaletteFavoriteColor, hasValue, r, g, b)
@@ -1897,39 +1899,75 @@ void EditorWindow::ResetTimeScale()
 	timeScaleSlider = kVanillaTimeScale;
 }
 
-void EditorWindow::UpdateTimeState()
+namespace
+{
+	// Time must keep running while these are up: the engine hangs on fast travel and sleep/wait
+	// never completes when game time cannot advance. MapMenu covers the fast travel launch point.
+	constexpr std::array kTimeSensitiveMenus{ RE::LoadingMenu::MENU_NAME, RE::SleepWaitMenu::MENU_NAME, RE::MapMenu::MENU_NAME };
+
+	/** @brief Returns true if the menu is one that must not run with a zero timescale. */
+	bool IsTimeSensitiveMenu(const RE::BSFixedString& a_menuName)
+	{
+		return std::ranges::any_of(kTimeSensitiveMenus, [&](std::string_view name) { return a_menuName == name; });
+	}
+
+	/** @brief Returns true if any menu that must not run with a zero timescale is still open. */
+	bool IsAnyTimeSensitiveMenuOpen()
+	{
+		auto ui = globals::game::ui ? globals::game::ui : RE::UI::GetSingleton();
+		return ui && std::ranges::any_of(kTimeSensitiveMenus, [&](std::string_view name) { return ui->IsMenuOpen(name); });
+	}
+}
+
+void EditorWindow::SetTimeRunningForMenu(bool a_needsRunningTime)
 {
 	auto calendar = globals::game::calendar ? globals::game::calendar : RE::Calendar::GetSingleton();
-	auto ui = globals::game::ui ? globals::game::ui : RE::UI::GetSingleton();
 	if (!calendar || !calendar->timeScale)
 		return;
 
-	bool needsTimeRestored = ui && (ui->IsMenuOpen(RE::SleepWaitMenu::MENU_NAME) || ui->IsMenuOpen(RE::LoadingMenu::MENU_NAME));
-
-	// External state sync (skip while a time-sensitive menu is open)
-	if (!needsTimeRestored) {
-		if (calendar->timeScale->value == 0.0f && !timePaused)
-			savedTimeScale = kVanillaTimeScale;
-		else if (calendar->timeScale->value > 0.0f && timePaused)
-			timePaused = false;
-	}
-
-	// Temporarily restore time during sleep/wait, fast travel, and loading screens
-	if (needsTimeRestored && calendar->timeScale->value == 0.0f) {
-		if (!wasRestoredForWait) {
-			wasPausedBeforeWait = true;
-			if (timePaused)
-				ResumeTime();
-			else
-				calendar->timeScale->value = std::max(savedTimeScale, kVanillaTimeScale);
-			wasRestoredForWait = true;
-		}
-	} else if (!needsTimeRestored && wasRestoredForWait) {
-		if (wasPausedBeforeWait && !timePaused)
+	if (a_needsRunningTime) {
+		if (timeRestoredForMenu || calendar->timeScale->value != 0.0f)
+			return;
+		// Only re-pause afterwards if the pause is ours; a zero timescale we did not set (stale
+		// save, console, other mod) stays restored so it cannot freeze the game again.
+		wasPausedBeforeMenu = timePaused;
+		if (timePaused)
+			ResumeTime();
+		else
+			calendar->timeScale->value = std::max(savedTimeScale, kVanillaTimeScale);
+		timeRestoredForMenu = true;
+	} else if (timeRestoredForMenu) {
+		if (wasPausedBeforeMenu)
 			PauseTime();
-		wasRestoredForWait = false;
-		wasPausedBeforeWait = false;
+		timeRestoredForMenu = false;
+		wasPausedBeforeMenu = false;
 	}
+}
+
+RE::BSEventNotifyControl EditorWindow::MenuOpenCloseEventHandler::ProcessEvent(const RE::MenuOpenCloseEvent* a_event, RE::BSTEventSource<RE::MenuOpenCloseEvent>*)
+{
+	// Fast travel overlaps these menus (map then loading), so a close only ends the guard once
+	// the whole set is closed.
+	if (a_event && IsTimeSensitiveMenu(a_event->menuName))
+		GetSingleton()->SetTimeRunningForMenu(a_event->opening || IsAnyTimeSensitiveMenuOpen());
+
+	return RE::BSEventNotifyControl::kContinue;
+}
+
+bool EditorWindow::MenuOpenCloseEventHandler::Register()
+{
+	static MenuOpenCloseEventHandler singleton;
+	auto ui = globals::game::ui ? globals::game::ui : RE::UI::GetSingleton();
+
+	if (!ui) {
+		logger::error("[CSEditor] UI event source not found");
+		return false;
+	}
+
+	ui->GetEventSource<RE::MenuOpenCloseEvent>()->AddEventSink(&singleton);
+	logger::info("[CSEditor] Registered MenuOpenCloseEventHandler");
+
+	return true;
 }
 
 bool EditorWindow::DrawGameHourSlider(const char* label, const char* format)
@@ -1946,6 +1984,10 @@ void EditorWindow::DrawTimeControls()
 	auto calendar = globals::game::calendar ? globals::game::calendar : RE::Calendar::GetSingleton();
 	if (!calendar || !calendar->gameHour || !calendar->timeScale)
 		return;
+
+	// An external timescale change (console, other mods, the menu guard) overrides our pause
+	if (timePaused && calendar->timeScale->value > 0.0f)
+		timePaused = false;
 
 	const float framePadX = ImGui::GetStyle().FramePadding.x * 2.0f;
 	const char* resumeTimeText = T(TKEY("resume_time"), "Resume Time");

--- a/src/CSEditor/EditorWindow.h
+++ b/src/CSEditor/EditorWindow.h
@@ -182,8 +182,22 @@ public:
 	/** @brief Returns true if in-game time is currently paused. */
 	bool IsTimePaused() const { return timePaused; }
 
-	/** @brief Call once per frame to handle sleep/wait menu and external time state sync. */
-	void UpdateTimeState();
+	/**
+	 * @brief Restores time around menus the engine cannot complete with a zero timescale, and
+	 * re-pauses once they close. Sleep/wait never finishes and fast travel hangs otherwise.
+	 * @param a_needsRunningTime True while any such menu is open.
+	 */
+	void SetTimeRunningForMenu(bool a_needsRunningTime);
+
+	/** @brief Drives the time guard off menu transitions, since the world render stops during them. */
+	class MenuOpenCloseEventHandler : public RE::BSTEventSink<RE::MenuOpenCloseEvent>
+	{
+	public:
+		virtual RE::BSEventNotifyControl ProcessEvent(const RE::MenuOpenCloseEvent* a_event, RE::BSTEventSource<RE::MenuOpenCloseEvent>*) override;
+
+		/** @brief Subscribes the singleton handler to the UI menu event source. */
+		static bool Register();
+	};
 
 	/**
 	 * @brief Draw a game-hour slider.
@@ -365,8 +379,8 @@ private:
 	bool timePaused = false;
 	float savedTimeScale = kVanillaTimeScale;
 	float timeScaleSlider = kVanillaTimeScale;
-	bool wasRestoredForWait = false;
-	bool wasPausedBeforeWait = false;
+	bool timeRestoredForMenu = false;
+	bool wasPausedBeforeMenu = false;
 
 	// Sorting state
 	enum class SortColumn

--- a/src/Features/CSEditor.cpp
+++ b/src/Features/CSEditor.cpp
@@ -33,6 +33,7 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 void CSEditor::DataLoaded()
 {
 	s_dataAvailable = true;
+	EditorWindow::MenuOpenCloseEventHandler::Register();
 }
 
 bool CSEditor::HasWidgetJsonFiles()
@@ -220,9 +221,6 @@ void CSEditor::Prepass()
 			sky->ForceWeather(lockedWeather, false);
 		}
 	}
-
-	// Update time controls (handles sleep/wait and external state sync)
-	editorWindow->UpdateTimeState();
 }
 
 void CSEditor::DrawWeatherPickerSection()

--- a/src/Menu/AdvancedSettingsRenderer.cpp
+++ b/src/Menu/AdvancedSettingsRenderer.cpp
@@ -707,8 +707,6 @@ void AdvancedSettingsRenderer::RenderDeveloperSection()
 				RE::Console::ExecuteCommand("player.setav speedmult 1000");
 				RE::Console::ExecuteCommand("tgm");
 				RE::Console::ExecuteCommand("tcl");
-				// Tracked pause rather than "set timescale to 0" so the freeze guard can restore
-				// time for the coc below and re-pause it once loading finishes.
 				EditorWindow::GetSingleton()->PauseTime();
 				RE::Console::ExecuteCommand("set gamehour to 12");
 				RE::Console::ExecuteCommand("coc whiterun");

--- a/src/Menu/AdvancedSettingsRenderer.cpp
+++ b/src/Menu/AdvancedSettingsRenderer.cpp
@@ -6,6 +6,7 @@
 #include <imgui_stdlib.h>
 #include <thread>
 
+#include "CSEditor/EditorWindow.h"
 #include "FeatureIssues.h"
 #include "Features/PerformanceOverlay/ABTesting/ABTesting.h"
 #include "Fonts.h"
@@ -706,7 +707,9 @@ void AdvancedSettingsRenderer::RenderDeveloperSection()
 				RE::Console::ExecuteCommand("player.setav speedmult 1000");
 				RE::Console::ExecuteCommand("tgm");
 				RE::Console::ExecuteCommand("tcl");
-				RE::Console::ExecuteCommand("set timescale to 0");
+				// Tracked pause rather than "set timescale to 0" so the freeze guard can restore
+				// time for the coc below and re-pause it once loading finishes.
+				EditorWindow::GetSingleton()->PauseTime();
 				RE::Console::ExecuteCommand("set gamehour to 12");
 				RE::Console::ExecuteCommand("coc whiterun");
 				RE::Console::ExecuteCommand("fw 81a");


### PR DESCRIPTION
Should finally stop people from accidentally freezing their game

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved time pausing and restoration when opening or closing time-sensitive menus by using event-based tracking instead of per-frame checks.
  * Prevented editor time handling from overwriting external timescale changes.
  * Updated editor time controls to correctly reflect the actual in-game timescale, including external adjustments.
* **Developer Tools**
  * Improved the “Test Conditions” time control to pause time via the editor’s pause action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->