### PR TITLE
fix(effect11): handling when no preset

### DIFF
--- a/package/SKSE/Plugins/CommunityShaders/Translations/en.json
+++ b/package/SKSE/Plugins/CommunityShaders/Translations/en.json
@@ -568,6 +568,7 @@
     "feature.effects11.key_feature_3": "Advanced post-processing pipeline",
     "feature.effects11.key_feature_4": "Custom technique execution",
     "feature.effects11.key_feature_5": "Dynamic UI variable system",
+    "feature.effects11.no_preset_detected": "No preset detected",
     "feature.exp_height_fog.apply_vanilla_fade": "Apply Vanilla Fade",
     "feature.exp_height_fog.apply_vanilla_fade_tooltip": "Applies vanilla fade brightness to exponential height fog.",
     "feature.exp_height_fog.cubemap_mip_level": "Cubemap Mip Level",

--- a/src/Features/Effects11.cpp
+++ b/src/Features/Effects11.cpp
@@ -465,8 +465,6 @@ void Effects11::CheckCommonData()
 		bool isMenuOpen = ui->IsMenuOpen(RE::MapMenu::MENU_NAME);
 		auto& effectManager = EffectManager::GetSingleton();
 
-		// A stale enbseries.ini can leave UseEffect on with no preset present; stay inert rather
-		// than applying ENB overrides no .fx file backs
 		enableEffect = !isMenuOpen && globals::shaderCache->IsEnabled() && settingManager.GetValue<bool>("UseEffect", "GLOBAL") && effectManager.IsPresetLoaded();
 
 		auto& weatherManager = WeatherManager::GetSingleton();

--- a/src/Features/Effects11.cpp
+++ b/src/Features/Effects11.cpp
@@ -463,9 +463,12 @@ void Effects11::CheckCommonData()
 		auto& settingManager = SettingManager::GetSingleton();
 		auto ui = globals::game::ui;
 		bool isMenuOpen = ui->IsMenuOpen(RE::MapMenu::MENU_NAME);
-		enableEffect = !isMenuOpen && globals::shaderCache->IsEnabled() && settingManager.GetValue<bool>("UseEffect", "GLOBAL");
-
 		auto& effectManager = EffectManager::GetSingleton();
+
+		// A stale enbseries.ini can leave UseEffect on with no preset present; stay inert rather
+		// than applying ENB overrides no .fx file backs
+		enableEffect = !isMenuOpen && globals::shaderCache->IsEnabled() && settingManager.GetValue<bool>("UseEffect", "GLOBAL") && effectManager.IsPresetLoaded();
+
 		auto& weatherManager = WeatherManager::GetSingleton();
 
 		effectManager.UpdateCommonData();
@@ -525,14 +528,19 @@ bool Effects11::HandleTonemapRender(RE::RENDER_TARGET a_input, RE::RENDER_TARGET
 
 	if (enableEffect && !settingManager.GetValue<bool>("UseOriginalPostProcessing", "EFFECT")) {
 		auto& renderTargets = globals::game::renderer->GetRuntimeData().renderTargets;
-		effectManager.ExecuteEffects(renderTargets[a_input], renderTargets[a_output]);
-		return true;
+		// Only claim the tonemap pass if the effect chain actually wrote the output
+		return effectManager.ExecuteEffects(renderTargets[a_input], renderTargets[a_output]);
 	}
 	return false;
 }
 
 void Effects11::ModifySky(RE::BSRenderPass* Pass)
 {
+	// State::UpdateSkyShaderPermutation ran first and already flagged both the sun disc and its
+	// glare; only narrow that to the disc when a preset is actually driving the procedural sun
+	if (!enableEffect)
+		return;
+
 	if (!Pass || !Pass->shaderProperty) {
 		return;
 	}

--- a/src/Features/Effects11/EffectManager.cpp
+++ b/src/Features/Effects11/EffectManager.cpp
@@ -313,16 +313,21 @@ void EffectManager::ExecuteEffect(EffectBase& a_effect, uint32_t enableSettingID
 	a_effect.profiler = nullptr;
 }
 
-void EffectManager::ExecuteEffects(RE::BSGraphics::RenderTargetData& a_input, [[maybe_unused]] RE::BSGraphics::RenderTargetData& a_output)
+bool EffectManager::ExecuteEffects(RE::BSGraphics::RenderTargetData& a_input, RE::BSGraphics::RenderTargetData& a_output)
 {
 	if (!initialized)
-		return;
+		return false;
 
 	auto context = globals::d3d::context;
 	auto renderer = globals::game::renderer;
 
 	if (!rasterizerState || !blendState || !quadVertexBuffer || !inputLayout || !renderer)
-		return;
+		return false;
+
+	// Without a preset nothing writes TextureSDRTemp, so the output RT would be copied from a
+	// never-written texture, i.e. a black screen
+	if (!IsPresetLoaded())
+		return false;
 
 	D3D11FullStateBackup stateBackup;
 	stateBackup.Save(context);
@@ -373,7 +378,8 @@ void EffectManager::ExecuteEffects(RE::BSGraphics::RenderTargetData& a_input, [[
 	textureManager.IncrementTextureSwap();
 
 	auto* textureSDRTemp = textureManager.GetCommonTexture("TextureSDRTemp");
-	if (textureSDRTemp && a_output.RTV) {
+	const bool wroteOutput = textureSDRTemp && a_output.RTV;
+	if (wroteOutput) {
 		globals::profiler->BeginPass("Effects11::CopyToOutput");
 		CopyTexture(textureSDRTemp->srv.get(), a_output.RTV);
 		globals::profiler->EndPass();
@@ -381,6 +387,8 @@ void EffectManager::ExecuteEffects(RE::BSGraphics::RenderTargetData& a_input, [[
 
 	stateBackup.Restore(context);
 	stateBackup.Release();
+
+	return wroteOutput;
 }
 
 std::string EffectManager::LoadShaderFile(const char* path)

--- a/src/Features/Effects11/EffectManager.h
+++ b/src/Features/Effects11/EffectManager.h
@@ -40,7 +40,9 @@ public:
 	static EffectManager& GetSingleton();
 
 	// Effect execution
-	void ExecuteEffects(RE::BSGraphics::RenderTargetData& a_input, RE::BSGraphics::RenderTargetData& a_output);
+	/** @brief Runs the effect chain from a_input into a_output.
+		@return true only if a_output was written; false means the caller must fall back to the stock pass. */
+	bool ExecuteEffects(RE::BSGraphics::RenderTargetData& a_input, RE::BSGraphics::RenderTargetData& a_output);
 
 	// Lifecycle
 	void Initialize();
@@ -125,6 +127,10 @@ public:
 	const CommonVariableData& GetCommonData() const { return commonData; }
 
 	bool IsInitialized() const { return initialized; }
+
+	/** @brief True when a usable preset is present; enbeffect.fx is required, so its absence means no preset.
+		Effects11 must stay fully inert in that case, leaving the image untouched. */
+	bool IsPresetLoaded() const { return enbEffect.IsCompiled(); }
 
 	bool performanceMode = false;
 

--- a/src/Features/Effects11/MenuManager.cpp
+++ b/src/Features/Effects11/MenuManager.cpp
@@ -6,6 +6,7 @@
 #include "Features/Effects11.h"
 #include "Features/Effects11/ShaderPatches.h"
 #include "Globals.h"
+#include "I18n/I18n.h"
 
 static const char* const timeOfDayNames[] = { "Dawn", "Sunrise", "Day", "Sunset", "Dusk", "Night", "InteriorDay", "InteriorNight" };
 
@@ -334,9 +335,20 @@ void MenuManager::RenderAllSettings()
 								switch (settingInfo->type) {
 								case SettingType::Bool:
 									{
-										bool v = settingManager.GetValue<bool>(settingID, true);
+										const bool noPreset = category == "GLOBAL" && settingKey == "UseEffect" && !EffectManager::GetSingleton().IsPresetLoaded();
+
+										bool v = !noPreset && settingManager.GetValue<bool>(settingID, true);
+										ImGui::BeginDisabled(noPreset);
 										if (ImGui::Checkbox(("##" + settingKey).c_str(), &v)) {
 											settingManager.SetValue<bool>(settingID, v);
+										}
+										ImGui::EndDisabled();
+
+										if (noPreset) {
+											ImGui::SameLine();
+											ImGui::PushStyleColor(ImGuiCol_Text, globals::menu->GetSettings().Theme.StatusPalette.Warning);
+											ImGui::TextUnformatted(T("feature.effects11.no_preset_detected", "No preset detected"));
+											ImGui::PopStyleColor();
 										}
 										break;
 									}


### PR DESCRIPTION
adds gates so that effect11 doesn't interfere with non-enb setups. fixed black screen when no preset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a localized “No preset detected” message.
  * Effects11 settings now indicate when no effect preset is available.

* **Bug Fixes**
  * Effects11 rendering now falls back to the standard rendering path when initialization, resources, or a preset are unavailable.
  * Sky shader adjustments are skipped unless effects are enabled.
  * Effect processing now accurately reports whether output was generated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->