### PR TITLE
fix(ui): unified ui and e11 map guards 

### DIFF
--- a/package/Shaders/ISSAOComposite.hlsl
+++ b/package/Shaders/ISSAOComposite.hlsl
@@ -178,7 +178,7 @@ PS_OUTPUT main(PS_INPUT input)
 
 #	if defined(APPLY_FOG)
 	float fogDistanceFactor = (2 * CameraNearFar.x * CameraNearFar.y) / ((CameraNearFar.y + CameraNearFar.x) - (2 * (1.01 * depth - 0.01) - 1) * (CameraNearFar.y - CameraNearFar.x));
-	float fogFactor = min(FogParam.w, pow(saturate(fogDistanceFactor * FogParam.y - FogParam.x), FogParam.z));
+	float fogFactor = SharedData::InMapMenu ? 0.0 : min(FogParam.w, pow(saturate(fogDistanceFactor * FogParam.y - FogParam.x), FogParam.z));
 	float3 fogColor = Color::Fog(lerp(FogNearColor.xyz, FogFarColor.xyz, fogFactor));
 #		if defined(IBL)
 	if (SharedData::iblSettings.EnableIBL) {

--- a/src/CSEditor/EditorWindow.cpp
+++ b/src/CSEditor/EditorWindow.cpp
@@ -2222,7 +2222,7 @@ bool EditorWindow::CanBeOpen()
 {
 	auto* player = globals::game::player;
 	auto* state = globals::state;
-	return player && player->parentCell && !state->isLoadingMenuOpen && !state->isMainMenuOpen;
+	return player && player->parentCell && !state->IsMainOrLoadingMenuOpen();
 }
 
 void EditorWindow::DisableVanityCamera()

--- a/src/Features/Effects11.cpp
+++ b/src/Features/Effects11.cpp
@@ -470,11 +470,9 @@ void Effects11::CheckCommonData()
 		ENBHelper::Update();
 
 		auto& settingManager = SettingManager::GetSingleton();
-		auto state = globals::state;
-		const bool inBlockedMenu = state->isMapMenuOpen || state->isStatsMenuOpen;
 		auto& effectManager = EffectManager::GetSingleton();
 
-		enableEffect = !inBlockedMenu && globals::shaderCache->IsEnabled() && settingManager.GetValue<bool>("UseEffect", "GLOBAL") && effectManager.IsPresetLoaded();
+		enableEffect = !globals::state->IsFullScreenMenuOpen() && globals::shaderCache->IsEnabled() && settingManager.GetValue<bool>("UseEffect", "GLOBAL") && effectManager.IsPresetLoaded();
 
 		auto& weatherManager = WeatherManager::GetSingleton();
 
@@ -634,7 +632,7 @@ void Effects11::DrawVolumetricRays()
 	if (globals::game::sky && globals::game::sky->flags.any(RE::Sky::Flags::kHideSky))
 		return;
 
-	if (globals::state->isMapMenuOpen || globals::state->isStatsMenuOpen)
+	if (globals::state->IsFullScreenMenuOpen())
 		return;
 
 	auto& settingManager = SettingManager::GetSingleton();

--- a/src/Features/Effects11.cpp
+++ b/src/Features/Effects11.cpp
@@ -51,7 +51,7 @@ Effects11::PerFrame Effects11::GetCommonBufferData()
 	data.ParticleAmbientInfluence = settingManager.GetInterpolatedTimeOfDayValue("AmbientInfluence", "PARTICLE");
 	data.ParticlePointLightingInfluence = settingManager.GetInterpolatedTimeOfDayValue("PointLightingInfluence", "PARTICLE");
 
-	data.EnableVolumetricRays = enableEffect && settingManager.GetValue<bool>("EnableVolumetricRays", "EFFECT");
+	data.EnableVolumetricRays = enableEffect && !globals::state->IsFullScreenMenuOpen() && settingManager.GetValue<bool>("EnableVolumetricRays", "EFFECT");
 	data.VolumetricRaysIntensity = settingManager.GetInterpolatedTimeOfDayValue("Intensity", "VOLUMETRICRAYS");
 	{
 		float density = std::max(0.1f, settingManager.GetInterpolatedTimeOfDayValue("Density", "VOLUMETRICRAYS"));
@@ -472,7 +472,7 @@ void Effects11::CheckCommonData()
 		auto& settingManager = SettingManager::GetSingleton();
 		auto& effectManager = EffectManager::GetSingleton();
 
-		enableEffect = !globals::state->IsFullScreenMenuOpen() && globals::shaderCache->IsEnabled() && settingManager.GetValue<bool>("UseEffect", "GLOBAL") && effectManager.IsPresetLoaded();
+		enableEffect = !globals::state->IsMainOrLoadingMenuOpen() && globals::shaderCache->IsEnabled() && settingManager.GetValue<bool>("UseEffect", "GLOBAL") && effectManager.IsPresetLoaded();
 
 		auto& weatherManager = WeatherManager::GetSingleton();
 

--- a/src/Features/Effects11.cpp
+++ b/src/Features/Effects11.cpp
@@ -51,7 +51,7 @@ Effects11::PerFrame Effects11::GetCommonBufferData()
 	data.ParticleAmbientInfluence = settingManager.GetInterpolatedTimeOfDayValue("AmbientInfluence", "PARTICLE");
 	data.ParticlePointLightingInfluence = settingManager.GetInterpolatedTimeOfDayValue("PointLightingInfluence", "PARTICLE");
 
-	data.EnableVolumetricRays = enableEffect && !globals::state->IsFullScreenMenuOpen() && settingManager.GetValue<bool>("EnableVolumetricRays", "EFFECT");
+	data.EnableVolumetricRays = enableEffect && settingManager.GetValue<bool>("EnableVolumetricRays", "EFFECT");
 	data.VolumetricRaysIntensity = settingManager.GetInterpolatedTimeOfDayValue("Intensity", "VOLUMETRICRAYS");
 	{
 		float density = std::max(0.1f, settingManager.GetInterpolatedTimeOfDayValue("Density", "VOLUMETRICRAYS"));
@@ -472,7 +472,7 @@ void Effects11::CheckCommonData()
 		auto& settingManager = SettingManager::GetSingleton();
 		auto& effectManager = EffectManager::GetSingleton();
 
-		enableEffect = !globals::state->IsMainOrLoadingMenuOpen() && globals::shaderCache->IsEnabled() && settingManager.GetValue<bool>("UseEffect", "GLOBAL") && effectManager.IsPresetLoaded();
+		enableEffect = !globals::state->IsFullScreenMenuOpen() && globals::shaderCache->IsEnabled() && settingManager.GetValue<bool>("UseEffect", "GLOBAL") && effectManager.IsPresetLoaded();
 
 		auto& weatherManager = WeatherManager::GetSingleton();
 

--- a/src/Features/HDRDisplay.cpp
+++ b/src/Features/HDRDisplay.cpp
@@ -1569,10 +1569,8 @@ float4 HDRDisplay::GetSharedDataHDR() const
 		return { 0.0f, 0.0f, 0.0f, 0.0f };
 
 	auto* state = globals::state;
-	const bool isMainOrLoading = state->isMainMenuOpen || state->isLoadingMenuOpen;
-	auto* ui = globals::game::ui;
-	const bool inMenuOrPause =
-		ui && (ui->GameIsPaused() || state->isMainMenuOpen || state->isLoadingMenuOpen || state->isMapMenuOpen);
+	const bool isMainOrLoading = state->IsMainOrLoadingMenuOpen();
+	const bool inMenuOrPause = state->IsPausedOrMenuOpen(globals::game::ui);
 
 	float menuSceneEncoding = kHdrMenuSceneGameplay;
 	if (isMainOrLoading) {
@@ -1591,7 +1589,7 @@ float4 HDRDisplay::GetSharedDataHDR() const
 
 HDRDisplay::HDRDataCB HDRDisplay::BuildHDRData() const
 {
-	bool isMainOrLoadingMenu = globals::state->isMainMenuOpen || globals::state->isLoadingMenuOpen;
+	bool isMainOrLoadingMenu = globals::state->IsMainOrLoadingMenuOpen();
 	auto* ui = globals::game::ui;
 	bool skipUIComposite = IsFGCompositingThisFrame();
 

--- a/src/Features/LinearLighting.cpp
+++ b/src/Features/LinearLighting.cpp
@@ -121,7 +121,7 @@ void LinearLighting::SetupResources()
 
 void LinearLighting::Prepass()
 {
-	bool isMainLoadingMenu = globals::state->isMainMenuOpen || globals::state->isLoadingMenuOpen;
+	bool isMainLoadingMenu = globals::state->IsMainOrLoadingMenuOpen();
 	dirLightMult = 1.0f;
 	if (!settings.enableLinearLighting || isMainLoadingMenu)
 		return;
@@ -164,7 +164,7 @@ LinearLighting::PerFrameData LinearLighting::GetCommonBufferData()
 		data.enableLinearLighting = false;
 		return data;
 	}
-	bool isMainLoadingMenu = globals::state->isMainMenuOpen || globals::state->isLoadingMenuOpen;
+	bool isMainLoadingMenu = globals::state->IsMainOrLoadingMenuOpen();
 	auto data = PerFrameData{};
 	data.enableLinearLighting = settings.enableLinearLighting && !isMainLoadingMenu;
 	data.isDirLightLinear = isDirLightLinear;

--- a/src/Features/Upscaling.cpp
+++ b/src/Features/Upscaling.cpp
@@ -1235,9 +1235,8 @@ bool Upscaling::IsFrameGenerationActive() const
 
 bool Upscaling::ShouldUseFrameGenerationThisFrame() const
 {
-	auto* ui = globals::game::ui;
 	auto* state = globals::state;
-	const bool menuOpen = (ui && ui->GameIsPaused()) || (state && state->IsMainOrLoadingMenuOpen(ui));
+	const bool menuOpen = state && state->IsPausedOrMenuOpen(globals::game::ui);
 	return IsFrameGenerationDx12PathActive() && settings.frameGenerationMode && (settings.frameGenerationAllowInMenus || !menuOpen);
 }
 

--- a/src/SceneSettingsManager.cpp
+++ b/src/SceneSettingsManager.cpp
@@ -302,10 +302,9 @@ RE::BSEventNotifyControl SceneSettingsManager::MenuOpenCloseEventHandler::Proces
 
 void SceneSettingsManager::Update()
 {
-	// Revert interior overrides on main/loading menu (same check as LinearLighting)
+	// Revert interior overrides on main/loading menu
 	if (isCurrentlyApplied) {
-		bool isMainOrLoading = globals::state->isMainMenuOpen || globals::state->isLoadingMenuOpen;
-		if (isMainOrLoading) {
+		if (globals::state->IsMainOrLoadingMenuOpen()) {
 			RevertToExteriorSettings();
 			isCurrentlyApplied = false;
 		}

--- a/src/State.h
+++ b/src/State.h
@@ -302,6 +302,13 @@ public:
 		return IsMainOrLoadingMenuOpen() ||
 		       (ui && (ui->IsMenuOpen(RE::MainMenu::MENU_NAME) || ui->IsMenuOpen(RE::LoadingMenu::MENU_NAME)));
 	}
+	/** @brief Full-screen menus drawing their own art, which must not be graded by post-process effects. */
+	bool IsFullScreenMenuOpen() const { return IsMainOrLoadingMenuOpen() || isMapMenuOpen || isStatsMenuOpen; }
+	/** @brief Gameplay is paused or suspended behind a menu. Cached menus are kept explicit in case a mod clears kPausesGame. */
+	bool IsPausedOrMenuOpen(RE::UI* ui) const
+	{
+		return (ui && ui->GameIsPaused()) || IsMainOrLoadingMenuOpen(ui) || isMapMenuOpen;
+	}
 
 	void UpdateSharedData(bool a_inWorld, bool a_prepass);
 	void UpdateSkyShaderPermutation(RE::BSRenderPass* a_pass);

--- a/src/State.h
+++ b/src/State.h
@@ -302,7 +302,7 @@ public:
 		return IsMainOrLoadingMenuOpen() ||
 		       (ui && (ui->IsMenuOpen(RE::MainMenu::MENU_NAME) || ui->IsMenuOpen(RE::LoadingMenu::MENU_NAME)));
 	}
-	/** @brief Full-screen menus drawing their own art, which must not be graded by post-process effects. */
+	/** @brief Full-screen menus, which have no usable scene depth for screen-space effects. */
 	bool IsFullScreenMenuOpen() const { return IsMainOrLoadingMenuOpen() || isMapMenuOpen || isStatsMenuOpen; }
 	/** @brief Gameplay is paused or suspended behind a menu. Cached menus are kept explicit in case a mod clears kPausesGame. */
 	bool IsPausedOrMenuOpen(RE::UI* ui) const

--- a/src/State.h
+++ b/src/State.h
@@ -302,7 +302,7 @@ public:
 		return IsMainOrLoadingMenuOpen() ||
 		       (ui && (ui->IsMenuOpen(RE::MainMenu::MENU_NAME) || ui->IsMenuOpen(RE::LoadingMenu::MENU_NAME)));
 	}
-	/** @brief Full-screen menus, which have no usable scene depth for screen-space effects. */
+	/** @brief Full-screen menus drawing their own art, which must not be graded by post-process effects. */
 	bool IsFullScreenMenuOpen() const { return IsMainOrLoadingMenuOpen() || isMapMenuOpen || isStatsMenuOpen; }
 	/** @brief Gameplay is paused or suspended behind a menu. Cached menus are kept explicit in case a mod clears kPausesGame. */
 	bool IsPausedOrMenuOpen(RE::UI* ui) const


### PR DESCRIPTION
based on some commits bottle made for effects 11 on his fork.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of full-screen, loading, map, and stats menus across the application.
  - Effects, volumetric lighting, and fog now disable consistently when appropriate menus are open.
  - HDR and lighting behavior is more reliable during menu transitions.
  - Frame generation and upscaling now respond more accurately when the game is paused or menus are displayed.
  - Editor availability and scene settings updates remain synchronized with the current menu state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->