### PR TITLE
chore: block Native Water LightStabilizer

### DIFF
--- a/src/XSEPlugin.cpp
+++ b/src/XSEPlugin.cpp
@@ -182,7 +182,8 @@ bool Load()
 		L"Data/SKSE/Plugins/SSEReShadeHelper.dll",
 		L"Data/SKSE/Plugins/TAASharpen.dll",
 		L"Data/SKSE/Plugins/NVIDIA_Reflex.dll",
-		L"Data/SKSE/Plugins/MARA.dll"
+		L"Data/SKSE/Plugins/MARA.dll",
+		L"Data/SKSE/Plugins/NativeWaterLightStabilizer.dll"
 	};
 
 	for (const auto dll : incompatibleDLLs) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility detection by identifying `NativeWaterLightStabilizer.dll` as incompatible during plugin loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->