### PR TITLE
fix(shader): rungrass compilation fail

### DIFF
--- a/package/Shaders/RunGrass.hlsl
+++ b/package/Shaders/RunGrass.hlsl
@@ -336,12 +336,15 @@ cbuffer AlphaTestRefCB : register(b11)
 
 #	define SampColorSampler SampBaseSampler
 
+#	if defined(SKYLIGHTING)
+#		define SKYLIGHTING_SHADOW_VIS
+#	endif
+
 #	if defined(DYNAMIC_CUBEMAPS)
 #		include "DynamicCubemaps/DynamicCubemaps.hlsli"
 #	endif
 
 #	if defined(SKYLIGHTING)
-#		define SKYLIGHTING_SHADOW_VIS
 #		include "Skylighting/Skylighting.hlsli"
 #	endif
 


### PR DESCRIPTION
fixes failing shaders after #2498

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shader lighting compatibility by ensuring shadow visibility settings are applied consistently when dynamic cubemaps and skylighting are enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->