### PR TITLE
fix(hdr): gate AutoHDR to the Effects11 tonemap path

### DIFF
--- a/features/HDR Display/Shaders/Features/HDRDisplay.ini
+++ b/features/HDR Display/Shaders/Features/HDRDisplay.ini
@@ -1,5 +1,5 @@
 [Info]
-Version = 1-2-0
+Version = 1-2-1
 
 [Nexus]
 nexusmodid = 179371

--- a/features/HDR Display/Shaders/HDRDisplay/HDROutputCS.hlsl
+++ b/features/HDR Display/Shaders/HDRDisplay/HDROutputCS.hlsl
@@ -22,6 +22,7 @@ cbuffer PerFrame : register(b0)
 	float isMainOrLoadingMenu : packoffset(c1.z);
 	float fgTweenMenuMidAlphaBoost : packoffset(c1.w);  ///< TweenMenu: soften AA band when compositing here (UIBrightnessCS skips while paused)
 	float previewSDR : packoffset(c2.x);                ///< 1.0 = emit sRGB SDR (crop preview) instead of PQ HDR10
+	float applyAutoHDR : packoffset(c2.y);              ///< 1.0 = Effects11 replaced ISHDR, so expand its SDR result into HDR
 }
 
 [numthreads(8, 8, 1)] void main(uint3 dispatchID : SV_DispatchThreadID) {
@@ -41,9 +42,11 @@ cbuffer PerFrame : register(b0)
 	if (hdrEnabled) {
 		bool sceneIsLinear = isSceneLinear > 0.5;
 
-		float3 outputColor = sceneIsLinear ? scene.xyz : Color::GammaToLinearSafe(scene.xyz);
-		outputColor = DisplayMapping::PumboAutoHDR(outputColor, SharedData::HDRData.z, SharedData::HDRData.y, 2.75, 1.0);
-		scene.xyz = sceneIsLinear ? outputColor : Color::LinearToGammaSafe(outputColor);
+		if (applyAutoHDR > 0.5) {
+			float3 outputColor = sceneIsLinear ? scene.xyz : Color::GammaToLinearSafe(scene.xyz);
+			outputColor = DisplayMapping::PumboAutoHDR(outputColor, SharedData::HDRData.z, SharedData::HDRData.y, 2.75, 1.0);
+			scene.xyz = sceneIsLinear ? outputColor : Color::LinearToGammaSafe(outputColor);
+		}
 
 		float3 compositedColorLinear;
 

--- a/src/Features/Effects11.cpp
+++ b/src/Features/Effects11.cpp
@@ -517,6 +517,11 @@ void Effects11::OnSkyUpdateColors(RE::Sky* a_sky)
 		OverrideWeather(a_sky);
 }
 
+bool Effects11::ReplacedTonemapperThisFrame() const
+{
+	return tonemapReplacedFrame == globals::state->frameCount;
+}
+
 bool Effects11::HandleTonemapRender(RE::RENDER_TARGET a_input, RE::RENDER_TARGET a_output)
 {
 	CheckCommonData();
@@ -527,7 +532,10 @@ bool Effects11::HandleTonemapRender(RE::RENDER_TARGET a_input, RE::RENDER_TARGET
 	if (enableEffect && !settingManager.GetValue<bool>("UseOriginalPostProcessing", "EFFECT")) {
 		auto& renderTargets = globals::game::renderer->GetRuntimeData().renderTargets;
 		// Only claim the tonemap pass if the effect chain actually wrote the output
-		return effectManager.ExecuteEffects(renderTargets[a_input], renderTargets[a_output]);
+		if (effectManager.ExecuteEffects(renderTargets[a_input], renderTargets[a_output])) {
+			tonemapReplacedFrame = globals::state->frameCount;
+			return true;
+		}
 	}
 	return false;
 }

--- a/src/Features/Effects11.h
+++ b/src/Features/Effects11.h
@@ -111,4 +111,9 @@ public:
 	__declspec(noinline) void ModifyParticle(RE::BSRenderPass* Pass);
 	void ParticleShaderHacks();
 	bool HandleTonemapRender(RE::RENDER_TARGET a_input, RE::RENDER_TARGET a_output);
+	/** @brief True when the effect chain replaced ISHDR this frame, leaving an SDR scene for HDR Display to expand. */
+	bool ReplacedTonemapperThisFrame() const;
+
+private:
+	uint tonemapReplacedFrame = UINT32_MAX;  ///< frameCount when the effect chain last wrote the tonemap output
 };

--- a/src/Features/HDRDisplay.cpp
+++ b/src/Features/HDRDisplay.cpp
@@ -3,6 +3,7 @@
 #include "PCH.h"
 
 #include "Buffer.h"
+#include "Effects11.h"
 #include "Globals.h"
 #include "I18n/I18n.h"
 #include "LinearLighting.h"
@@ -1612,6 +1613,7 @@ HDRDisplay::HDRDataCB HDRDisplay::BuildHDRData() const
 	// TweenMenu = pause UI. ScaleUIBrightnessForFG skips while GameIsPaused(), so HDROutputCS applies the same mid-alpha boost when compositing gamma UI.
 	data.fgTweenMenuMidAlphaBoost = (ui && ui->IsMenuOpen(RE::TweenMenu::MENU_NAME)) ? 1.f : 0.f;
 	data.previewSDR = 0.f;
+	data.applyAutoHDR = globals::features::effects11.ReplacedTonemapperThisFrame() ? 1.f : 0.f;
 	return data;
 }
 

--- a/src/Features/HDRDisplay.h
+++ b/src/Features/HDRDisplay.h
@@ -172,7 +172,7 @@ public:
 		float pad0;                      ///< 1.0 = main menu/loading screen active
 		float fgTweenMenuMidAlphaBoost;  ///< 1.0 = TweenMenu (pause) open — FG UIBrightnessCS mid-alpha boost only
 		float previewSDR;                ///< 1.0 = emit sRGB SDR (crop preview) instead of PQ HDR10
-		float pad1;
+		float applyAutoHDR;              ///< 1.0 = Effects11 replaced ISHDR, so expand its SDR result into HDR
 		float pad2;
 		float pad3;
 	};


### PR DESCRIPTION
PumboAutoHDR was added to HDROutputCS with no gate. bad

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HDR rendering when an alternate tonemapper is active.
  * Auto-HDR processing now runs only when needed, preventing unwanted tone mapping on unaffected frames.
  * Preserved existing color conversion behavior for consistent HDR output.
  * Improved frame-by-frame handling when switching between standard and HDR rendering effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->