### PR TITLE
fix(effects11): guard menus from effects

### DIFF
--- a/src/Features/Effects11.cpp
+++ b/src/Features/Effects11.cpp
@@ -470,11 +470,11 @@ void Effects11::CheckCommonData()
 		ENBHelper::Update();
 
 		auto& settingManager = SettingManager::GetSingleton();
-		auto ui = globals::game::ui;
-		bool isMenuOpen = ui->IsMenuOpen(RE::MapMenu::MENU_NAME);
+		auto state = globals::state;
+		const bool inBlockedMenu = state->isMapMenuOpen || state->isStatsMenuOpen;
 		auto& effectManager = EffectManager::GetSingleton();
 
-		enableEffect = !isMenuOpen && globals::shaderCache->IsEnabled() && settingManager.GetValue<bool>("UseEffect", "GLOBAL") && effectManager.IsPresetLoaded();
+		enableEffect = !inBlockedMenu && globals::shaderCache->IsEnabled() && settingManager.GetValue<bool>("UseEffect", "GLOBAL") && effectManager.IsPresetLoaded();
 
 		auto& weatherManager = WeatherManager::GetSingleton();
 
@@ -634,7 +634,7 @@ void Effects11::DrawVolumetricRays()
 	if (globals::game::sky && globals::game::sky->flags.any(RE::Sky::Flags::kHideSky))
 		return;
 
-	if (globals::state->isMapMenuOpen)
+	if (globals::state->isMapMenuOpen || globals::state->isStatsMenuOpen)
 		return;
 
 	auto& settingManager = SettingManager::GetSingleton();

--- a/src/Features/IBL.cpp
+++ b/src/Features/IBL.cpp
@@ -213,8 +213,9 @@ void IBL::RegisterWeatherVariables()
 
 IBL::PerFrame IBL::GetCommonBufferData() const
 {
+	const bool sceneDisabled = IsDisabledForCurrentScene();
 	PerFrame data = {
-		.EnableIBL = IsDisabledForCurrentScene() ? 0u : settings.EnableIBL,
+		.EnableIBL = sceneDisabled ? 0u : settings.EnableIBL,
 		.PreserveFogLuminance = settings.PreserveFogLuminance,
 		.UseStaticIBL = settings.UseStaticIBL,
 		.DALCAmount = settings.DALCAmount,
@@ -226,7 +227,7 @@ IBL::PerFrame IBL::GetCommonBufferData() const
 		.DALCMode = settings.DALCMode
 	};
 
-	if (globals::features::effects11.loaded) {
+	if (!sceneDisabled && globals::features::effects11.loaded) {
 		auto& enb = globals::features::effects11;
 		if (enb.enableEffect) {
 			auto& settingManager = SettingManager::GetSingleton();

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -221,12 +221,13 @@ void State::Reset()
 	globals::profiler->EndFrame();
 
 	Feature::ForEachLoadedFeature("Reset", [](Feature* feature) { feature->Reset(); });
-	if (!globals::game::ui->GameIsPaused())
-		timer += RE::GetSecondsSinceLastFrame();
 
 	// Cache menu open states once per frame to avoid repeated IsMenuOpen calls
 	// (each call constructs a BSFixedString, which is expensive at scale).
 	if (auto ui = globals::game::ui) {
+		if (!ui->GameIsPaused())
+			timer += RE::GetSecondsSinceLastFrame();
+
 		isMainMenuOpen = ui->IsMenuOpen(RE::MainMenu::MENU_NAME);
 		isLoadingMenuOpen = ui->IsMenuOpen(RE::LoadingMenu::MENU_NAME);
 		isMapMenuOpen = ui->IsMenuOpen(RE::MapMenu::MENU_NAME);

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -230,10 +230,12 @@ void State::Reset()
 		isMainMenuOpen = ui->IsMenuOpen(RE::MainMenu::MENU_NAME);
 		isLoadingMenuOpen = ui->IsMenuOpen(RE::LoadingMenu::MENU_NAME);
 		isMapMenuOpen = ui->IsMenuOpen(RE::MapMenu::MENU_NAME);
+		isStatsMenuOpen = ui->IsMenuOpen(RE::StatsMenu::MENU_NAME);
 	} else {
 		isMainMenuOpen = false;
 		isLoadingMenuOpen = false;
 		isMapMenuOpen = false;
+		isStatsMenuOpen = false;
 	}
 
 	lastModifiedPixelDescriptor = 0;

--- a/src/State.h
+++ b/src/State.h
@@ -293,6 +293,7 @@ public:
 	bool isMainMenuOpen = false;
 	bool isLoadingMenuOpen = false;
 	bool isMapMenuOpen = false;
+	bool isStatsMenuOpen = false;
 	/** @brief Returns true if the cached main-menu or loading-menu state is open. */
 	bool IsMainOrLoadingMenuOpen() const { return isMainMenuOpen || isLoadingMenuOpen; }
 	/** @brief Returns true if main/loading menu is open, with a live fallback query via the UI pointer. */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Effects and volumetric rays are now disabled while either the map or stats menu is open.
  * Image-based lighting is more reliably disabled in scenes where it is turned off, including when external lighting settings are active.
  * Menu state handling is now more consistent when the interface is unavailable or the game is paused.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->