### PR TITLE
fix(unified-water): guard hooks against null cache

### DIFF
--- a/src/Features/UnifiedWater.cpp
+++ b/src/Features/UnifiedWater.cpp
@@ -63,23 +63,38 @@ namespace
 		logger::error("[Unified Water] Skipping {} patch at {:X}: unexpected branch bytes {:02X} {:02X}", label, address, bytes[0], bytes[1]);
 	}
 
-	/** @brief Disables the vanilla LOD water and flow map paths that Unified Water supersedes. Irreversible, so it must only run once Unified Water is fully initialized. */
-	void DisableVanillaWaterLOD()
+	bool CanPatchBranch(const std::uintptr_t address)
+	{
+		const auto bytes = reinterpret_cast<const std::uint8_t*>(address);
+		return IsShortBranch(bytes[0]) || IsNearConditionalBranch(bytes[0], bytes[1]);
+	}
+
+	/** @brief Disables the vanilla LOD water and flow map paths that Unified Water supersedes. Irreversible, so it must only run once the meshes are validated. */
+	bool DisableVanillaWaterLOD()
 	{
 		// DataLoaded can run more than once, and re-patching a patched branch no longer matches either encoding
 		static bool patched = false;
 		if (patched)
-			return;
-		patched = true;
+			return true;
 
 		// Skip iterating attached meshes and calling TESWaterSystem::AddLODWater, this is handled in Attach now
-		PatchBranchToUnconditional(REL::RelocationID(30934, 31737).address() + REL::Relocate(0x109, 0x109), "attached mesh add loop");
-		PatchBranchToUnconditional(REL::RelocationID(30978, 31751).address() + REL::Relocate(0x54, 0xEA), "LOD water add loop");
+		const auto attachedMeshAddLoop = REL::RelocationID(30934, 31737).address() + REL::Relocate(0x109, 0x109);
+		const auto lodWaterAddLoop = REL::RelocationID(30978, 31751).address() + REL::Relocate(0x54, 0xEA);
+
+		if (!CanPatchBranch(attachedMeshAddLoop) || !CanPatchBranch(lodWaterAddLoop)) {
+			logger::error("[Unified Water] Unexpected branch bytes at {:X} or {:X}; another mod may patch the same code", attachedMeshAddLoop, lodWaterAddLoop);
+			return false;
+		}
+		patched = true;
+
+		PatchBranchToUnconditional(attachedMeshAddLoop, "attached mesh add loop");
+		PatchBranchToUnconditional(lodWaterAddLoop, "LOD water add loop");
 
 		// Patch out the compute shader calls that write to the flow map in Main::RenderWaterEffects
 		REL::safe_fill(REL::RelocationID(35561, 36560).address() + REL::Relocate(0x1B7, 0x1F7), REL::NOP, 5);
 		REL::safe_fill(REL::RelocationID(35561, 36560).address() + REL::Relocate(0x1EA, 0x22A), REL::NOP, 5);
 		REL::safe_fill(REL::RelocationID(35561, 36560).address() + REL::Relocate(0x202, 0x242), REL::NOP, 5);
+		return true;
 	}
 
 }
@@ -228,11 +243,13 @@ void UnifiedWater::DataLoaded()
 	}
 	optimisedWaterMesh = RE::NiPointer(optimisedWaterShape);
 	logger::debug("[Unified Water] Optimised water mesh loaded");
+	if (!DisableVanillaWaterLOD()) {
+		fail("Could not disable vanilla water LOD");
+		return;
+	}
 
 	flowmap = new Flowmap();
 	waterCache = new WaterCache();
-
-	DisableVanillaWaterLOD();
 
 	if (LoadOrderChanged()) {
 		logger::info("[Unified Water] Load order or plugin version changed, regenerating flowmap and caches");

--- a/src/Features/UnifiedWater.cpp
+++ b/src/Features/UnifiedWater.cpp
@@ -207,13 +207,13 @@ void UnifiedWater::DataLoaded()
 	args.postProcess = false;
 	RE::NiPointer<RE::NiNode> nif;
 
-	const auto fail = [this](const char* reason) {
+	const auto fail = [this](std::string reason) {
 		logger::error("[Unified Water] {}; distant water falls back to vanilla LOD", reason);
-		failedLoadedMessage = reason;
+		failedLoadedMessage = std::move(reason);
 	};
 
 	if (const auto error = RE::BSModelDB::Demand("meshes\\water\\watermesh.nif", nif, args); error != RE::BSResource::ErrorCode::kNone) {
-		fail("Failed to load water mesh");
+		fail(std::format("Failed to load water mesh ({})", magic_enum::enum_name(error)));
 		return;
 	}
 	if (!nif || nif->GetChildren().empty() || !nif->GetChildren().front()->AsNode() || nif->GetChildren().front()->AsNode()->GetChildren().empty()) {
@@ -229,7 +229,7 @@ void UnifiedWater::DataLoaded()
 	logger::debug("[Unified Water] Water mesh loaded");
 
 	if (const auto error = RE::BSModelDB::Demand("meshes\\water\\optimisedwatermesh.nif", nif, args); error != RE::BSResource::ErrorCode::kNone) {
-		fail("Failed to load optimised water mesh");
+		fail(std::format("Failed to load optimised water mesh ({})", magic_enum::enum_name(error)));
 		return;
 	}
 	if (!nif || nif->GetChildren().empty() || !nif->GetChildren().front()->AsNode() || nif->GetChildren().front()->AsNode()->GetChildren().empty()) {
@@ -562,6 +562,11 @@ void UnifiedWater::TES_DestroySkyCell::thunk(RE::TES* tes)
 
 void UnifiedWater::BGSTerrainNode_UpdateWaterMeshSubVisibility::thunk(const RE::BGSTerrainNode* node, RE::BSMultiBoundNode* waterParent)
 {
+	if (!globals::features::unifiedWater.IsWaterDataReady()) {
+		func(node, waterParent);
+		return;
+	}
+
 	if (!node || !waterParent)
 		return;
 

--- a/src/Features/UnifiedWater.cpp
+++ b/src/Features/UnifiedWater.cpp
@@ -63,6 +63,25 @@ namespace
 		logger::error("[Unified Water] Skipping {} patch at {:X}: unexpected branch bytes {:02X} {:02X}", label, address, bytes[0], bytes[1]);
 	}
 
+	/** @brief Disables the vanilla LOD water and flow map paths that Unified Water supersedes. Irreversible, so it must only run once Unified Water is fully initialized. */
+	void DisableVanillaWaterLOD()
+	{
+		// DataLoaded can run more than once, and re-patching a patched branch no longer matches either encoding
+		static bool patched = false;
+		if (patched)
+			return;
+		patched = true;
+
+		// Skip iterating attached meshes and calling TESWaterSystem::AddLODWater, this is handled in Attach now
+		PatchBranchToUnconditional(REL::RelocationID(30934, 31737).address() + REL::Relocate(0x109, 0x109), "attached mesh add loop");
+		PatchBranchToUnconditional(REL::RelocationID(30978, 31751).address() + REL::Relocate(0x54, 0xEA), "LOD water add loop");
+
+		// Patch out the compute shader calls that write to the flow map in Main::RenderWaterEffects
+		REL::safe_fill(REL::RelocationID(35561, 36560).address() + REL::Relocate(0x1B7, 0x1F7), REL::NOP, 5);
+		REL::safe_fill(REL::RelocationID(35561, 36560).address() + REL::Relocate(0x1EA, 0x22A), REL::NOP, 5);
+		REL::safe_fill(REL::RelocationID(35561, 36560).address() + REL::Relocate(0x202, 0x242), REL::NOP, 5);
+	}
+
 }
 
 void UnifiedWater::LoadSettings(json& o_json)
@@ -173,33 +192,38 @@ void UnifiedWater::DataLoaded()
 	args.postProcess = false;
 	RE::NiPointer<RE::NiNode> nif;
 
+	const auto fail = [this](const char* reason) {
+		logger::error("[Unified Water] {}; distant water falls back to vanilla LOD", reason);
+		failedLoadedMessage = reason;
+	};
+
 	if (const auto error = RE::BSModelDB::Demand("meshes\\water\\watermesh.nif", nif, args); error != RE::BSResource::ErrorCode::kNone) {
-		logger::error("[Unified Water] Failed to load water mesh");
+		fail("Failed to load water mesh");
 		return;
 	}
 	if (!nif || nif->GetChildren().empty() || !nif->GetChildren().front()->AsNode() || nif->GetChildren().front()->AsNode()->GetChildren().empty()) {
-		logger::error("[Unified Water] Invalid water mesh hierarchy");
+		fail("Invalid water mesh hierarchy");
 		return;
 	}
 	const auto waterShape = nif->GetChildren().front()->AsNode()->GetChildren().front()->AsTriShape();
 	if (!waterShape) {
-		logger::error("[Unified Water] Water mesh does not contain valid TriShape");
+		fail("Water mesh does not contain valid TriShape");
 		return;
 	}
 	waterMesh = RE::NiPointer(waterShape);
 	logger::debug("[Unified Water] Water mesh loaded");
 
 	if (const auto error = RE::BSModelDB::Demand("meshes\\water\\optimisedwatermesh.nif", nif, args); error != RE::BSResource::ErrorCode::kNone) {
-		logger::error("[Unified Water] Failed to load optimised water mesh");
+		fail("Failed to load optimised water mesh");
 		return;
 	}
 	if (!nif || nif->GetChildren().empty() || !nif->GetChildren().front()->AsNode() || nif->GetChildren().front()->AsNode()->GetChildren().empty()) {
-		logger::error("[Unified Water] Invalid optimised water mesh hierarchy");
+		fail("Invalid optimised water mesh hierarchy");
 		return;
 	}
 	const auto optimisedWaterShape = nif->GetChildren().front()->AsNode()->GetChildren().front()->AsTriShape();
 	if (!optimisedWaterShape) {
-		logger::error("[Unified Water] Optimised water mesh does not contain valid TriShape");
+		fail("Optimised water mesh does not contain valid TriShape");
 		return;
 	}
 	optimisedWaterMesh = RE::NiPointer(optimisedWaterShape);
@@ -207,6 +231,8 @@ void UnifiedWater::DataLoaded()
 
 	flowmap = new Flowmap();
 	waterCache = new WaterCache();
+
+	DisableVanillaWaterLOD();
 
 	if (LoadOrderChanged()) {
 		logger::info("[Unified Water] Load order or plugin version changed, regenerating flowmap and caches");
@@ -422,12 +448,6 @@ void UnifiedWater::PostPostLoad()
 
 	stl::detour_thunk<BGSTerrainBlock_Attach>(REL::RelocationID(30934, 31737));
 
-	// Skip iterating attached meshes and calling TESWaterSystem::AddLODWater, this is handled in Attach now
-	const auto addLoopOffset = REL::RelocationID(30934, 31737).address() + REL::Relocate(0x109, 0x109);
-	const auto addLoopOffset2 = REL::RelocationID(30978, 31751).address() + REL::Relocate(0x54, 0xEA);
-	PatchBranchToUnconditional(addLoopOffset, "attached mesh add loop");
-	PatchBranchToUnconditional(addLoopOffset2, "LOD water add loop");
-
 	stl::detour_thunk<BGSTerrainBlock_Detach>(REL::RelocationID(30936, 31739));
 
 	stl::detour_thunk<BGSTerrainNode_UpdateWaterMeshSubVisibility>(REL::RelocationID(31059, 31846));
@@ -435,11 +455,6 @@ void UnifiedWater::PostPostLoad()
 	stl::detour_thunk<TESWaterSystem_UpdateDisplacementMeshPosition>(REL::RelocationID(31384, 32175));
 
 	stl::write_vfunc<0x6, BSWaterShader_SetupGeometry>(RE::VTABLE_BSWaterShader[0]);
-
-	// Patch out the code compute shader calls that write to the flow map in Main::RenderWaterEffects
-	REL::safe_fill(REL::RelocationID(35561, 36560).address() + REL::Relocate(0x1B7, 0x1F7), REL::NOP, 5);
-	REL::safe_fill(REL::RelocationID(35561, 36560).address() + REL::Relocate(0x1EA, 0x22A), REL::NOP, 5);
-	REL::safe_fill(REL::RelocationID(35561, 36560).address() + REL::Relocate(0x202, 0x242), REL::NOP, 5);
 
 	gWaterLOD = reinterpret_cast<RE::NiNode**>(REL::RelocationID(516171, 402322).address());
 	gFlowMapSize = reinterpret_cast<int32_t*>(REL::RelocationID(527644, 414596).address());
@@ -484,6 +499,11 @@ int32_t UnifiedWater::BSWaterShaderMaterial_ComputeCRC32::thunk(RE::BSWaterShade
 	return func(material, srcHash);
 }
 
+bool UnifiedWater::IsWaterDataReady() const
+{
+	return waterCache && waterMesh && optimisedWaterMesh;
+}
+
 bool UnifiedWater::IsExteriorWorldspaceActive() const
 {
 	// Interior cells may still inherit stale exterior worldspace state during transitions
@@ -507,7 +527,8 @@ void UnifiedWater::TES_SetWorldSpace::thunk(RE::TES* tes, RE::TESWorldSpace* wor
 
 	auto& singleton = globals::features::unifiedWater;
 	singleton.exteriorWorldspaceActive.store(worldSpace && isExterior, std::memory_order_release);
-	singleton.waterCache->SetCurrentWorldSpace(worldSpace);
+	if (singleton.IsWaterDataReady())
+		singleton.waterCache->SetCurrentWorldSpace(worldSpace);
 	singleton.UpdateWaterLODCull();
 }
 
@@ -517,7 +538,8 @@ void UnifiedWater::TES_DestroySkyCell::thunk(RE::TES* tes)
 
 	auto& singleton = globals::features::unifiedWater;
 	singleton.exteriorWorldspaceActive.store(false, std::memory_order_release);
-	singleton.waterCache->SetCurrentWorldSpace(nullptr);
+	if (singleton.IsWaterDataReady())
+		singleton.waterCache->SetCurrentWorldSpace(nullptr);
 	singleton.UpdateWaterLODCull();
 }
 
@@ -572,7 +594,7 @@ void UnifiedWater::BGSTerrainBlock_Attach::thunk(RE::BGSTerrainBlock* block)
 	// Keeps the backing RuntimeCache alive for as long as `built` holds pointers into it.
 	WaterCache::InstructionResult instructionResult;
 
-	if (block && block->loaded && !block->attached && block->chunk && block->water) {
+	if (singleton.IsWaterDataReady() && block && block->loaded && !block->attached && block->chunk && block->water) {
 		// Keep terrain water alive while moving it out of its owning node
 		water = RE::NiPointer<RE::BSMultiBoundNode>(block->water);
 		block->chunk->DetachChild2(water.get());

--- a/src/Features/UnifiedWater.cpp
+++ b/src/Features/UnifiedWater.cpp
@@ -31,6 +31,14 @@ namespace
 		return cell && cell->IsInteriorCell();
 	}
 
+	/** @brief Logs the resource error alongside whether the process can see the loose file; the path stays relative so USVFS-virtualised files resolve. */
+	void LogMeshLoadFailure(RE::BSResource::ErrorCode error, const char* dataRelativePath)
+	{
+		std::error_code ec;
+		logger::error("[Unified Water] {} load failed: {}, loose file present: {}", dataRelativePath, magic_enum::enum_name(error),
+			std::filesystem::exists(std::filesystem::path("Data") / dataRelativePath, ec));
+	}
+
 	bool IsShortBranch(const std::uint8_t opcode)
 	{
 		return opcode == 0xEB || (opcode >= 0x70 && opcode <= 0x7F);
@@ -213,7 +221,8 @@ void UnifiedWater::DataLoaded()
 	};
 
 	if (const auto error = RE::BSModelDB::Demand("meshes\\water\\watermesh.nif", nif, args); error != RE::BSResource::ErrorCode::kNone) {
-		fail(std::format("Failed to load water mesh ({})", magic_enum::enum_name(error)));
+		LogMeshLoadFailure(error, "meshes\\water\\WaterMesh.nif");
+		fail("Failed to load water mesh");
 		return;
 	}
 	if (!nif || nif->GetChildren().empty() || !nif->GetChildren().front()->AsNode() || nif->GetChildren().front()->AsNode()->GetChildren().empty()) {
@@ -229,7 +238,8 @@ void UnifiedWater::DataLoaded()
 	logger::debug("[Unified Water] Water mesh loaded");
 
 	if (const auto error = RE::BSModelDB::Demand("meshes\\water\\optimisedwatermesh.nif", nif, args); error != RE::BSResource::ErrorCode::kNone) {
-		fail(std::format("Failed to load optimised water mesh ({})", magic_enum::enum_name(error)));
+		LogMeshLoadFailure(error, "meshes\\water\\OptimisedWaterMesh.nif");
+		fail("Failed to load optimised water mesh");
 		return;
 	}
 	if (!nif || nif->GetChildren().empty() || !nif->GetChildren().front()->AsNode() || nif->GetChildren().front()->AsNode()->GetChildren().empty()) {

--- a/src/Features/UnifiedWater.h
+++ b/src/Features/UnifiedWater.h
@@ -145,6 +145,8 @@ private:
 	std::atomic_bool mapMenuOpen{ false };
 
 	void SetFlowmapTex() const;
+	/** @brief Returns whether the meshes and water cache built in DataLoaded are available; hooks installed in PostPostLoad run before it and survive its failure paths. */
+	bool IsWaterDataReady() const;
 	bool IsExteriorWorldspaceActive() const;
 	void UpdateWaterLODCull() const;
 	static bool LoadOrderChanged();


### PR DESCRIPTION
Hooks install at kPostPostLoad but waterCache is created in DataLoaded,
so hooks ran with a null pointer, permanently so if DataLoaded took an
early return. Guard the three hooks that dereference it.

PostPostLoad also NOPed the vanilla LOD water and flow map paths before
anything was validated, so a failed init left no water at all. Those
patches move to DisableVanillaWaterLOD(), run once after init succeeds.

Also includes logging for if similar errors happen again

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved water rendering fallback behavior when required mesh or hierarchy data is unavailable.
  * Prevented water-cache access before resources are ready during world transitions, sky-cell cleanup, and terrain attachment.
  * Disabled conflicting vanilla water rendering paths more reliably to avoid visual inconsistencies.
  * Added validation for water rendering setup to prevent incomplete or invalid initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->