### PR TITLE
chore: expand beta/alpha with unreleased

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -360,7 +360,7 @@ Unreleased = True
 
 -   Flags: `Alpha`, `Beta`, `Unreleased`. Truthy values are `true`, `1`, `yes`, `on` (case-insensitive). Absent or non-truthy means the flag is off.
 -   `Alpha` takes precedence over `Beta` when both are set.
--   `Unreleased` is **orthogonal to the stage**: it does not participate in stage resolution, has no UI marker of its own, and is unknown to the version audit. It only hides the feature until installed, and is **only ever set or cleared by hand**; no tooling touches it.
+-   `Unreleased` is **orthogonal to the stage**: it does not participate in stage resolution, has no UI marker of its own, and is unknown to the version audit. It only hides the feature until installed, and is **only ever set or cleared by hand**; no tooling modifies it.
 -   The flag line must start the line (after optional whitespace). For `Alpha`/`Beta`, the CMake parser in `CMakeLists.txt` and the Python parser in `tools/feature_version_audit.py` are both line-anchored; **keep these two regexes in sync** so build-time classification and audit enforcement agree. `Unreleased` is parsed by CMake only.
 
 **Build-time baking**: `CMakeLists.txt` collects flagged features into `FEATURE_ALPHA_NAMES` / `FEATURE_BETA_NAMES` / `FEATURE_UNRELEASED_NAMES` in the generated `FeatureVersions.h` (same mechanism as `FEATURE_CORE_NAMES`).

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -345,9 +345,9 @@ Modular ImGui-based configuration interface with specialized renderers for diffe
 
 Feature versions are automatically extracted from `.ini` files and compiled into `FeatureVersions.h` at build time for backward compatibility checking.
 
-### Release Stages (Alpha / Beta)
+### Release Stages (Alpha / Beta) and the Unreleased flag
 
-Features can declare a release-maturity stage in their `.ini` `[Info]` section. This drives the default-enabled state, a UI marker, and the version-audit policy.
+Features can declare a release-maturity stage in their `.ini` `[Info]` section. This drives the default-enabled state, a UI marker, and the version-audit policy. A separate `Unreleased` flag gates UI visibility.
 
 **Declaring a stage** (in `features/<Feature>/Shaders/Features/<Feature>.ini`):
 
@@ -355,20 +355,24 @@ Features can declare a release-maturity stage in their `.ini` `[Info]` section. 
 [Info]
 Version = 0-2-0
 Beta = True
+Unreleased = True
 ```
 
--   Flags: `Alpha` or `Beta`. Truthy values are `true`, `1`, `yes`, `on` (case-insensitive). Absent or non-truthy means full **Release**.
+-   Flags: `Alpha`, `Beta`, `Unreleased`. Truthy values are `true`, `1`, `yes`, `on` (case-insensitive). Absent or non-truthy means the flag is off.
 -   `Alpha` takes precedence over `Beta` when both are set.
--   The flag line must start the line (after optional whitespace). The CMake parser in `CMakeLists.txt` and the Python parser in `tools/feature_version_audit.py` are both line-anchored; **keep these two regexes in sync** so build-time classification and audit enforcement agree.
+-   `Unreleased` is **orthogonal to the stage**: it does not participate in stage resolution, has no UI marker of its own, and is unknown to the version audit. It only hides the feature until installed, and is **only ever set or cleared by hand**; no tooling touches it.
+-   The flag line must start the line (after optional whitespace). For `Alpha`/`Beta`, the CMake parser in `CMakeLists.txt` and the Python parser in `tools/feature_version_audit.py` are both line-anchored; **keep these two regexes in sync** so build-time classification and audit enforcement agree. `Unreleased` is parsed by CMake only.
 
-**Build-time baking**: `CMakeLists.txt` collects flagged features into `FEATURE_ALPHA_NAMES` / `FEATURE_BETA_NAMES` in the generated `FeatureVersions.h` (same mechanism as `FEATURE_CORE_NAMES`).
+**Build-time baking**: `CMakeLists.txt` collects flagged features into `FEATURE_ALPHA_NAMES` / `FEATURE_BETA_NAMES` / `FEATURE_UNRELEASED_NAMES` in the generated `FeatureVersions.h` (same mechanism as `FEATURE_CORE_NAMES`).
 
 **Runtime API** (`src/Feature.h`):
 
 -   `Feature::GetReleaseStage()` returns `ReleaseStage::{Release, Beta, Alpha}` by looking the short name up in the baked sets. Resolve it once and pass it around; it is not cached.
 -   `IsAlpha()` / `IsBeta()` convenience predicates.
 -   `static GetReleaseStageTag(ReleaseStage)` returns the localized `[ALPHA]` / `[BETA]` marker (empty for Release). It takes the stage so callers that already resolved it avoid a redundant lookup.
--   `IsDisabledByDefault()` returns `true` for any non-Release stage, so **Alpha/Beta features start disabled on first install**. Users can still enable them via the "Disable at Boot" menu. Do not add a redundant `IsDisabledByDefault` override on a feature that already carries a stage flag.
+-   `installed` is set once at boot in `State::Load` from the presence of the feature `.ini`. Unlike `loaded` it stays `true` for features disabled at boot, so they remain reachable in the UI.
+-   `IsUnreleased()` reflects the `Unreleased` flag. `IsHiddenUnreleased()` is `true` for an unreleased feature whose `.ini` is not installed: such features are omitted from the "Unloaded Features" list and the "Disable at Boot" list, so a shipped build never advertises work in progress. Once installed they render like any other feature, untagged.
+-   `IsDisabledByDefault()` returns `true` only for **CORE** features at a non-Release stage: those ship with the base mod without the user asking for them. A pre-release addon is installed deliberately, so it starts enabled. Users can flip either via the "Disable at Boot" menu. Do not add a redundant `IsDisabledByDefault` override on a feature that already carries a stage flag.
 
 **UI**: `FeatureListRenderer` draws the stage tag next to the feature name. Alpha uses the theme `StatusPalette.Error` color, Beta uses `StatusPalette.Warning`.
 
@@ -377,7 +381,7 @@ Beta = True
 -   Pre-release features use `0.x` versions. Entering pre-release from a release/fresh baseline: Beta starts at `0-2-0`, Alpha at `0-1-0`.
 -   `alpha -> beta` bumps the minor and resets the patch.
 -   Within the same pre-release stage, normal semver applies inside `0.x`.
--   A breaking change (`feat!:` / `BREAKING CHANGE:`) on a pre-release feature **promotes it to release `1-0-0` and strips the Alpha/Beta flag**. `--apply-bumps` performs both the version bump and the flag removal automatically.
+-   A breaking change (`feat!:` / `BREAKING CHANGE:`) on a pre-release feature **promotes it to release `1-0-0` and strips the Alpha/Beta flag**. `--apply-bumps` performs both the version bump and the flag removal automatically. An `Unreleased` flag is left alone by promotion; clear it by hand when the feature actually ships.
 -   Stage transitions are exact-match enforced (they may legitimately lower the version, e.g. release `1.x` -> beta `0-2-0`), unlike the lenient `>` check used within a stage.
 
 ## Key Development Patterns

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -269,6 +269,17 @@ foreach(FEATURE_PATH ${FEATURE_CONFIG_FILES})
         list(APPEND FEATURE_BETA_NAMES "\t\t\"${FEATURE}\"sv")
     endif()
 
+    # Detect the Unreleased flag, which gates UI visibility independently of the
+    # release stage above. Same line anchoring and CMAKE_MATCH_2 guard.
+    set(_STAGE_UNRELEASED "")
+    string(REGEX MATCH "(^|[\r\n])[ \t]*[Uu]nreleased[ \t]*=[ \t]*([A-Za-z0-9]+)" _STAGE_UNRELEASED_MATCH "${CONFIG_VALUE}")
+    if(_STAGE_UNRELEASED_MATCH)
+        string(TOLOWER "${CMAKE_MATCH_2}" _STAGE_UNRELEASED)
+    endif()
+    if(_STAGE_UNRELEASED MATCHES "^(true|1|yes|on)$")
+        list(APPEND FEATURE_UNRELEASED_NAMES "\t\t\"${FEATURE}\"sv")
+    endif()
+
     # Detect core features by checking for the CORE marker file in the
     # feature root (features/<Folder>/CORE). FEATURE_PATH is
     # features/<Folder>/Shaders/Features/<ShortName>.ini, so the feature
@@ -291,6 +302,7 @@ string(REPLACE ";" ",\n" FEATURE_VERSIONS "${FEATURE_VERSIONS}")
 string(REPLACE ";" ",\n" FEATURE_CORE_NAMES "${FEATURE_CORE_NAMES}")
 string(REPLACE ";" ",\n" FEATURE_ALPHA_NAMES "${FEATURE_ALPHA_NAMES}")
 string(REPLACE ";" ",\n" FEATURE_BETA_NAMES "${FEATURE_BETA_NAMES}")
+string(REPLACE ";" ",\n" FEATURE_UNRELEASED_NAMES "${FEATURE_UNRELEASED_NAMES}")
 
 configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/cmake/FeatureVersions.h.in

--- a/cmake/FeatureVersions.h.in
+++ b/cmake/FeatureVersions.h.in
@@ -25,4 +25,9 @@ namespace FeatureVersions
 	{
 @FEATURE_BETA_NAMES@
 	};
+
+	static const std::unordered_set<std::string_view> FEATURE_UNRELEASED_NAMES
+	{
+@FEATURE_UNRELEASED_NAMES@
+	};
 }

--- a/features/Cloud Shadows/Shaders/Features/CloudShadows.ini
+++ b/features/Cloud Shadows/Shaders/Features/CloudShadows.ini
@@ -1,5 +1,2 @@
 [Info]
 Version = 1-5-0
-
-[Nexus]
-autoupload = false

--- a/features/Dynamic Cubemaps/Shaders/Features/DynamicCubemaps.ini
+++ b/features/Dynamic Cubemaps/Shaders/Features/DynamicCubemaps.ini
@@ -1,5 +1,2 @@
 [Info]
 Version = 2-4-0
-
-[Nexus]
-autoupload = false

--- a/features/Exponential Height Fog/Shaders/Features/ExponentialHeightFog.ini
+++ b/features/Exponential Height Fog/Shaders/Features/ExponentialHeightFog.ini
@@ -1,5 +1,6 @@
 [Info]
 Version = 1-3-1
+Unreleased = True
 
 [Nexus]
 autoupload = false

--- a/features/Grass Collision/Shaders/Features/GrassCollision.ini
+++ b/features/Grass Collision/Shaders/Features/GrassCollision.ini
@@ -1,5 +1,2 @@
 [Info]
 Version = 3-1-0
-
-[Nexus]
-autoupload = false

--- a/features/IBL/Shaders/Features/ImageBasedLighting.ini
+++ b/features/IBL/Shaders/Features/ImageBasedLighting.ini
@@ -1,5 +1,2 @@
 [Info]
 Version = 1-3-0
-
-[Nexus]
-autoupload = false

--- a/features/Light Limit Fix/Shaders/Features/LightLimitFix.ini
+++ b/features/Light Limit Fix/Shaders/Features/LightLimitFix.ini
@@ -1,5 +1,2 @@
 [Info]
 Version = 3-2-0
-
-[Nexus]
-autoupload = false

--- a/features/Linear Lighting/Shaders/Features/LinearLighting.ini
+++ b/features/Linear Lighting/Shaders/Features/LinearLighting.ini
@@ -1,5 +1,6 @@
 [Info]
 Version = 1-2-0
+Unreleased = True
 
 [Nexus]
 autoupload = false

--- a/features/Performance Overlay/Shaders/Features/PerformanceOverlay.ini
+++ b/features/Performance Overlay/Shaders/Features/PerformanceOverlay.ini
@@ -1,5 +1,2 @@
 [Info]
 Version = 1-2-0
-
-[Nexus]
-autoupload = false

--- a/features/Subsurface Scattering/Shaders/Features/SubsurfaceScattering.ini
+++ b/features/Subsurface Scattering/Shaders/Features/SubsurfaceScattering.ini
@@ -1,5 +1,2 @@
 [Info]
 Version = 3-2-0
-
-[Nexus]
-autoupload = false

--- a/features/Terrain Shadows/Shaders/Features/TerrainShadows.ini
+++ b/features/Terrain Shadows/Shaders/Features/TerrainShadows.ini
@@ -1,5 +1,2 @@
 [Info]
 Version = 1-2-0
-
-[Nexus]
-autoupload = false

--- a/features/Volumetric Shadows/Shaders/Features/VolumetricShadows.ini
+++ b/features/Volumetric Shadows/Shaders/Features/VolumetricShadows.ini
@@ -1,5 +1,2 @@
 [Info]
 Version = 2-1-0
-
-[Nexus]
-autoupload = false

--- a/src/Feature.h
+++ b/src/Feature.h
@@ -46,6 +46,9 @@ virtual const void* GetSettingsBlob() const { return nullptr; }
 	// Nexus Mods base URL for Skyrim Special Edition
 	static constexpr std::string_view NEXUS_BASE_URL = "https://www.nexusmods.com/skyrimspecialedition/mods/";
 	bool loaded = false;
+	// Whether the feature .ini is present on disk. Unlike `loaded` this stays true for
+	// features disabled at boot, so they remain reachable in the UI.
+	bool installed = false;
 	std::string version;
 	std::string failedLoadedMessage;
 
@@ -117,6 +120,20 @@ public:
 	bool IsBeta() const { return GetReleaseStage() == ReleaseStage::Beta; }
 
 	/**
+	 * Whether the feature has yet to ship, declared via `Unreleased = True` in the
+	 * feature .ini and baked into FeatureVersions.h at build time. Orthogonal to
+	 * ReleaseStage: it gates UI visibility only, and carries no marker of its own.
+	 */
+	bool IsUnreleased() const { return FeatureVersions::FEATURE_UNRELEASED_NAMES.contains(const_cast<Feature*>(this)->GetShortName()); }
+
+	/**
+	 * Whether an unreleased feature must stay out of the UI entirely. Unreleased
+	 * features only surface once their .ini is installed, so a shipped build never
+	 * advertises work in progress; once installed they render like any other feature.
+	 */
+	bool IsHiddenUnreleased() const { return !installed && IsUnreleased(); }
+
+	/**
 	 * Localized stage marker shown after the feature name ("[ALPHA]", "[BETA]"),
 	 * empty for release features. Takes the stage so callers that already resolved
 	 * it (see GetReleaseStage) avoid a redundant lookup.
@@ -125,10 +142,11 @@ public:
 
 	/**
 	 * Whether the feature is disabled at boot by default (before any user override).
-	 * Alpha and Beta features start disabled on first install; users can still enable
-	 * them via the "Disable at Boot" menu.
+	 * Only pre-release CORE features start disabled, since they ship with the base mod
+	 * without the user asking for them. A pre-release addon is installed deliberately,
+	 * so it starts enabled. Users can flip either via the "Disable at Boot" menu.
 	 */
-	virtual bool IsDisabledByDefault() const { return GetReleaseStage() != ReleaseStage::Release; }
+	virtual bool IsDisabledByDefault() const { return IsCore() && GetReleaseStage() != ReleaseStage::Release; }
 
 	/**
 	 * Whether the feature will show up in the GUI menu

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -898,6 +898,9 @@ void Menu::DrawDisableAtBootSettings()
 
 		// Display sorted features
 		for (auto* feature : featureList) {
+			if (feature->IsHiddenUnreleased())
+				continue;
+
 			const std::string featureName = feature->GetShortName();
 			bool isDisabled = disabledFeatures.contains(featureName) && disabledFeatures[featureName];
 

--- a/src/Menu/FeatureListRenderer.cpp
+++ b/src/Menu/FeatureListRenderer.cpp
@@ -2,11 +2,9 @@
 
 #include <algorithm>
 #include <cmath>
-#include <filesystem>
 #include <format>
 #include <imgui.h>
 #include <ranges>
-#include <system_error>
 #include <unordered_set>
 
 #include "Feature.h"
@@ -424,7 +422,7 @@ std::vector<FeatureListRenderer::MenuFuncInfo> FeatureListRenderer::BuildMenuLis
 	}
 
 	auto unloadedFeatures = sortedFeatureList | std::ranges::views::filter([](Feature* feat) {
-		return !feat->loaded && feat->IsInMenu() && (!FeatureIssues::IsObsoleteFeature(feat->GetShortName()) || globals::state->IsDeveloperMode());
+		return !feat->loaded && feat->IsInMenu() && !feat->IsHiddenUnreleased() && (!FeatureIssues::IsObsoleteFeature(feat->GetShortName()) || globals::state->IsDeveloperMode());
 	});
 	if (std::ranges::distance(unloadedFeatures) != 0) {
 		menuList.push_back(T("menu.features.unloaded_features", "Unloaded Features"));
@@ -598,14 +596,9 @@ void FeatureListRenderer::ListMenuVisitor::operator()(Feature* feat)
 	} else if (hasFailedMessage) {
 		textColor = feat->version.empty() ? themeSettings.StatusPalette.Disable : themeSettings.StatusPalette.Error;
 	} else {
-		// No failed message but not loaded - check if INI file exists
-		if (!std::filesystem::exists(Util::PathHelpers::GetFeatureIniPath(feat->GetShortName()))) {
-			// INI file missing - treat as missing feature (grey)
-			textColor = themeSettings.StatusPalette.Disable;
-		} else {
-			// INI file exists but feature not loaded - truly pending restart (green)
-			textColor = themeSettings.StatusPalette.RestartNeeded;
-		}
+		// Installed but not loaded means the feature is only pending a restart (green),
+		// otherwise it is simply missing (grey).
+		textColor = feat->installed ? themeSettings.StatusPalette.RestartNeeded : themeSettings.StatusPalette.Disable;
 	}
 
 	// Create selectable item with semantic color
@@ -678,13 +671,6 @@ void FeatureListRenderer::DrawMenuVisitor::operator()(Feature* feat)
 	ImGui::EndChild();
 	// Render reactive constraint warning outside the child window so it can appear as a top-level popup
 	RenderReactiveConstraintWarningDialog();
-}
-
-bool FeatureListRenderer::DrawMenuVisitor::IsFeatureInstalled(const std::string& featureName)
-{
-	const auto path = Util::PathHelpers::GetFeatureIniPath(featureName);
-	std::error_code ec;
-	return std::filesystem::exists(path, ec);
 }
 
 void FeatureListRenderer::DrawMenuVisitor::RenderFeatureHeader(Feature* feat, bool isDisabled, bool isLoaded, bool sceneControlled)
@@ -914,7 +900,7 @@ void FeatureListRenderer::DrawMenuVisitor::RenderFeatureSettings(Feature* feat, 
 		} else {
 			if (FeatureIssues::IsObsoleteFeature(feat->GetShortName())) {
 				feat->DrawUnloadedUI();
-			} else if (IsFeatureInstalled(feat->GetShortName())) {
+			} else if (feat->installed) {
 				ImGui::Text("%s", T("menu.features.available_after_restart", "This feature will be available after restart."));
 			} else {
 				feat->DrawUnloadedUI();

--- a/src/Menu/FeatureListRenderer.h
+++ b/src/Menu/FeatureListRenderer.h
@@ -85,7 +85,6 @@ private:
 		std::string& pendingFeatureSelection;
 
 		// Helper methods for Feature rendering
-		static bool IsFeatureInstalled(const std::string& featureName);
 		void RenderFeatureHeader(Feature* feat, bool isDisabled, bool isLoaded, bool sceneControlled);
 		void RenderFeatureSettings(Feature* feat, bool isDisabled, bool isLoaded, bool hasFailedMessage, bool sceneControlled);
 		static void RenderRestoreDefaultsButton(Feature* feat, bool isDisabled, bool isLoaded);

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -416,6 +416,10 @@ void State::Load(ConfigMode a_configMode, bool a_allowReload)
 		for (auto* feature : Feature::GetFeatureList()) {
 			try {
 				const std::string featureName = feature->GetShortName();
+				// Resolved here rather than in Feature::Load so features disabled at boot,
+				// which never reach Load, still report their install state to the UI.
+				std::error_code ec;
+				feature->installed = std::filesystem::exists(Util::PathHelpers::GetFeatureIniPath(featureName), ec);
 				if (!disabledFeatures.contains(featureName) && feature->IsDisabledByDefault()) {
 					disabledFeatures[featureName] = true;
 					logger::info("Feature '{}' is disabled by default", featureName);

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -419,7 +419,11 @@ void State::Load(ConfigMode a_configMode, bool a_allowReload)
 				// Resolved here rather than in Feature::Load so features disabled at boot,
 				// which never reach Load, still report their install state to the UI.
 				std::error_code ec;
-				feature->installed = std::filesystem::exists(Util::PathHelpers::GetFeatureIniPath(featureName), ec);
+				const bool iniExists = std::filesystem::exists(Util::PathHelpers::GetFeatureIniPath(featureName), ec);
+				// exists() reports false on error, so treat an unreadable path as installed rather than letting a probe failure hide the feature.
+				if (ec)
+					logger::warn("Could not determine install state for feature '{}': {}", featureName, ec.message());
+				feature->installed = ec || iniExists;
 				if (!disabledFeatures.contains(featureName) && feature->IsDisabledByDefault()) {
 					disabledFeatures[featureName] = true;
 					logger::info("Feature '{}' is disabled by default", featureName);


### PR DESCRIPTION
adds the unreleased tag for features, they will be hidden in the UI unless the ini is present.
ini is read on build time to construct this.
now also doesn't read disk every frame to check release status
cleaned all feature inis
LL and fog are tagged as unreleased
beta/alpha features that are not core are not disabled by default, adv skin.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for marking features as unreleased independently of their maturity stage.
  * Unreleased features that are not installed are hidden from feature lists and boot settings.
* **Bug Fixes**
  * Improved feature availability and installation status reporting, including features disabled at startup.
  * Pre-release add-ons now start enabled by default, while pre-release core features remain disabled.
* **Configuration**
  * Updated feature definitions and removed obsolete upload settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->