### PR TITLE
fix(unified-water): (BLEND) define water normals not animated

### DIFF
--- a/src/Features/UnifiedWater.cpp
+++ b/src/Features/UnifiedWater.cpp
@@ -448,7 +448,7 @@ bool UnifiedWater::LoadOrderChanged()
 	return changed;
 }
 
-void UnifiedWater::SetFlowmapTex() const
+void UnifiedWater::SetFlowmapTex()
 {
 	RE::NiPointer<RE::NiSourceTexture> tex;
 	if (!flowmap->TryGetFlowmap(tex))
@@ -493,13 +493,20 @@ void UnifiedWater::PostPostLoad()
 	logger::info("[Unified Water] Installed hooks");
 }
 
+namespace
+{
+	// Vanilla material CRC omits normal texture names, so distinct water forms can collide and
+	// steal each other's Normals01/02/03. Fold texture-name hashes into CRC via this side channel —
+	// never stash them in normalTexture1 (that used to null the pointer and kill BLEND_NORMALS scroll).
+	thread_local uint32_t t_waterNormalTextureHash = 0;
+	thread_local bool t_hasWaterNormalTextureHash = false;
+}
+
 void UnifiedWater::TESWaterSystem_InitializeWater_SetWaterShaderMaterialParams::thunk(RE::TESWaterForm* form, RE::BSWaterShaderMaterial* material)
 {
-	// The game prefills the material and hashes its contents, it uses this hash to check if there is an existing identical material and swaps
-	// to using that material if so.
-	// Problem is it does not include all data from the form, especially normal textures which can cause problems with existing materials
-	// having their textures swapped out.
-	// This func hash the texture names and temporarily stashes them in a ptr slot, this is added to the hash in ComputeCRC and zeroed back out again
+	t_hasWaterNormalTextureHash = false;
+	t_waterNormalTextureHash = 0;
+
 	func(form, material);
 
 	uint32_t hash = 2166136261u;
@@ -514,15 +521,17 @@ void UnifiedWater::TESWaterSystem_InitializeWater_SetWaterShaderMaterialParams::
 	addStrToHash(form->noiseTextures[1].textureName.c_str());
 	addStrToHash(form->noiseTextures[2].textureName.c_str());
 	addStrToHash(form->noiseTextures[3].textureName.c_str());
-	uintptr_t bits = hash;
-	std::memcpy(&material->normalTexture1, &bits, sizeof(uintptr_t));
+	t_waterNormalTextureHash = hash;
+	t_hasWaterNormalTextureHash = true;
 }
 
 int32_t UnifiedWater::BSWaterShaderMaterial_ComputeCRC32::thunk(RE::BSWaterShaderMaterial* material, uint32_t srcHash)
 {
-	srcHash ^= static_cast<uint32_t>(reinterpret_cast<uint64_t>(material->normalTexture1.get())) + (srcHash << 6) + (srcHash >> 2);
-	constexpr auto zero = static_cast<uintptr_t>(0);
-	std::memcpy(&material->normalTexture1, &zero, sizeof(uintptr_t));
+	if (t_hasWaterNormalTextureHash) {
+		srcHash ^= t_waterNormalTextureHash + (srcHash << 6) + (srcHash >> 2);
+		t_hasWaterNormalTextureHash = false;
+		t_waterNormalTextureHash = 0;
+	}
 	return func(material, srcHash);
 }
 
@@ -795,7 +804,7 @@ void UnifiedWater::BGSTerrainBlock_Detach::thunk(RE::BGSTerrainBlock* block)
 
 void UnifiedWater::BSWaterShader_SetupGeometry::thunk(RE::BSShader* waterShader, RE::BSRenderPass* pass)
 {
-	const auto& singleton = globals::features::unifiedWater;
+	auto& singleton = globals::features::unifiedWater;
 
 	if (singleton.IsExteriorWorldspaceActive() && singleton.flowmap && pass && pass->geometry) {
 		// ObjectUV.xyz below, xy contains width and height, z contains mesh scale

--- a/src/Features/UnifiedWater.h
+++ b/src/Features/UnifiedWater.h
@@ -146,6 +146,8 @@ private:
 
 	void SetFlowmapTex() const;
 	/** @brief Returns whether the meshes and water cache built in DataLoaded are available; hooks installed in PostPostLoad run before it and survive its failure paths. */
+	void SetFlowmapTex();
+	/** @brief Returns whether the water mesh and cache built in DataLoaded are available; hooks installed in PostPostLoad run before it and survive its failure paths. */
 	bool IsWaterDataReady() const;
 	bool IsExteriorWorldspaceActive() const;
 	void UpdateWaterLODCull() const;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved water rendering consistency by preserving material texture references during normal-texture processing.
  * Improved water shader setup reliability when accessing shared water-rendering resources.
* **Refactor**
  * Updated water flow-map handling and readiness checks to better reflect the water mesh and cache state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->