### PR TITLE
fix(effects11): robust preset loading

### DIFF
--- a/package/SKSE/Plugins/CommunityShaders/Translations/en.json
+++ b/package/SKSE/Plugins/CommunityShaders/Translations/en.json
@@ -570,7 +570,7 @@
     "feature.effects11.key_feature_3": "Advanced post-processing pipeline",
     "feature.effects11.key_feature_4": "Custom technique execution",
     "feature.effects11.key_feature_5": "Dynamic UI variable system",
-    "feature.effects11.no_preset_detected": "No preset detected",
+    "feature.effects11.no_valid_preset": "No valid preset loaded",
     "feature.exp_height_fog.apply_vanilla_fade": "Apply Vanilla Fade",
     "feature.exp_height_fog.apply_vanilla_fade_tooltip": "Applies vanilla fade brightness to exponential height fog.",
     "feature.exp_height_fog.cubemap_mip_level": "Cubemap Mip Level",

--- a/src/Features/Effects11/EffectManager.cpp
+++ b/src/Features/Effects11/EffectManager.cpp
@@ -103,10 +103,13 @@ void EffectManager::LogPresetStatus() const
 	}
 
 	// Effects11 stays inert without a preset, so make the reason findable
-	if (!enbEffect.IsFilePresent())
+	if (!enbEffect.IsFilePresent()) {
 		logger::warn("[EFFECTS11] No preset in use: '{}' not found", enbEffect.GetFilePath().string());
-	else
-		logger::error("[EFFECTS11] No preset in use: '{}' failed to compile", enbEffect.GetFilePath().string());
+	} else {
+		const auto& errors = enbEffect.GetErrors();
+		logger::error("[EFFECTS11] No preset in use: '{}' failed to load: {}", enbEffect.GetFilePath().string(),
+			errors.empty() ? "unknown error" : errors.back());
+	}
 }
 
 void EffectManager::Apply()

--- a/src/Features/Effects11/EffectManager.cpp
+++ b/src/Features/Effects11/EffectManager.cpp
@@ -5,6 +5,7 @@
 #include "Globals.h"
 #include "State.h"
 
+#include "PresetManager.h"
 #include "SettingManager.h"
 #include "TextureManager.h"
 #include "WeatherManager.h"
@@ -90,6 +91,24 @@ void EffectManager::Initialize()
 
 }
 
+void EffectManager::LogPresetStatus() const
+{
+	auto& presetManager = PresetManager::GetSingleton();
+
+	if (IsPresetLoaded()) {
+		logger::info("[EFFECTS11] Preset loaded from '{}', settings from '{}'",
+			presetManager.GetENBSeriesPath().string(),
+			presetManager.GetENBSeriesIniPath().string());
+		return;
+	}
+
+	// Effects11 stays inert without a preset, so make the reason findable
+	if (!enbEffect.IsFilePresent())
+		logger::warn("[EFFECTS11] No preset in use: '{}' not found", enbEffect.GetFilePath().string());
+	else
+		logger::error("[EFFECTS11] No preset in use: '{}' failed to compile", enbEffect.GetFilePath().string());
+}
+
 void EffectManager::Apply()
 {
 	globals::features::effects11.LoadRaindropTexture();
@@ -107,13 +126,14 @@ void EffectManager::Apply()
 			effect->LoadWeatherData();
 	}
 #endif
+
+	LogPresetStatus();
 }
 
 void EffectManager::Load()
 {
 	Effect* allEffects[] = { &enbBloom, &enbLens, &enbAdaptation, &enbEffect, &enbEffectPostPass };
 	for (auto* effect : allEffects) {
-		effect->lastIniWriteTime = {};
 		effect->Load();
 		effect->UpdateUIVariables();
 	}

--- a/src/Features/Effects11/EffectManager.h
+++ b/src/Features/Effects11/EffectManager.h
@@ -150,5 +150,8 @@ public:
 	std::vector<std::string> GetAllErrors() const;
 
 private:
+	/** @brief Logs the resolved preset location, or why no preset is in use. */
+	void LogPresetStatus() const;
+
 	bool initialized = false;
 };

--- a/src/Features/Effects11/Effects/Effect.cpp
+++ b/src/Features/Effects11/Effects/Effect.cpp
@@ -13,6 +13,11 @@
 #include "Features/Effects11/SettingsPatches.h"
 #include "Features/Effects11/ShaderPatches.h"
 
+std::filesystem::path Effect::GetFilePath() const
+{
+	return PresetManager::GetSingleton().GetENBSeriesPath() / GetName();
+}
+
 bool Effect::Load()
 {
 	std::filesystem::path iniPath = PresetManager::GetSingleton().GetENBSeriesPath() / (GetName() + ".ini");
@@ -21,13 +26,6 @@ bool Effect::Load()
 		logger::info("[EFFECTS11] Could not find ini file '{}' for effect '{}', using defaults", iniPath.string(), GetName());
 		return true;
 	}
-
-	auto writeTime = std::filesystem::last_write_time(iniPath);
-	if (writeTime == lastIniWriteTime) {
-		logger::info("[EFFECTS11] Skipping unchanged ini file '{}' for effect '{}'", iniPath.string(), GetName());
-		return true;
-	}
-	lastIniWriteTime = writeTime;
 
 	std::string section = GetName();
 	std::transform(section.begin(), section.end(), section.begin(), ::toupper);
@@ -119,6 +117,10 @@ bool Effect::Load()
 
 void Effect::Save()
 {
+	// Nothing loaded means nothing to persist; writing would leave stub ini files in the preset
+	if (!IsCompiled())
+		return;
+
 	std::filesystem::path iniPath = PresetManager::GetSingleton().GetENBSeriesPath() / (GetName() + ".ini");
 
 	std::string section = GetName();
@@ -197,15 +199,15 @@ bool Effect::Apply()
 
 	if (!LoadFXFile()) {
 		if (!filePresent) {
+			// A missing optional effect is normal, a missing required one means there is no preset
 			if (IsRequired()) {
-				errors.push_back("Required effect file not found");
-				logger::error("[EFFECTS11] Required effect file not found for '{}'", GetName());
+				logger::error("[EFFECTS11] Required effect file not found: '{}'", GetFilePath().string());
 				return false;
 			}
-			logger::info("[EFFECTS11] Effect file not found for '{}', skipping", GetName());
+			logger::info("[EFFECTS11] Effect file not found, skipping: '{}'", GetFilePath().string());
 			return true;
 		}
-		logger::error("[EFFECTS11] Failed to compile FX file for effect '{}'", GetName());
+		logger::error("[EFFECTS11] Failed to compile '{}'", GetFilePath().string());
 		return false;
 	}
 
@@ -244,14 +246,12 @@ void Effect::Unload()
 	filePresent = false;
 	errors.clear();
 
-	lastIniWriteTime = {};
-
 	logger::info("[EFFECTS11] Unloaded effect '{}'", GetName());
 }
 
 bool Effect::LoadFXFile()
 {
-	auto filePath = PresetManager::GetSingleton().GetENBSeriesPath() / GetName();
+	auto filePath = GetFilePath();
 
 	if (!std::filesystem::exists(filePath)) {
 		filePresent = false;

--- a/src/Features/Effects11/Effects/Effect.cpp
+++ b/src/Features/Effects11/Effects/Effect.cpp
@@ -207,7 +207,8 @@ bool Effect::Apply()
 			logger::info("[EFFECTS11] Effect file not found, skipping: '{}'", GetFilePath().string());
 			return true;
 		}
-		logger::error("[EFFECTS11] Failed to compile '{}'", GetFilePath().string());
+		// The file exists but could not be read or compiled; errors holds the specific reason
+		logger::error("[EFFECTS11] Failed to load '{}': {}", GetFilePath().string(), errors.empty() ? "unknown error" : errors.back());
 		return false;
 	}
 

--- a/src/Features/Effects11/Effects/Effect.h
+++ b/src/Features/Effects11/Effects/Effect.h
@@ -32,6 +32,9 @@ public:
 	bool IsFilePresent() const { return filePresent; }
 	const std::vector<std::string>& GetErrors() const { return errors; }
 
+	/** @brief Absolute path of this effect's .fx file inside the resolved preset folder. */
+	std::filesystem::path GetFilePath() const;
+
 	virtual void Execute() = 0;
 	virtual void UpdateEffectVariables() {}
 
@@ -223,9 +226,6 @@ public:
 	};
 
 	std::vector<UIDefineInfo> uiDefines;
-
-	// INI file modification time tracking to skip redundant reloads
-	std::filesystem::file_time_type lastIniWriteTime{};
 
 	struct TechniqueSequenceResult
 	{

--- a/src/Features/Effects11/MenuManager.cpp
+++ b/src/Features/Effects11/MenuManager.cpp
@@ -49,6 +49,10 @@ void MenuManager::RenderSettingsPanel()
 	auto& settingManager = SettingManager::GetSingleton();
 	auto& effectManager = EffectManager::GetSingleton();
 
+	// Without a preset there is no ini to write back to, so saving would only create stubs
+	const bool presetLoaded = effectManager.IsPresetLoaded();
+
+	ImGui::BeginDisabled(!presetLoaded);
 	if (ImGui::Button("Save & Apply")) {
 		settingManager.Save();
 		effectManager.Save();
@@ -59,6 +63,7 @@ void MenuManager::RenderSettingsPanel()
 	if (ImGui::IsItemHovered()) {
 		ImGui::SetTooltip("Save all settings, then reload and recompile shaders");
 	}
+	ImGui::EndDisabled();
 
 	ImGui::SameLine();
 
@@ -83,6 +88,7 @@ void MenuManager::RenderSettingsPanel()
 
 	ImGui::SameLine();
 
+	ImGui::BeginDisabled(!presetLoaded);
 	if (ImGui::Button("Save")) {
 		settingManager.Save();
 		effectManager.Save();
@@ -90,6 +96,7 @@ void MenuManager::RenderSettingsPanel()
 	if (ImGui::IsItemHovered()) {
 		ImGui::SetTooltip("Save all settings to enbseries.ini, weather files, and effect configurations");
 	}
+	ImGui::EndDisabled();
 
 	ImGui::Separator();
 
@@ -335,6 +342,7 @@ void MenuManager::RenderAllSettings()
 								switch (settingInfo->type) {
 								case SettingType::Bool:
 									{
+										// Covers both a missing preset and one whose enbeffect.fx failed to compile
 										const bool noPreset = category == "GLOBAL" && settingKey == "UseEffect" && !EffectManager::GetSingleton().IsPresetLoaded();
 
 										bool v = !noPreset && settingManager.GetValue<bool>(settingID, true);
@@ -347,7 +355,7 @@ void MenuManager::RenderAllSettings()
 										if (noPreset) {
 											ImGui::SameLine();
 											ImGui::PushStyleColor(ImGuiCol_Text, globals::menu->GetSettings().Theme.StatusPalette.Warning);
-											ImGui::TextUnformatted(T("feature.effects11.no_preset_detected", "No preset detected"));
+											ImGui::TextUnformatted(T("feature.effects11.no_valid_preset", "No valid preset loaded"));
 											ImGui::PopStyleColor();
 										}
 										break;

--- a/src/Features/Effects11/SettingManager.cpp
+++ b/src/Features/Effects11/SettingManager.cpp
@@ -5,6 +5,7 @@
 #include <Windows.h>
 #include <algorithm>
 #include <cctype>
+#include <filesystem>
 #include <string>
 #include <tuple>
 
@@ -501,16 +502,10 @@ void SettingManager::LoadWeatherSettings(const std::vector<uint32_t>& weatherIDs
 		return;
 	}
 
-	auto writeTime = std::filesystem::last_write_time(filePath);
-
-	// Snapshot allSettings and check for changes under a short shared lock
+	// Snapshot allSettings under a short shared lock
 	std::vector<Setting> settingsCopy;
 	{
 		std::shared_lock lock(mutex);
-		auto it = weatherFileWriteTimes.find(filePath);
-		if (it != weatherFileWriteTimes.end() && it->second == writeTime) {
-			return;  // File unchanged since last load
-		}
 		settingsCopy = allSettings;
 	}
 
@@ -529,7 +524,6 @@ void SettingManager::LoadWeatherSettings(const std::vector<uint32_t>& weatherIDs
 	// Store loaded values for all provided weather IDs under write lock
 	{
 		std::unique_lock lock(mutex);
-		weatherFileWriteTimes[filePath] = writeTime;
 		for (uint32_t weatherID : weatherIDs) {
 			weatherData[weatherID] = loadedValues;
 			lastSavedWeatherData[weatherID] = loadedValues;
@@ -617,7 +611,6 @@ void SettingManager::ReloadAllWeatherSettings()
 	{
 		std::unique_lock lock(mutex);
 		weatherData.clear();
-		weatherFileWriteTimes.clear();  // Force re-read of all weather files
 	}
 	auto& weatherManager = WeatherManager::GetSingleton();
 	weatherManager.Initialize();
@@ -639,16 +632,11 @@ void SettingManager::LoadFromFile(const std::string& filePath)
 		return;
 	}
 
-	auto writeTime = std::filesystem::last_write_time(absPath);
-
 	// Snapshot settings and identify weather categories under brief shared lock
 	std::vector<Setting> settingsCopy;
 	std::vector<std::string> weatherCategories;
 	{
 		std::shared_lock lock(mutex);
-		if (writeTime == lastMainIniWriteTime) {
-			return;  // File unchanged since last load
-		}
 		settingsCopy = allSettings;
 		for (const auto& [catName, catData] : categories) {
 			for (const auto& [key, settingID] : catData.settings) {
@@ -697,7 +685,6 @@ void SettingManager::LoadFromFile(const std::string& filePath)
 	// Store results under unique lock
 	{
 		std::unique_lock lock(mutex);
-		lastMainIniWriteTime = writeTime;
 		allSettings = std::move(settingsCopy);
 
 		// Apply weather ignore settings
@@ -1045,10 +1032,6 @@ void SettingManager::SetIgnoreWeatherSystemInterior(const std::string& category,
 
 void SettingManager::Load()
 {
-	{
-		std::unique_lock lock(mutex);
-		lastMainIniWriteTime = {};
-	}
 	LoadFromFile(PresetManager::GetSingleton().GetENBSeriesIniPath().string());
 	ReloadAllWeatherSettings();
 }

--- a/src/Features/Effects11/SettingManager.h
+++ b/src/Features/Effects11/SettingManager.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <filesystem>
 #include <map>
 #include <optional>
 #include <shared_mutex>
@@ -204,10 +203,6 @@ private:
 
 	float timeOfDay1[4] = { 0, 0, 0, 0 };
 	float timeOfDay2[4] = { 0, 0, 0, 0 };
-
-	// INI file modification time tracking to skip redundant reloads
-	std::filesystem::file_time_type lastMainIniWriteTime{};
-	std::unordered_map<std::string, std::filesystem::file_time_type> weatherFileWriteTimes;
 
 	mutable std::shared_mutex mutex;
 

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -262,7 +262,8 @@ namespace WeatherExtensions
 		static void thunk(RE::Sky* sky, float a_delta)
 		{
 			func(sky, a_delta);
-			globals::features::effects11.OnSkyUpdateColors(sky);
+			if (globals::features::effects11.loaded)
+				globals::features::effects11.OnSkyUpdateColors(sky);
 			globals::features::skySync.OnSkyUpdateColors(sky);
 		}
 		static inline REL::Relocation<decltype(thunk)> func;


### PR DESCRIPTION
1. Effect::Save() returns early if not compiled; the two Save buttons in MenuManager.cpp are disabled without a preset.
2. Renamed feature.effects11.no_preset_detected → no_valid_preset ("No valid preset loaded"), en.json regenerated.
3. Effect::Apply() now logs missing-required vs missing-optional vs compile-failure by path; new EffectManager::LogPresetStatus() logs the resolved preset/ini paths or the reason there's none. New Effect::GetFilePath() helper.
4. Removed the unreachable error push and all three write-time caches (Effect::lastIniWriteTime, SettingManager::lastMainIniWriteTime, weatherFileWriteTimes).
5. sky hook in Hooks.cpp now checks effects11.loaded.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer status reporting for loaded presets, including preset and effect file locations.
  * Improved messages when presets are missing or fail to compile.

* **Bug Fixes**
  * Prevented saving settings when no valid preset is available.
  * Improved effect and settings reload behavior.
  * Prevented Effects11 updates when the feature is not loaded.
  * Prevented attempts to save effects that failed to compile.
  * Updated status text to “No valid preset loaded.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->