### PR TITLE
fix: revert unrelated changes in Skylighting, SkySync, SubsurfaceScattering

### DIFF
--- a/src/Features/SkySync.h
+++ b/src/Features/SkySync.h
@@ -26,7 +26,7 @@ public:
 				T("feature.sky_sync.key_feature_4", "Moon light source can be switched between Masser, Secunda, or the brightest"),
 				T("feature.sky_sync.key_feature_5", "Automatic calculation of moon lighting intensity based on moon phase"),
 				T("feature.sky_sync.key_feature_6", "Fixes the sun appearing higher on the horizon when the player gains altitude") } };
-	}
+	};
 
 	struct Settings
 	{

--- a/src/Features/Skylighting.h
+++ b/src/Features/Skylighting.h
@@ -51,7 +51,7 @@ public:
 
 	struct Settings
 	{
-		float MaxZenith = 3.1415926f / 4.f;  // 45 deg
+		float MaxZenith = 3.1415926f / 2.f;  // 90 deg
 		float MinDiffuseVisibility = 0.1f;
 		float MinSpecularVisibility = 0.1f;
 	} settings;

--- a/src/Features/SubsurfaceScattering.h
+++ b/src/Features/SubsurfaceScattering.h
@@ -27,7 +27,7 @@ public:
 	{
 		uint EnableCharacterLighting = false;
 		float CharacterLightingStrength = 1.0f;
-		int SSMode = 0;
+		int SSMode = 1;
 		int ScatterMode = kPreAndPostScatter;
 		DiffusionProfile BaseProfile{ 1.0f, 1.0f, { 0.48f, 0.41f, 0.28f }, { 0.56f, 0.56f, 0.56f } };
 		DiffusionProfile HumanProfile{ 1.0f, 1.0f, { 0.48f, 0.41f, 0.28f }, { 1.0f, 0.37f, 0.3f } };


### PR DESCRIPTION
## Summary
- Reverts unintended changes in three feature headers back to their `dev` state
- **Skylighting.h**: `MaxZenith` restored to `pi/2` (90 deg) from `pi/4` (45 deg)
- **SkySync.h**: Restores semicolon after key features closing brace
- **SubsurfaceScattering.h**: `SSMode` restored to `1` from `0`

## Test plan
- [ ] Verify Skylighting, SkySync, and SubsurfaceScattering features work correctly in-game
- [ ] Build with ALL preset

🤖 Generated with [Claude Code](https://claude.com/claude-code)