### PR TITLE
fix(SSGI): flash after loading screens

### DIFF
--- a/src/Features/ScreenSpaceGI.cpp
+++ b/src/Features/ScreenSpaceGI.cpp
@@ -354,6 +354,33 @@ void ScreenSpaceGI::SaveSettings(json& o_json)
 	o_json = settings;
 }
 
+RE::BSEventNotifyControl ScreenSpaceGI::MenuOpenCloseEventHandler::ProcessEvent(const RE::MenuOpenCloseEvent* a_event, RE::BSTEventSource<RE::MenuOpenCloseEvent>*)
+{
+	if (a_event->menuName == RE::LoadingMenu::MENU_NAME && !a_event->opening)
+		globals::features::screenSpaceGI.queuedResetHistory = true;
+
+	return RE::BSEventNotifyControl::kContinue;
+}
+
+bool ScreenSpaceGI::MenuOpenCloseEventHandler::Register()
+{
+	static MenuOpenCloseEventHandler singleton;
+	auto ui = globals::game::ui;
+
+	if (!ui) {
+		logger::error("UI event source not found");
+		return false;
+	}
+
+	ui->GetEventSource<RE::MenuOpenCloseEvent>()->AddEventSink(&singleton);
+	return true;
+}
+
+void ScreenSpaceGI::PostPostLoad()
+{
+	MenuOpenCloseEventHandler::Register();
+}
+
 void ScreenSpaceGI::SetupResources()
 {
 	auto renderer = globals::game::renderer;
@@ -718,6 +745,14 @@ void ScreenSpaceGI::DrawSSGI()
 	static uint lastFrameAccumTexIdx = 0;
 	uint inputAoTexIdx = lastFrameAoTexIdx;
 	uint inputGITexIdx = lastFrameGITexIdx;
+
+	// Zeroing the accumulation count drives the denoiser's lerp factor to 1, dropping stale
+	// history in one frame instead of fading it over MaxAccumFrames.
+	if (queuedResetHistory.exchange(false)) {
+		FLOAT clr[4] = { 0.f, 0.f, 0.f, 0.f };
+		for (auto& tex : texAccumFrames)
+			context->ClearUnorderedAccessViewFloat(tex->uav.get(), clr);
+	}
 
 	//////////////////////////////////////////////////////
 

--- a/src/Features/ScreenSpaceGI.h
+++ b/src/Features/ScreenSpaceGI.h
@@ -35,6 +35,8 @@ public:
 	virtual void LoadSettings(json& o_json) override;
 	virtual void SaveSettings(json& o_json) override;
 
+	/** @brief Registers the loading screen listener that resets the temporal history. */
+	virtual void PostPostLoad() override;
 	/** @brief Creates GPU textures, samplers, constant buffers, and compiles compute shaders. */
 	virtual void SetupResources() override;
 	/** @brief Releases and recompiles all SSGI compute shaders. */
@@ -54,6 +56,18 @@ public:
 	bool recompileFlag = false;
 	uint outputAoIdx = 0;
 	uint outputIlIdx = 0;
+
+	// Loading screen radiance decays at only 1/MaxAccumFrames per frame, bleeding the old scene
+	// into the new one for some frames.
+	std::atomic<bool> queuedResetHistory{ true };
+
+	class MenuOpenCloseEventHandler : public RE::BSTEventSink<RE::MenuOpenCloseEvent>
+	{
+	public:
+		virtual RE::BSEventNotifyControl ProcessEvent(const RE::MenuOpenCloseEvent* a_event, RE::BSTEventSource<RE::MenuOpenCloseEvent>*) override;
+
+		static bool Register();
+	};
 
 	struct Settings
 	{

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -274,8 +274,15 @@ namespace WeatherExtensions
 		{
 			if (globals::features::effects11.loaded) {
 				globals::features::effects11.CheckCommonData();
-				if (globals::features::effects11.enableEffect)
-					globals::features::effects11.OverrideAmbientLighting(DirectionalAmbientColors);
+				if (globals::features::effects11.enableEffect) {
+					// The engine passes Sky's own cube by reference, so overriding in place writes
+					// the scaled result back into Sky and compounds on every call Sky has not
+					// recomputed colors for. Push an overridden copy and leave Sky's cube alone.
+					Effects11::DirectionalAmbientColors overridden = DirectionalAmbientColors;
+					globals::features::effects11.OverrideAmbientLighting(overridden);
+					func(overridden, AmbientSpecularTint, AmbientSpecularFresnel);
+					return;
+				}
 			}
 			func(DirectionalAmbientColors, AmbientSpecularTint, AmbientSpecularFresnel);
 		}

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -275,9 +275,8 @@ namespace WeatherExtensions
 			if (globals::features::effects11.loaded) {
 				globals::features::effects11.CheckCommonData();
 				if (globals::features::effects11.enableEffect) {
-					// The engine passes Sky's own cube by reference, so overriding in place writes
-					// the scaled result back into Sky and compounds on every call Sky has not
-					// recomputed colors for. Push an overridden copy and leave Sky's cube alone.
+					// The engine passes Sky's own cube by reference, so overriding in place would
+					// compound on every call Sky has not recomputed colors for.
 					Effects11::DirectionalAmbientColors overridden = DirectionalAmbientColors;
 					globals::features::effects11.OverrideAmbientLighting(overridden);
 					func(overridden, AmbientSpecularTint, AmbientSpecularFresnel);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Temporal screen-space global illumination history now resets when loading screens close, helping prevent stale or ghosted lighting artifacts.
  * Improved ambient-light handling when Effects11 lighting adjustments are enabled, while preserving the standard lighting behavior otherwise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->