### PR TITLE
fix(cmake): use 7z for AIO package install fallback

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -193,7 +193,7 @@ jobs:
                   # semantic-release's floor for every RC cut from dev.
                   commit: ${{ github.event.pull_request.head.sha }}
                   prerelease: true
-                  artifacts: "${{ github.workspace }}/dist/CommunityShaders_AIO-*.zip"
+                  artifacts: "${{ github.workspace }}/dist/CommunityShaders_AIO-*.7z,${{ github.workspace }}/dist/CommunityShaders_AIO-*.zip"
                   bodyFile: release-notes.md
                   allowUpdates: true
                   replacesArtifacts: true
@@ -209,7 +209,7 @@ jobs:
                   # step above for why dev-reachable preview tags break releases.
                   commit: ${{ github.event.pull_request.head.sha }}
                   prerelease: true
-                  artifacts: "${{ github.workspace }}/dist/CommunityShaders_AIO-*.zip"
+                  artifacts: "${{ github.workspace }}/dist/CommunityShaders_AIO-*.7z,${{ github.workspace }}/dist/CommunityShaders_AIO-*.zip"
                   generateReleaseNotes: true
                   allowUpdates: true
                   replacesArtifacts: true

--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -183,7 +183,8 @@ jobs:
                   draft: true
                   omitDraftDuringUpdate: true
                   tag: ${{ steps.combined_notes.outputs.release_tag }}
-                  artifacts: "${{ github.workspace }}/dist/*.zip"
+                  # AIO is .7z when 7-Zip is found at configure time, .zip otherwise.
+                  artifacts: "${{ github.workspace }}/dist/*.zip,${{ github.workspace }}/dist/*.7z"
                   bodyFile: ${{ steps.combined_notes.outputs.body_file }}
                   generateReleaseNotes: false
                   replacesArtifacts: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1198,13 +1198,14 @@ else()
         COMMAND ${CMAKE_COMMAND} -E rm -f "${AIO_PACKAGE}"
         COMMAND ${CMAKE_COMMAND} -E chdir ${AIO_DIR} ${AIO_ARCHIVE_COMMAND}
         COMMENT "Creating AIO archive (full install)"
+        VERBATIM
     )
 endif()
 add_custom_target("Package-AIO-Manual" DEPENDS ${AIO_PACKAGE})
 
 message("*************************************************************")
 message("Community Shaders configuration complete")
-message("To prepare a ZIP package of AIO, Core, or Features")
+message("To prepare a package of AIO (.7z when 7-Zip is found), Core, or Features")
 message("  Build cmake targets:")
 message("    - Package-Core: Core package")
 message("    - Package-AIO-Manual: AIO package (manual)")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1178,15 +1178,26 @@ if(TARGET PREPARE_AIO)
         )
     endif()
 else()
+    # AIO_PACKAGE is named .7z whenever 7-Zip exists, so this branch must honour
+    # SEVENZ_EXECUTABLE too or it emits a deflate zip wearing a .7z extension.
+    if(SEVENZ_EXECUTABLE)
+        set(AIO_ARCHIVE_COMMAND
+            "${SEVENZ_EXECUTABLE}" a -t7z -mx1 -mmt=on "${AIO_PACKAGE}" *
+        )
+    else()
+        set(AIO_ARCHIVE_COMMAND
+            ${CMAKE_COMMAND} -E tar cfv ${AIO_PACKAGE} --format=zip -- .
+        )
+    endif()
     add_custom_command(
         OUTPUT ${AIO_PACKAGE}
         DEPENDS ${PROJECT_NAME} ${CORE_SOURCES}
         COMMAND ${CMAKE_COMMAND} -E make_directory ${AIO_DIR}
         COMMAND ${CMAKE_COMMAND} --install ${CMAKE_BINARY_DIR} --config $<CONFIG> --prefix ${AIO_DIR}
-        COMMAND
-            ${CMAKE_COMMAND} -E chdir ${AIO_DIR} ${CMAKE_COMMAND} -E tar cfv
-            ${AIO_PACKAGE} --format=zip -- .
-        COMMENT "Creating AIO zip package (full install)"
+        COMMAND ${CMAKE_COMMAND} -E make_directory "${DIST_PATH}"
+        COMMAND ${CMAKE_COMMAND} -E rm -f "${AIO_PACKAGE}"
+        COMMAND ${CMAKE_COMMAND} -E chdir ${AIO_DIR} ${AIO_ARCHIVE_COMMAND}
+        COMMENT "Creating AIO archive (full install)"
     )
 endif()
 add_custom_target("Package-AIO-Manual" DEPENDS ${AIO_PACKAGE})

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -166,7 +166,7 @@
         },
         {
             "name": "Package",
-            "description": "Build preset to generate a AIO package (.7z when 7-Zip is found, else .zip) in <SRC>/dist folder, mostly for CI",
+            "description": "Build preset to generate an AIO package (.7z when 7-Zip is found, else .zip) in <SRC>/dist folder, mostly for CI",
             "configurePreset": "ALL",
             "configuration": "Release",
             "targets": ["Package-AIO-Manual"]

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -166,7 +166,7 @@
         },
         {
             "name": "Package",
-            "description": "Build preset to generate a AIO zip package in <SRC>/dist folder, mostly for CI",
+            "description": "Build preset to generate a AIO package (.7z when 7-Zip is found, else .zip) in <SRC>/dist folder, mostly for CI",
             "configurePreset": "ALL",
             "configuration": "Release",
             "targets": ["Package-AIO-Manual"]


### PR DESCRIPTION
Package-AIO-Manual names its output .7z whenever SEVENZ_EXECUTABLE is
found, but the no-PREPARE_AIO branch always ran `cmake -E tar
--format=zip`, producing a deflate zip wearing a .7z extension (~108 MB
vs ~90 MB for the same content). Honour SEVENZ_EXECUTABLE in that branch
and add the rm -f / make_directory parity the other branches have.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved manual package creation by using 7-Zip when available, producing archives that match the `.7z` filename.
  * Retained ZIP packaging as a fallback when 7-Zip is unavailable.
  * Ensured destination folders and existing archives are prepared cleanly before packaging.

* **Release Improvements**
  * Prerelease and release builds now provide both `.7z` and `.zip` download options.

* **Documentation**
  * Clarified which archive format packaging produces based on available tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->