### PR TITLE
fix(profiler): drop stale timings after 60 frames

### DIFF
--- a/src/Profiler.cpp
+++ b/src/Profiler.cpp
@@ -239,12 +239,11 @@ void Profiler::CollectResults()
 		results.push_back(std::move(result));
 	}
 }
-
 void Profiler::RetireStaleTimers()
 {
 	const size_t before = knownTimers.size();
 	std::erase_if(knownTimers, [this](const KnownTimer& known) {
-		return collectedFrames - known.lastSampleFrame > kTimerRetireFrames;
+		return collectedFrames - known.lastSampleFrame >= kTimerRetireFrames;
 	});
 	if (knownTimers.size() != before)
 		RebuildTimerIndex();

--- a/src/Profiler.cpp
+++ b/src/Profiler.cpp
@@ -74,6 +74,7 @@ void Profiler::Release()
 	results.clear();
 	knownTimers.clear();
 	knownTimerIndex.clear();
+	collectedFrames = 0;
 	totalTimeMs = 0.0f;
 	cpuTotalTimeMs = 0.0f;
 	initialized = false;
@@ -164,6 +165,7 @@ void Profiler::CollectResults()
 		return;
 
 	frame.inFlight = false;
+	collectedFrames++;
 
 	struct ActiveTimerData
 	{
@@ -202,8 +204,11 @@ void Profiler::CollectResults()
 			auto& known = knownTimers[it->second];
 			known.gpu.PushSample(ms);
 			known.cpu.PushSample(timer.cpuMs);
+			known.lastSampleFrame = collectedFrames;
 		}
 	}
+
+	RetireStaleTimers();
 
 	totalTimeMs = activeTotalMs;
 	cpuTotalTimeMs = activeCpuTotalMs;
@@ -233,4 +238,21 @@ void Profiler::CollectResults()
 		result.historyCount = known.gpu.count;
 		results.push_back(std::move(result));
 	}
+}
+
+void Profiler::RetireStaleTimers()
+{
+	const size_t before = knownTimers.size();
+	std::erase_if(knownTimers, [this](const KnownTimer& known) {
+		return collectedFrames - known.lastSampleFrame > kTimerRetireFrames;
+	});
+	if (knownTimers.size() != before)
+		RebuildTimerIndex();
+}
+
+void Profiler::RebuildTimerIndex()
+{
+	knownTimerIndex.clear();
+	for (size_t i = 0; i < knownTimers.size(); i++)
+		knownTimerIndex[knownTimers[i].name] = i;
 }

--- a/src/Profiler.h
+++ b/src/Profiler.h
@@ -19,6 +19,9 @@ public:
 	static constexpr uint32_t kMaxTimers = 128;
 	static constexpr uint32_t kFrameLatency = 3;
 	static constexpr uint32_t kHistorySize = 300;
+	// Must exceed the longest legitimate gap between samples of a still-running pass;
+	// the DynamicCubemaps state machine spreads its passes over 6 frames.
+	static constexpr uint64_t kTimerRetireFrames = 60;
 
 	using PerfEventCallback = std::function<void(std::string_view)>;
 
@@ -131,6 +134,7 @@ public:
 		results.clear();
 		knownTimers.clear();
 		knownTimerIndex.clear();
+		collectedFrames = 0;
 		totalTimeMs = 0.0f;
 		cpuTotalTimeMs = 0.0f;
 	}
@@ -145,9 +149,7 @@ public:
 		std::erase_if(knownTimers, [&prefix](const KnownTimer& kt) {
 			return kt.name.starts_with(prefix);
 		});
-		knownTimerIndex.clear();
-		for (size_t i = 0; i < knownTimers.size(); i++)
-			knownTimerIndex[knownTimers[i].name] = i;
+		RebuildTimerIndex();
 	}
 
 private:
@@ -187,11 +189,19 @@ private:
 		std::string name;
 		RollingHistory gpu;
 		RollingHistory cpu;
+		uint64_t lastSampleFrame = 0;
 	};
 	std::vector<KnownTimer> knownTimers;
 	std::unordered_map<std::string, size_t> knownTimerIndex;
+	uint64_t collectedFrames = 0;
 	float totalTimeMs = 0.0f;
 	float cpuTotalTimeMs = 0.0f;
 
 	void CollectResults();
+
+	/** @brief Drops timers that have not been sampled for kTimerRetireFrames, so disabled passes stop reporting stale values. */
+	void RetireStaleTimers();
+
+	/** @brief Repoints knownTimerIndex at the current knownTimers positions after an erase. */
+	void RebuildTimerIndex();
 };


### PR DESCRIPTION
so that disabled features are not left in the profiling data filling it with useless data.
60 frame timer so that features that may not be present every frame do not flicker in and out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Improved profiler timer lifecycle management by retiring inactive timers after a configured period.
- Ensured timer indexes remain accurate when timers are removed.
- Reset profiling state correctly when releasing or clearing timers.
- Updated frame tracking so GPU timing results are associated with the latest sample.
- Reduced the risk of stale profiling data affecting timer results and performance measurements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->