### PR TITLE
fix(cs-editor): compile fail due to stale leftover code

### DIFF
--- a/src/CSEditor/EditorWindow.cpp
+++ b/src/CSEditor/EditorWindow.cpp
@@ -2049,17 +2049,14 @@ namespace
 	/** @brief Returns true if any menu that must not run with a zero timescale is still open. */
 	bool IsAnyTimeSensitiveMenuOpen()
 	{
-		auto ui = globals::game::ui ? globals::game::ui : RE::UI::GetSingleton();
+		auto ui = GetUI();
 		return ui && std::ranges::any_of(kTimeSensitiveMenus, [&](std::string_view name) { return ui->IsMenuOpen(name); });
 	}
 }
 
 void EditorWindow::SetTimeRunningForMenu(bool a_needsRunningTime)
 {
-
 	auto calendar = GetCalendar();
-	auto ui = GetUI();
-
 	if (!calendar || !calendar->timeScale)
 		return;
 
@@ -2098,7 +2095,7 @@ RE::BSEventNotifyControl EditorWindow::MenuOpenCloseEventHandler::ProcessEvent(c
 bool EditorWindow::MenuOpenCloseEventHandler::Register()
 {
 	static MenuOpenCloseEventHandler singleton;
-	auto ui = globals::game::ui ? globals::game::ui : RE::UI::GetSingleton();
+	auto ui = GetUI();
 
 	if (!ui) {
 		logger::error("[CSEditor] UI event source not found");

--- a/src/Features/CSEditor.cpp
+++ b/src/Features/CSEditor.cpp
@@ -219,9 +219,6 @@ void CSEditor::Prepass()
 	}
 
 	EditorWindow::MaintainWeatherLock();
-
-	// Update time controls (handles sleep/wait and external state sync)
-	EditorWindow::GetSingleton()->UpdateTimeState();
 }
 
 void CSEditor::DrawWeatherPickerSection()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved editor weather-lock maintenance during per-frame updates.
  * Prevented unintended time-state updates from occurring during this process.
  * Increased reliability of time-sensitive menu detection and the related open/close event handling by consistently using the centralized UI accessor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->