### PR TITLE
fix(upscaling): check sharpness toggle in DLSS output routing

### DIFF
--- a/src/Features/Upscaling/Streamline.cpp
+++ b/src/Features/Upscaling/Streamline.cpp
@@ -564,7 +564,7 @@ void Streamline::Upscale(ID3D11Resource* a_upscalingTexture, ID3D11Resource* a_r
 	// sharpen directly into kMAIN.UAV without a CopyResource round-trip.
 	auto& upscaling = globals::features::upscaling;
 	ID3D11Resource* colorOut =
-		(upscaling.settings.sharpnessDLSS > 0.0f && upscaling.sharpenerTexture) ? upscaling.sharpenerTexture->resource.get() : a_upscalingTexture;
+		(upscaling.settings.sharpnessEnabledDLSS && upscaling.settings.sharpnessDLSS > 0.0f && upscaling.sharpenerTexture) ? upscaling.sharpenerTexture->resource.get() : a_upscalingTexture;
 
 	sl::Extent extentIn{ 0, 0, (uint)renderSize.x, (uint)renderSize.y };
 	sl::Extent extentOut{ 0, 0, (uint)screenSize.x, (uint)screenSize.y };


### PR DESCRIPTION
## Summary
- Fixed DLSS output being written to `sharpenerTexture` instead of kMAIN when sharpness was toggled off but the slider value was still > 0
- The routing condition in `Streamline::Upscale()` now checks `sharpnessEnabledDLSS` in addition to the slider value, matching the guard in `ApplySharpening()`

## Test plan
- [ ] Enable DLSS with sharpness on and slider > 0, verify sharpening works
- [ ] Toggle sharpness off (leaving slider unchanged), verify the image is still correctly upscaled (no stale/broken frame)
- [ ] Toggle sharpness back on, verify sharpening resumes
- [ ] Verify FSR path is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected DLSS sharpening behavior so the sharpening texture is used only when DLSS sharpening is explicitly enabled and configured with a positive strength.
  - Prevents unintended sharpening output when the feature is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->