### PR TITLE
fix(features): enable NvAPI passthrough for RenderDoc captures

### DIFF
--- a/src/Features/RenderDoc.cpp
+++ b/src/Features/RenderDoc.cpp
@@ -124,6 +124,14 @@ void RenderDoc::Load()
 	// Menu input owns capture hotkeys so they respect the configured frame count.
 	renderDocApi->SetCaptureKeys(nullptr, 0);
 
+	// RenderDoc disables vendor extensions (NvAPI) by default: nvapi_QueryInterface returns
+	// NULL for every function. Skyrim relies on NvAPI for D3D11, and on hybrid graphics
+	// systems this makes the driver remove the device at the first Present, crashing the
+	// game shortly after startup. 0x10DE is the NVIDIA vendor id, enabling NvAPI passthrough.
+	// Available since RenderDoc 1.3.0.
+	// 0x10DE = NVIDIA
+	renderDocApi->SetCaptureOptionU32(eRENDERDOC_Option_AllowUnsupportedVendorExtensions, 0x10DE);
+
 	// Initialize capture count tracking
 	lastCaptureCount = renderDocApi->GetNumCaptures();
 

--- a/src/Features/RenderDoc.cpp
+++ b/src/Features/RenderDoc.cpp
@@ -125,12 +125,15 @@ void RenderDoc::Load()
 	renderDocApi->SetCaptureKeys(nullptr, 0);
 
 	// RenderDoc disables vendor extensions (NvAPI) by default: nvapi_QueryInterface returns
-	// NULL for every function. Skyrim relies on NvAPI for D3D11, and on hybrid graphics
-	// systems this makes the driver remove the device at the first Present, crashing the
-	// game shortly after startup. 0x10DE is the NVIDIA vendor id, enabling NvAPI passthrough.
+	// NULL for unsupported NvAPI interfaces (known or whitelisted ones still pass through).
+	// Skyrim relies on NvAPI for D3D11, and on hybrid graphics systems this makes the
+	// driver remove the device at the first Present, crashing the game shortly after
+	// startup. 0x10DE is the NVIDIA vendor id, enabling NvAPI passthrough.
 	// Available since RenderDoc 1.3.0.
-	// 0x10DE = NVIDIA
-	renderDocApi->SetCaptureOptionU32(eRENDERDOC_Option_AllowUnsupportedVendorExtensions, 0x10DE);
+	const int result = renderDocApi->SetCaptureOptionU32(eRENDERDOC_Option_AllowUnsupportedVendorExtensions, 0x10DE);
+	if (result != 1) {
+		logger::warn("[RenderDoc] Failed to enable NvAPI passthrough (renderdoc.dll rejected vendor extensions, result {})", result);
+	}
 
 	// Initialize capture count tracking
 	lastCaptureCount = renderDocApi->GetNumCaptures();


### PR DESCRIPTION
Fixes #2620 

RenderDoc disables vendor extensions (NvAPI) by default, which makes its
nvapi_QueryInterface hook return NULL for every NvAPI function. Skyrim relies on
NvAPI for D3D11, and on hybrid-graphics NVIDIA laptops the driver removes the
D3D11 device at the first Present (DXGI_ERROR_DEVICE_REMOVED) — the game crashes
~10s after startup with RenderDoc capture enabled. Desktop-only setups may not
hit it.

This enables NvAPI passthrough with one in-app API call in RenderDoc::Load(),
right after the API interface is obtained and before any frame renders:

```cpp
renderDocApi->SetCaptureOptionU32(eRENDERDOC_Option_AllowUnsupportedVendorExtensions, 0x10DE); // 0x10DE = NVIDIA
```

The option is only settable through the in-application API (the RenderDoc GUI
has no toggle), is available since RenderDoc 1.3.0, and only affects sessions
where CS itself loaded renderdoc.dll from Data/Renderdoc/.

Testing (RTX 4060 Max-Q + AMD iGPU hybrid laptop, Win11):
- Stock official renderdoc.dll 1.43/1.45 + this call → game boots, F12 captures work
- Without the call → crash reproduces (crash log attached to #2620 )
- No behavior change when RenderDoc capture is disabled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for NVIDIA vendor extensions during RenderDoc capture initialization.
  * Improves compatibility when capturing applications that use NVIDIA-specific graphics features.
  * Capture setup now reports a warning if NVIDIA extension support cannot be enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->