### PR TITLE
fix(skylighting): advance shadow history

### DIFF
--- a/features/Skylighting/Shaders/Skylighting/UpdateProbesCS.hlsl
+++ b/features/Skylighting/Shaders/Skylighting/UpdateProbesCS.hlsl
@@ -102,7 +102,7 @@ static const float3 noise3D[32] = {
 		float shadowSample = 1.0;
 		DirectionalShadowLightData shadowData = DirectionalShadowLights[0];
 
-		uint bitIndex = SharedData::FrameCount % 32;
+		uint bitIndex = SharedData::FrameCountAlwaysActive % 32;
 		float3 jitteredMS = cellCentreMS + noise3D[bitIndex] * 128;
 
 		float ndcDepth = FrameBuffer::GetShadowDepth(jitteredMS);


### PR DESCRIPTION
Use the always-active frame counter for shadow visibility bitmask accumulation so history continues updating when temporal AA is disabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shadow bitmask sampling consistency across frames by using the always-active frame counter.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->