### PR TITLE
fix(terrain-helper): guard null material in hook

### DIFF
--- a/src/Features/TerrainHelper.cpp
+++ b/src/Features/TerrainHelper.cpp
@@ -214,6 +214,12 @@ struct TH_BSLightingShader_SetupMaterial
 {
 	static void thunk(RE::BSLightingShader* shader, RE::BSLightingShaderMaterialBase const* material)
 	{
+		// A geometry with no resolvable material (e.g. a decal whose textures all
+		// failed to load) can reach here with material == nullptr; the original
+		// engine function dereferences it unconditionally.
+		if (!material)
+			return;
+
 		func(shader, material);
 
 		auto& terrainHelper = globals::features::terrainHelper;


### PR DESCRIPTION
cherrypicked form OS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability by safely handling cases where terrain materials are unavailable.
  * Prevented unnecessary processing when no material is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->