### PR TITLE
refactor(effect11): clean up post-processing and settings

### DIFF
--- a/package/Shaders/Common/SharedData.hlsli
+++ b/package/Shaders/Common/SharedData.hlsli
@@ -278,28 +278,12 @@ namespace SharedData
 
 		uint EnableCloudsScattering;
 		uint EnableCloudsLightingFromMoon;
-		uint ScatteringColorHDRWeighting;
-		float SkyScatteringAtmosphereThickness;
-
-		float SkyScatteringHorizonRange;
 		float SkyScatteringIntensity;
 		float SkyScatteringAmount;
-		float SkyScatteringDustVolume;
-
-		float SkyScatteringDustDensity;
-		float SkyScatteringDustDarkening;
-		float SkyScatteringShadowAmount;
-		float SkyScatteringColorFromSun;
 
 		float3 SkyScatteringColor;
-		float SkyScatteringAirGlowIntensity;
+		float SkyScatteringColorFromSun;
 
-		float SkyScatteringAirGlowRange;
-		float SkyScatteringSunGlowIntensity;
-		float SkyScatteringSunGlowRange;
-		float SkyScatteringMoonGlowAmount;
-
-		float SkyScatteringMoonGlowRange;
 		float SkyScatteringCloudsLightingSunMultiplier;
 		float SkyScatteringCloudsLightingMoonIntensity;
 
@@ -313,6 +297,7 @@ namespace SharedData
 		float RainMotionTransparency;
 		float FireIntensity;
 		float FireCurve;
+		uint pad0;
 	};
 	struct TerrainBlendingSettings
 	{

--- a/src/Features/Effect11.cpp
+++ b/src/Features/Effect11.cpp
@@ -27,8 +27,8 @@ Effect11::PerFrame Effect11::GetCommonBufferData()
 	PerFrame data{};
 
 	data.Enable = enableEffect;
-	data.EnableSky = enableEffect && settingManager.GetValue<bool>("Enable", "SKY");
-	data.ColorPow = settingManager.GetInterpolatedTimeOfDayValue("ColorPow", "ENVIRONMENT");
+	data.EnableSky = enableEffect;
+	data.ColorPow = settingManager.GetValue<float>("ColorPow", "ENVIRONMENT");
 
 	data.CloudsCurve = settingManager.GetInterpolatedTimeOfDayValue("CloudsCurve", "SKY");
 	data.CloudsDesaturation = settingManager.GetInterpolatedTimeOfDayValue("CloudsDesaturation", "SKY");
@@ -42,7 +42,7 @@ Effect11::PerFrame Effect11::GetCommonBufferData()
 	data.UseProceduralGradientWeights = enableEffect && settingManager.GetValue<bool>("UseProceduralGradientWeights", "SKY");
 	data.ProceduralGradientWeightCurve = settingManager.GetInterpolatedTimeOfDayValue("ProceduralGradientWeightCurve", "SKY");
 
-	data.LightSpriteIntensity = settingManager.GetInterpolatedTimeOfDayValue("Intensity", "LIGHTSPRITE");
+	data.LightSpriteIntensity = settingManager.GetValue<float>("Intensity", "LIGHTSPRITE");
 
 	data.ParticleIntensity = settingManager.GetInterpolatedTimeOfDayValue("Intensity", "PARTICLE");
 	data.ParticleLightingInfluence = settingManager.GetInterpolatedTimeOfDayValue("LightingInfluence", "PARTICLE");
@@ -50,24 +50,11 @@ Effect11::PerFrame Effect11::GetCommonBufferData()
 	data.ParticlePointLightingInfluence = settingManager.GetInterpolatedTimeOfDayValue("PointLightingInfluence", "PARTICLE");
 
 	data.EnableCloudsLightingFromMoon = settingManager.GetValue<bool>("EnableCloudsLightingFromMoon", "SKYSCATTERING");
-	data.ScatteringColorHDRWeighting = settingManager.GetValue<bool>("ScatteringColorHDRWeighting", "SKYSCATTERING");
-	data.SkyScatteringAtmosphereThickness = settingManager.GetInterpolatedTimeOfDayValue("AtmosphereThickness", "SKYSCATTERING");
-	data.SkyScatteringHorizonRange = settingManager.GetInterpolatedTimeOfDayValue("HorizonRange", "SKYSCATTERING");
 	data.SkyScatteringIntensity = settingManager.GetInterpolatedTimeOfDayValue("Intensity", "SKYSCATTERING");
 	data.SkyScatteringAmount = settingManager.GetInterpolatedTimeOfDayValue("Amount", "SKYSCATTERING");
-	data.SkyScatteringDustVolume = settingManager.GetInterpolatedTimeOfDayValue("DustVolume", "SKYSCATTERING");
-	data.SkyScatteringDustDensity = settingManager.GetInterpolatedTimeOfDayValue("DustDensity", "SKYSCATTERING");
-	data.SkyScatteringDustDarkening = settingManager.GetInterpolatedTimeOfDayValue("DustDarkening", "SKYSCATTERING");
-	data.SkyScatteringShadowAmount = settingManager.GetInterpolatedTimeOfDayValue("ShadowAmount", "SKYSCATTERING");
 	data.SkyScatteringColorFromSun = settingManager.GetInterpolatedTimeOfDayValue("ColorFromSun", "SKYSCATTERING");
 	auto scatteringColor = settingManager.GetInterpolatedColorTimeOfDayValue("ScatteringColor", "SKYSCATTERING");
 	data.SkyScatteringColor = { scatteringColor.x, scatteringColor.y, scatteringColor.z };
-	data.SkyScatteringAirGlowIntensity = settingManager.GetInterpolatedTimeOfDayValue("AirGlowIntensity", "SKYSCATTERING");
-	data.SkyScatteringAirGlowRange = settingManager.GetInterpolatedTimeOfDayValue("AirGlowRange", "SKYSCATTERING");
-	data.SkyScatteringSunGlowIntensity = settingManager.GetInterpolatedTimeOfDayValue("SunGlowIntensity", "SKYSCATTERING");
-	data.SkyScatteringSunGlowRange = settingManager.GetInterpolatedTimeOfDayValue("SunGlowRange", "SKYSCATTERING");
-	data.SkyScatteringMoonGlowAmount = settingManager.GetInterpolatedTimeOfDayValue("MoonGlowAmount", "SKYSCATTERING");
-	data.SkyScatteringMoonGlowRange = settingManager.GetInterpolatedTimeOfDayValue("MoonGlowRange", "SKYSCATTERING");
 	data.SkyScatteringCloudsLightingSunMultiplier = settingManager.GetInterpolatedTimeOfDayValue("CloudsLightingSunMultiplier", "SKYSCATTERING");
 	data.SkyScatteringCloudsLightingMoonIntensity = settingManager.GetInterpolatedTimeOfDayValue("CloudsLightingMoonIntensity", "SKYSCATTERING");
 
@@ -81,7 +68,7 @@ Effect11::PerFrame Effect11::GetCommonBufferData()
 	}
 	data.VolumetricRaysSkyColorAmount = settingManager.GetInterpolatedTimeOfDayValue("SkyColorAmount", "VOLUMETRICRAYS");
 
-	data.EnableRain = enableEffect && raindropSRV && settingManager.GetValue<bool>("Enable", "RAIN");
+	data.EnableRain = enableEffect && raindropSRV;
 	data.RainMotionStretch = settingManager.GetInterpolatedTimeOfDayValue("MotionStretch", "RAIN");
 	data.RainMotionTransparency = settingManager.GetInterpolatedTimeOfDayValue("MotionTransparency", "RAIN");
 
@@ -120,12 +107,14 @@ void Effect11::LoadRaindropTexture()
 {
 	raindropTexture = nullptr;
 	raindropSRV = nullptr;
+	raindropStatus.clear();
 
 	auto& presetManager = PresetManager::GetSingleton();
 	auto enbPath = presetManager.GetENBSeriesPath();
 	auto raindropPath = enbPath / "enbraindrops.png";
 
 	if (!std::filesystem::exists(raindropPath)) {
+		raindropStatus = "Texture not found: enbraindrops.png";
 		logger::debug("[Effect11] Raindrop texture not found: {}", raindropPath.string());
 		return;
 	}
@@ -135,6 +124,7 @@ void Effect11::LoadRaindropTexture()
 	DirectX::ScratchImage image;
 	HRESULT hr = DirectX::LoadFromWICFile(widePath.c_str(), DirectX::WIC_FLAGS_IGNORE_SRGB, nullptr, image);
 	if (FAILED(hr)) {
+		raindropStatus = std::format("Failed to load texture (invalid image, HRESULT 0x{:08X})", static_cast<uint32_t>(hr));
 		logger::error("[Effect11] Failed to load raindrop texture: {}", raindropPath.string());
 		return;
 	}
@@ -143,6 +133,7 @@ void Effect11::LoadRaindropTexture()
 	hr = DirectX::GenerateMipMaps(image.GetImages(), image.GetImageCount(), image.GetMetadata(),
 		DirectX::TEX_FILTER_DEFAULT, 0, mipImage);
 	if (FAILED(hr)) {
+		raindropStatus = std::format("Failed to generate mipmaps (HRESULT 0x{:08X})", static_cast<uint32_t>(hr));
 		logger::error("[Effect11] Failed to generate mipmaps for raindrop texture");
 		return;
 	}
@@ -151,6 +142,7 @@ void Effect11::LoadRaindropTexture()
 	hr = DirectX::Compress(mipImage.GetImages(), mipImage.GetImageCount(), mipImage.GetMetadata(),
 		DXGI_FORMAT_BC7_UNORM, DirectX::TEX_COMPRESS_BC7_QUICK, 1.0f, bc7Image);
 	if (FAILED(hr)) {
+		raindropStatus = std::format("Failed to compress texture (HRESULT 0x{:08X})", static_cast<uint32_t>(hr));
 		logger::error("[Effect11] Failed to compress raindrop texture to BC7");
 		return;
 	}
@@ -160,6 +152,7 @@ void Effect11::LoadRaindropTexture()
 		bc7Image.GetImages(), bc7Image.GetImageCount(), bc7Image.GetMetadata(),
 		reinterpret_cast<ID3D11Resource**>(raindropTexture.put()));
 	if (FAILED(hr)) {
+		raindropStatus = std::format("Failed to create GPU texture (HRESULT 0x{:08X})", static_cast<uint32_t>(hr));
 		logger::error("[Effect11] Failed to create raindrop GPU texture");
 		return;
 	}
@@ -174,6 +167,7 @@ void Effect11::LoadRaindropTexture()
 
 	hr = device->CreateShaderResourceView(raindropTexture.get(), &srvDesc, raindropSRV.put());
 	if (FAILED(hr)) {
+		raindropStatus = std::format("Failed to create shader resource view (HRESULT 0x{:08X})", static_cast<uint32_t>(hr));
 		logger::error("[Effect11] Failed to create raindrop SRV");
 		raindropTexture = nullptr;
 		return;
@@ -228,10 +222,6 @@ void Effect11::Prepass()
 	}
 
 	auto& settingManager = SettingManager::GetSingleton();
-
-	if (!settingManager.GetValue<bool>("Enable", "SKY")) {
-		return;
-	}
 
 	auto imageSpaceManager = RE::ImageSpaceManager::GetSingleton();
 	if (!imageSpaceManager) {
@@ -364,9 +354,7 @@ void Effect11::OverrideWeather(RE::Sky* a_sky)
 		a_sky->fogFar /= fogAmountMultiplier;
 	}
 
-	const bool enableSky = enableEffect && settingManager.GetValue<bool>("Enable", "SKY");
-
-	if (enableSky) {
+	if (enableEffect) {
 		{
 			auto& sunColor = colors[(uint)RE::TESWeather::ColorTypes::kSun];
 
@@ -511,9 +499,9 @@ void Effect11::OverridePointLightColor(float3& a_color)
 {
 	auto& settingManager = SettingManager::GetSingleton();
 
-	a_color = Curve(a_color, settingManager.GetInterpolatedTimeOfDayValue("PointLightingCurve", "ENVIRONMENT"));
-	a_color = Desaturation(a_color, settingManager.GetInterpolatedTimeOfDayValue("PointLightingDesaturation", "ENVIRONMENT"));
-	a_color = Intensity(a_color, settingManager.GetInterpolatedTimeOfDayValue("PointLightingIntensity", "ENVIRONMENT"));
+	a_color = Curve(a_color, settingManager.GetValue<float>("PointLightingCurve", "ENVIRONMENT"));
+	a_color = Desaturation(a_color, settingManager.GetValue<float>("PointLightingDesaturation", "ENVIRONMENT"));
+	a_color = Intensity(a_color, settingManager.GetValue<float>("PointLightingIntensity", "ENVIRONMENT"));
 }
 
 void Effect11::OverrideAmbientLighting(DirectionalAmbientColors& DirectionalAmbientColors)
@@ -552,11 +540,8 @@ bool Effect11::HandleTonemapRender(RE::RENDER_TARGET a_input, RE::RENDER_TARGET 
 	auto& effectManager = EffectManager::GetSingleton();
 
 	if (enableEffect && !settingManager.GetValue<bool>("UseOriginalPostProcessing", "EFFECT")) {
-		auto renderer = globals::game::renderer;
-		auto& renderTargets = renderer->GetRuntimeData().renderTargets;
-		bool validInput = a_input > RE::RENDER_TARGETS::kNONE && a_input < RE::RENDER_TARGETS::kTOTAL && renderTargets[a_input].SRV;
-		auto& input = validInput ? renderTargets[a_input] : renderTargets[RE::RENDER_TARGETS::kMAIN];
-		effectManager.ExecuteEffects(input, renderTargets[a_output]);
+		auto& renderTargets = globals::game::renderer->GetRuntimeData().renderTargets;
+		effectManager.ExecuteEffects(renderTargets[a_input], renderTargets[a_output]);
 		return true;
 	}
 	return false;

--- a/src/Features/Effect11.h
+++ b/src/Features/Effect11.h
@@ -57,28 +57,12 @@ public:
 
 		uint EnableCloudsScattering;
 		uint EnableCloudsLightingFromMoon;
-		uint ScatteringColorHDRWeighting;
-		float SkyScatteringAtmosphereThickness;
-
-		float SkyScatteringHorizonRange;
 		float SkyScatteringIntensity;
 		float SkyScatteringAmount;
-		float SkyScatteringDustVolume;
-
-		float SkyScatteringDustDensity;
-		float SkyScatteringDustDarkening;
-		float SkyScatteringShadowAmount;
-		float SkyScatteringColorFromSun;
 
 		float3 SkyScatteringColor;
-		float SkyScatteringAirGlowIntensity;
+		float SkyScatteringColorFromSun;
 
-		float SkyScatteringAirGlowRange;
-		float SkyScatteringSunGlowIntensity;
-		float SkyScatteringSunGlowRange;
-		float SkyScatteringMoonGlowAmount;
-
-		float SkyScatteringMoonGlowRange;
 		float SkyScatteringCloudsLightingSunMultiplier;
 		float SkyScatteringCloudsLightingMoonIntensity;
 
@@ -92,6 +76,7 @@ public:
 		float RainMotionTransparency;
 		float FireIntensity;
 		float FireCurve;
+		uint pad0;
 	};
 
 	bool enableEffect = false;
@@ -111,6 +96,7 @@ public:
 
 	winrt::com_ptr<ID3D11Texture2D> raindropTexture;
 	winrt::com_ptr<ID3D11ShaderResourceView> raindropSRV;
+	std::string raindropStatus;
 	void LoadRaindropTexture();
 
 	PerFrame GetCommonBufferData();

--- a/src/Features/Effect11/EffectManager.cpp
+++ b/src/Features/Effect11/EffectManager.cpp
@@ -175,9 +175,9 @@ void EffectManager::RegisterSettings()
 	settingManager.RegisterTimeOfDaySetting("DirectLightingDesaturation", "ENVIRONMENT", 0.0f, -1.0f, 1.0f, 0.01f, true);
 	settingManager.RegisterTimeOfDaySetting("AmbientLightingIntensity", "ENVIRONMENT", 1.0f, 0.0f, 30000.0f, 0.01f, true);
 	settingManager.RegisterTimeOfDaySetting("AmbientLightingDesaturation", "ENVIRONMENT", 0.0f, -1.0f, 1.0f, 0.01f, true);
-	settingManager.RegisterTimeOfDaySetting("PointLightingIntensity", "ENVIRONMENT", 1.0f, 0.0f, 30000.0f, 0.01f, true);
-	settingManager.RegisterTimeOfDaySetting("PointLightingCurve", "ENVIRONMENT", 1.0f, 0.1f, 4.0f, 0.01f, true);
-	settingManager.RegisterTimeOfDaySetting("PointLightingDesaturation", "ENVIRONMENT", 0.0f, -1.0f, 1.0f, 0.01f, true);
+	settingManager.RegisterFloatSetting("PointLightingIntensity", "ENVIRONMENT", 1.0f, 0.0f, 30000.0f, 0.01f, false);
+	settingManager.RegisterFloatSetting("PointLightingCurve", "ENVIRONMENT", 1.0f, 0.1f, 4.0f, 0.01f, false);
+	settingManager.RegisterFloatSetting("PointLightingDesaturation", "ENVIRONMENT", 0.0f, -1.0f, 1.0f, 0.01f, false);
 	settingManager.RegisterColorTimeOfDaySetting("DirectLightingColorFilter", "ENVIRONMENT", { 1.0f, 1.0f, 1.0f }, true);
 	settingManager.RegisterTimeOfDaySetting("DirectLightingColorFilterAmount", "ENVIRONMENT", 0.0f, 0.0f, 1.0f, 0.01f, true);
 	settingManager.RegisterTimeOfDaySetting("FogColorMultiplier", "ENVIRONMENT", 1.0f, 0.0f, 30000.0f, 0.01f, true);
@@ -186,9 +186,8 @@ void EffectManager::RegisterSettings()
 	settingManager.RegisterTimeOfDaySetting("FogCurveMultiplier", "ENVIRONMENT", 1.0f, 0.0f, 10.0f, 0.01f, true);
 	settingManager.RegisterColorTimeOfDaySetting("FogColorFilter", "ENVIRONMENT", { 1.0f, 1.0f, 1.0f }, true);
 	settingManager.RegisterTimeOfDaySetting("FogColorFilterAmount", "ENVIRONMENT", 0.0f, 0.0f, 1.0f, 0.01f, true);
-	settingManager.RegisterTimeOfDaySetting("ColorPow", "ENVIRONMENT", 1.0f, 1.0f, 2.2f, 0.01f, true);
+	settingManager.RegisterFloatSetting("ColorPow", "ENVIRONMENT", 1.0f, 1.0f, 2.2f, 0.01f, false);
 
-	settingManager.RegisterBoolSetting("Enable", "SKY", true, false);
 	settingManager.RegisterBoolSetting("DisableWrongSkyMath", "SKY", false, false);
 	settingManager.RegisterTimeOfDaySetting("GradientIntensity", "SKY", 1.0f, 0.0f, 30000.0f, 0.01f, true);
 	settingManager.RegisterTimeOfDaySetting("GradientDesaturation", "SKY", 0.0f, -1.0f, 1.0f, 0.01f, true);
@@ -219,23 +218,10 @@ void EffectManager::RegisterSettings()
 	settingManager.RegisterTimeOfDaySetting("ProceduralGradientWeightCurve", "SKY", 4.0f, 1.0f, 32.0f, 0.01f, true);
 
 	settingManager.RegisterBoolSetting("EnableCloudsLightingFromMoon", "SKYSCATTERING", true, false);
-	settingManager.RegisterBoolSetting("ScatteringColorHDRWeighting", "SKYSCATTERING", false, false);
-	settingManager.RegisterTimeOfDaySetting("AtmosphereThickness", "SKYSCATTERING", 1.0f, 0.0f, 10.0f, 0.01f, true);
-	settingManager.RegisterTimeOfDaySetting("HorizonRange", "SKYSCATTERING", 0.5f, 0.0f, 1.0f, 0.01f, true);
 	settingManager.RegisterTimeOfDaySetting("Intensity", "SKYSCATTERING", 1.0f, 0.0f, 30000.0f, 0.01f, true);
 	settingManager.RegisterTimeOfDaySetting("Amount", "SKYSCATTERING", 0.0f, 0.0f, 1.0f, 0.01f, true);
-	settingManager.RegisterTimeOfDaySetting("DustVolume", "SKYSCATTERING", 0.2f, 0.0f, 1.0f, 0.01f, true);
-	settingManager.RegisterTimeOfDaySetting("DustDensity", "SKYSCATTERING", 0.2f, 0.0f, 1.0f, 0.01f, true);
-	settingManager.RegisterTimeOfDaySetting("DustDarkening", "SKYSCATTERING", 0.0f, 0.0f, 1.0f, 0.01f, true);
-	settingManager.RegisterTimeOfDaySetting("ShadowAmount", "SKYSCATTERING", 0.3f, 0.0f, 1.0f, 0.01f, true);
 	settingManager.RegisterTimeOfDaySetting("ColorFromSun", "SKYSCATTERING", 0.0f, 0.0f, 1.0f, 0.01f, true);
 	settingManager.RegisterColorTimeOfDaySetting("ScatteringColor", "SKYSCATTERING", { 1.0f, 1.0f, 1.0f }, true);
-	settingManager.RegisterTimeOfDaySetting("AirGlowIntensity", "SKYSCATTERING", 0.0f, 0.0f, 10.0f, 0.01f, true);
-	settingManager.RegisterTimeOfDaySetting("AirGlowRange", "SKYSCATTERING", 0.2f, 0.0f, 1.0f, 0.01f, true);
-	settingManager.RegisterTimeOfDaySetting("SunGlowIntensity", "SKYSCATTERING", 0.0f, 0.0f, 100.0f, 0.01f, true);
-	settingManager.RegisterTimeOfDaySetting("SunGlowRange", "SKYSCATTERING", 0.2f, 0.0f, 1.0f, 0.01f, true);
-	settingManager.RegisterTimeOfDaySetting("MoonGlowAmount", "SKYSCATTERING", 0.0f, 0.0f, 1.0f, 0.01f, true);
-	settingManager.RegisterTimeOfDaySetting("MoonGlowRange", "SKYSCATTERING", 0.2f, 0.0f, 1.0f, 0.01f, true);
 	settingManager.RegisterTimeOfDaySetting("CloudsLightingSunMultiplier", "SKYSCATTERING", 0.0f, 0.0f, 100.0f, 0.01f, true);
 	settingManager.RegisterTimeOfDaySetting("CloudsLightingMoonIntensity", "SKYSCATTERING", 0.0f, 0.0f, 10.0f, 0.01f, true);
 
@@ -256,9 +242,8 @@ void EffectManager::RegisterSettings()
 	settingManager.RegisterTimeOfDaySetting("AmbientInfluence", "PARTICLE", 0.5f, 0.0f, 10.0f, 0.01f, true);
 	settingManager.RegisterTimeOfDaySetting("PointLightingInfluence", "PARTICLE", 1.0f, 0.0f, 10.0f, 0.01f, true);
 
-	settingManager.RegisterTimeOfDaySetting("Intensity", "LIGHTSPRITE", 1.0f, 0.0f, 30000.0f, 0.01f, true);
+	settingManager.RegisterFloatSetting("Intensity", "LIGHTSPRITE", 1.0f, 0.0f, 30000.0f, 0.01f, false);
 
-	settingManager.RegisterBoolSetting("Enable", "RAIN", true);
 	settingManager.RegisterTimeOfDaySetting("MotionStretch", "RAIN", 0.28f, 0.0f, 1.0f, 0.01f, true);
 	settingManager.RegisterTimeOfDaySetting("MotionTransparency", "RAIN", 0.1f, 0.0f, 1.0f, 0.01f, true);
 
@@ -273,21 +258,19 @@ void EffectManager::RegisterSettings()
 	settingManager.RegisterTimeOfDaySetting("Density", "VOLUMETRICRAYS", 1.0f, 0.1f, 100.0f, 0.01f, true);
 	settingManager.RegisterTimeOfDaySetting("SkyColorAmount", "VOLUMETRICRAYS", 0.5f, 0.0f, 10.0f, 0.01f, true);
 
-	settingManager.SetCategoryTab("BLOOM", "Weather");
-	settingManager.SetCategoryTab("LENS", "Weather");
-	settingManager.SetCategoryTab("ENVIRONMENT", "Weather");
-	settingManager.SetCategoryTab("SKY", "Weather");
-	settingManager.SetCategoryTab("SKYSCATTERING", "Weather");
-	settingManager.SetCategoryTab("PROCEDURALSUN", "Weather");
-	settingManager.SetCategoryTab("VOLUMETRICFOG", "Weather");
-	settingManager.SetCategoryTab("VOLUMETRICRAYS", "Weather");
-	settingManager.SetCategoryTab("IMAGEBASEDLIGHTING", "Weather");
-	settingManager.SetCategoryTab("PARTICLE", "Weather");
-	settingManager.SetCategoryTab("RAIN", "Weather");
-	settingManager.SetCategoryTab("LIGHTSPRITE", "Weather");
-	settingManager.SetCategoryTab("GAMEVOLUMETRICRAYS", "Weather");
-	settingManager.SetCategoryTab("SUNGLARE", "Weather");
-	settingManager.SetCategoryTab("CLOUDSHADOWS", "Weather");
+	settingManager.SetCategoryDependency("BLOOM", "EnableBloom", "EFFECT");
+	settingManager.SetCategoryDependency("LENS", "EnableLens", "EFFECT");
+	settingManager.SetCategoryDependency("ADAPTATION", "EnableAdaptation", "EFFECT");
+	settingManager.SetCategoryDependency("PROCEDURALSUN", "EnableProceduralSun", "EFFECT");
+	settingManager.SetCategoryDependency("CLOUDSHADOWS", "EnableCloudShadows", "EFFECT");
+	settingManager.SetCategoryDependency("SKYSCATTERING", "EnableCloudsScattering", "EFFECT");
+	settingManager.SetCategoryDependency("IMAGEBASEDLIGHTING", "EnableImageBasedLighting", "EFFECT");
+	settingManager.SetCategoryDependency("VOLUMETRICRAYS", "EnableVolumetricRays", "EFFECT");
+
+	settingManager.SetSettingDependency("ProceduralGradientWeightCurve", "SKY", "UseProceduralGradientWeights", "SKY");
+	settingManager.SetSettingDependency("AdaptationMin", "ADAPTATION", "ForceMinMaxValues", "ADAPTATION");
+	settingManager.SetSettingDependency("AdaptationMax", "ADAPTATION", "ForceMinMaxValues", "ADAPTATION");
+	settingManager.SetSettingDependency("CloudsLightingMoonIntensity", "SKYSCATTERING", "EnableCloudsLightingFromMoon", "SKYSCATTERING");
 
 	settingManager.SetCategoryExteriorOnly("RAIN", true);
 	settingManager.SetCategoryExteriorOnly("SKYLIGHTING", true);

--- a/src/Features/Effect11/MenuManager.cpp
+++ b/src/Features/Effect11/MenuManager.cpp
@@ -3,7 +3,9 @@
 #include "EffectManager.h"
 #include "SettingManager.h"
 #include "TextureManager.h"
+#include "Features/Effect11.h"
 #include "Features/Effect11/ShaderPatches.h"
+#include "Globals.h"
 
 static const char* const timeOfDayNames[] = { "Dawn", "Sunrise", "Day", "Sunset", "Dusk", "Night", "InteriorDay", "InteriorNight" };
 
@@ -273,17 +275,30 @@ void MenuManager::RenderAllSettings()
 				}
 
 				for (const auto& category : categories) {
+					if (!settingManager.IsCategoryEnabled(category))
+						continue;
+
 					ImGuiTreeNodeFlags flags = (tabName == "Weather") ? ImGuiTreeNodeFlags_None : ImGuiTreeNodeFlags_DefaultOpen;
 
 					if (ImGui::TreeNodeEx(category.c_str(), flags)) {
+						bool categoryDisabled = false;
+						if (category == "RAIN") {
+							if (!globals::features::effect11.raindropStatus.empty()) {
+								categoryDisabled = true;
+								ImGui::PushStyleColor(ImGuiCol_Text, ImVec4(1.0f, 0.6f, 0.2f, 1.0f));
+								ImGui::TextWrapped("Rain disabled: %s", globals::features::effect11.raindropStatus.c_str());
+								ImGui::PopStyleColor();
+							}
+						}
+
 						auto settings = settingManager.GetSettingsByCategory(category);
 
-						if (ImGui::BeginTable((category + "_table").c_str(), 2, ImGuiTableFlags_BordersInnerV | ImGuiTableFlags_SizingStretchProp)) {
+						if (!categoryDisabled && ImGui::BeginTable((category + "_table").c_str(), 2, ImGuiTableFlags_BordersInnerV | ImGuiTableFlags_SizingStretchProp)) {
 							ImGui::TableSetupColumn("Parameter", ImGuiTableColumnFlags_WidthFixed);
 							ImGui::TableSetupColumn("Value", ImGuiTableColumnFlags_WidthStretch);
 
-							// Add weather ignore controls for categories with weather support
-							if (settingManager.CategoryHasWeatherSupport(category)) {
+							// Add weather ignore controls for categories with weather support (Weather tab only)
+							if (tabName == "Weather" && settingManager.CategoryHasWeatherSupport(category)) {
 								auto& effectManager = EffectManager::GetSingleton();
 								bool isInterior = effectManager.commonData.eInteriorFactor > 0.5f;
 
@@ -326,6 +341,15 @@ void MenuManager::RenderAllSettings()
 							for (const auto& settingKey : settings) {
 								auto settingInfo = settingManager.GetSettingInfo(settingKey, category);
 								if (!settingInfo)
+									continue;
+
+								bool isTod = (settingInfo->type == SettingType::TimeOfDay || settingInfo->type == SettingType::ColorTimeOfDay);
+								if (tabName == "Main" && isTod)
+									continue;
+								if (tabName == "Weather" && !isTod)
+									continue;
+
+								if (!settingManager.IsSettingEnabled(settingKey, category))
 									continue;
 
 								uint32_t settingID = settingInfo->id;

--- a/src/Features/Effect11/SettingManager.cpp
+++ b/src/Features/Effect11/SettingManager.cpp
@@ -445,10 +445,81 @@ std::map<std::string, std::vector<std::string>> SettingManager::GetCategorizedSe
 		auto it = categories.find(catName);
 		if (it == categories.end())
 			continue;
-		result[it->second.tab].push_back(catName);
+
+		if (it->second.tab == "Debug") {
+			result["Debug"].push_back(catName);
+			continue;
+		}
+
+		bool hasNonTod = false;
+		bool hasTod = false;
+		for (const auto& [key, id] : it->second.settings) {
+			auto type = allSettings[id].type;
+			if (type == SettingType::TimeOfDay || type == SettingType::ColorTimeOfDay)
+				hasTod = true;
+			else
+				hasNonTod = true;
+		}
+
+		if (hasNonTod)
+			result["Main"].push_back(catName);
+		if (hasTod)
+			result["Weather"].push_back(catName);
 	}
 
 	return result;
+}
+
+void SettingManager::SetCategoryDependency(const std::string& category, const std::string& dependsOnKey, const std::string& dependsOnCategory)
+{
+	std::unique_lock lock(mutex);
+	auto it = categories.find(category);
+	if (it != categories.end()) {
+		it->second.dependsOnKey = dependsOnKey;
+		it->second.dependsOnCategory = dependsOnCategory;
+	}
+}
+
+void SettingManager::SetSettingDependency(const std::string& key, const std::string& category, const std::string& dependsOnKey, const std::string& dependsOnCategory)
+{
+	std::unique_lock lock(mutex);
+	uint32_t id = GetSettingIDInternal(key, category);
+	if (id != 0xFFFFFFFF) {
+		allSettings[id].dependsOnKey = dependsOnKey;
+		allSettings[id].dependsOnCategory = dependsOnCategory;
+	}
+}
+
+bool SettingManager::IsCategoryEnabled(const std::string& category)
+{
+	std::string depKey, depCategory;
+	{
+		std::shared_lock lock(mutex);
+		auto it = categories.find(category);
+		if (it == categories.end())
+			return true;
+		depKey = it->second.dependsOnKey;
+		depCategory = it->second.dependsOnCategory;
+	}
+	if (depKey.empty())
+		return true;
+	return GetValue<bool>(depKey, depCategory);
+}
+
+bool SettingManager::IsSettingEnabled(const std::string& key, const std::string& category)
+{
+	std::string depKey, depCategory;
+	{
+		std::shared_lock lock(mutex);
+		uint32_t id = GetSettingIDInternal(key, category);
+		if (id == 0xFFFFFFFF)
+			return true;
+		depKey = allSettings[id].dependsOnKey;
+		depCategory = allSettings[id].dependsOnCategory;
+	}
+	if (depKey.empty())
+		return true;
+	return GetValue<bool>(depKey, depCategory);
 }
 
 void SettingManager::SetWeatherBlendFactors(uint32_t newCurrentWeatherID, uint32_t newLastWeatherID, float blendFactor)

--- a/src/Features/Effect11/SettingManager.h
+++ b/src/Features/Effect11/SettingManager.h
@@ -115,6 +115,8 @@ struct Setting
 	float minValue = 0.0f;
 	float maxValue = 10.0f;
 	float step = 0.01f;
+	std::string dependsOnKey;
+	std::string dependsOnCategory;
 };
 
 class SettingManager
@@ -164,6 +166,11 @@ public:
 	std::string GetCategoryTab(const std::string& category) const;
 	std::map<std::string, std::vector<std::string>> GetCategorizedSettings() const;
 
+	void SetCategoryDependency(const std::string& category, const std::string& dependsOnKey, const std::string& dependsOnCategory);
+	void SetSettingDependency(const std::string& key, const std::string& category, const std::string& dependsOnKey, const std::string& dependsOnCategory);
+	bool IsCategoryEnabled(const std::string& category);
+	bool IsSettingEnabled(const std::string& key, const std::string& category);
+
 	// Weather integration
 	void SetWeatherBlendFactors(uint32_t currentWeatherID, uint32_t lastWeatherID, float blendFactor);
 	void LoadWeatherSettings(const std::vector<uint32_t>& weatherIDs, const std::string& filePath);
@@ -200,6 +207,8 @@ private:
 		bool lastSavedIgnoreWeatherSystem = false;
 		bool lastSavedIgnoreWeatherSystemInterior = true;
 		bool exteriorOnly = false;
+		std::string dependsOnKey;
+		std::string dependsOnCategory;
 	};
 
 	std::vector<Setting> allSettings;

--- a/src/Features/Effect11/TextureManager.cpp
+++ b/src/Features/Effect11/TextureManager.cpp
@@ -205,46 +205,8 @@ void TextureManager::CreateDownsampleResources()
 		nullptr,
 		downsamplePS.put()));
 
-	// Create Kawase blur pixel shader
-	auto blurPixelShaderSource = EffectManager::LoadShaderFile("Data\\Shaders\\Effect11\\KawaseBlurPS.hlsl");
-	if (blurPixelShaderSource.empty())
-		return;
-
-	winrt::com_ptr<ID3DBlob> blurShaderBlob;
-	winrt::com_ptr<ID3DBlob> blurErrorBlob;
-
-	HRESULT blurResult = D3DCompile(
-		blurPixelShaderSource.data(),
-		blurPixelShaderSource.size(),
-		"KawaseBlurPS.hlsl",
-		nullptr,
-		nullptr,
-		"main",
-		"ps_5_0",
-		0,
-		0,
-		blurShaderBlob.put(),
-		blurErrorBlob.put());
-
-	if (FAILED(blurResult)) {
-		if (blurErrorBlob) {
-			logger::error("[TextureManager] Blur shader compilation failed: {}",
-				static_cast<const char*>(blurErrorBlob->GetBufferPointer()));
-		}
-		return;
-	}
-
-	DX::ThrowIfFailed(device->CreatePixelShader(
-		blurShaderBlob->GetBufferPointer(),
-		blurShaderBlob->GetBufferSize(),
-		nullptr,
-		blurPS.put()));
-
 	// Create shared downsample texture
 	sharedDownsampleTexture = CreateDownsampleTexture(DXGI_FORMAT_R11G11B10_FLOAT);
-
-	// Create temp texture for pre-blur downsample
-	downsampleTempTexture = CreateTexture(1024, 1024, DXGI_FORMAT_R11G11B10_FLOAT, "TextureManager::DownsampleTemp");
 }
 
 TextureManager::DownsampleTexture TextureManager::CreateDownsampleTexture(DXGI_FORMAT format)
@@ -302,7 +264,7 @@ TextureManager::DownsampleTexture TextureManager::CreateDownsampleTexture(DXGI_F
 
 void TextureManager::DownsampleToFixed(ID3D11ShaderResourceView* source, DownsampleTexture& texture)
 {
-	if (!source || !texture.rtv || !downsampleVS || !downsamplePS || !blurPS || !linearSampler || !texture.srvChain || !downsampleTempTexture.rtv) {
+	if (!source || !texture.rtv || !downsampleVS || !downsamplePS || !linearSampler || !texture.srvChain) {
 		return;
 	}
 
@@ -320,26 +282,11 @@ void TextureManager::DownsampleToFixed(ID3D11ShaderResourceView* source, Downsam
 	ID3D11SamplerState* samplerArray[] = { linearSampler.get() };
 	context->PSSetSamplers(0, 1, samplerArray);
 
-	// Pass 1: Downsample source into temp texture
-	ID3D11RenderTargetView* tempRTV[] = { downsampleTempTexture.rtv.get() };
-	context->OMSetRenderTargets(1, tempRTV, nullptr);
+	ID3D11RenderTargetView* rtvArray[] = { texture.rtv.get() };
+	context->OMSetRenderTargets(1, rtvArray, nullptr);
 	context->PSSetShaderResources(0, 1, &source);
 	context->PSSetShader(downsamplePS.get(), nullptr, 0);
 	globals::profiler->BeginPass("Effect11::Downsample");
-	context->Draw(4, 0);
-	globals::profiler->EndPass();
-
-	// Pass 2: Kawase blur from temp into final texture
-	ID3D11ShaderResourceView* nullSRV[] = { nullptr };
-	context->PSSetShaderResources(0, 1, nullSRV);
-
-	ID3D11RenderTargetView* finalRTV[] = { texture.rtv.get() };
-	context->OMSetRenderTargets(1, finalRTV, nullptr);
-
-	ID3D11ShaderResourceView* tempSRV[] = { downsampleTempTexture.srv.get() };
-	context->PSSetShaderResources(0, 1, tempSRV);
-	context->PSSetShader(blurPS.get(), nullptr, 0);
-	globals::profiler->BeginPass("Effect11::DownsampleBlur");
 	context->Draw(4, 0);
 	globals::profiler->EndPass();
 

--- a/src/Features/Effect11/TextureManager.h
+++ b/src/Features/Effect11/TextureManager.h
@@ -53,11 +53,9 @@ private:
 	// Downsampling resources
 	winrt::com_ptr<ID3D11VertexShader> downsampleVS;
 	winrt::com_ptr<ID3D11PixelShader> downsamplePS;
-	winrt::com_ptr<ID3D11PixelShader> blurPS;
 
 	winrt::com_ptr<ID3D11SamplerState> linearSampler;
 	DownsampleTexture sharedDownsampleTexture;
-	Texture downsampleTempTexture;
 
 	// Frame-based state
 	uint32_t textureSwap = 0;


### PR DESCRIPTION
- Simplify HandleTonemapRender to use game's input/output RTs directly
- Remove Kawase blur pass from downsample (single SampleLevel + GenerateMips)
- Reduce SKYSCATTERING setting dependencies in SharedData
- Add rain texture warning in MenuManager
- Add fire detection settings support in SettingManager