### PR TITLE
chore(dynamic-cubemaps): increase to 256x256 resolution

### DIFF
--- a/features/Dynamic Cubemaps/Shaders/DynamicCubemaps/DynamicCubemaps.hlsli
+++ b/features/Dynamic Cubemaps/Shaders/DynamicCubemaps/DynamicCubemaps.hlsli
@@ -29,7 +29,7 @@ namespace DynamicCubemaps
 #	else
 		float3 R = reflect(-V, N);
 
-		float level = roughness * 7.0;
+		float level = roughness * 8.0;
 
 		float3 finalIrradiance = 0;
 

--- a/features/Dynamic Cubemaps/Shaders/DynamicCubemaps/DynamicCubemaps.hlsli
+++ b/features/Dynamic Cubemaps/Shaders/DynamicCubemaps/DynamicCubemaps.hlsli
@@ -122,7 +122,8 @@ namespace DynamicCubemaps
 		}
 		} else {
 #		if defined(IBL) && defined(LIGHTING)
-			float3 specularIrradiance = ImageBasedLighting::StaticSpecularIBLTexture.SampleLevel(SampColorSampler, R.xzy, level).xyz;
+			// StaticSpecularIBLTexture is hardcoded to 8 mips (IBL.cpp); do not share the dynamic cubemap scale.
+			float3 specularIrradiance = ImageBasedLighting::StaticSpecularIBLTexture.SampleLevel(SampColorSampler, R.xzy, roughness * 7.0).xyz;
 			finalIrradiance = specularIrradiance;
 #		endif
 		}

--- a/features/Dynamic Cubemaps/Shaders/DynamicCubemaps/InferCubemapCS.hlsl
+++ b/features/Dynamic Cubemaps/Shaders/DynamicCubemaps/InferCubemapCS.hlsl
@@ -58,19 +58,19 @@ float3 GetSamplingVector(uint3 ThreadID, in RWTexture2DArray<float4> OutputTextu
 	float brightness = k;
 #endif
 
-	while (color.w < 1.0 && mipLevel <= 8) {
+	while (color.w < 1.0 && mipLevel <= 9) {
 		mipLevel++;
 
 		float4 tempColor = 0.0;
-		if (mipLevel < 8) {
+		if (mipLevel < 9) {
 			tempColor = EnvCaptureTexture.SampleLevel(LinearSampler, uv, mipLevel);
 		} else {
-			tempColor += EnvCaptureTexture.SampleLevel(LinearSampler, float3(-1.0, 0.0, 0.0), 9);
-			tempColor += EnvCaptureTexture.SampleLevel(LinearSampler, float3(1.0, 0.0, 0.0), 9);
-			tempColor += EnvCaptureTexture.SampleLevel(LinearSampler, float3(0.0, -1.0, 0.0), 9);
-			tempColor += EnvCaptureTexture.SampleLevel(LinearSampler, float3(0.0, 1.0, 0.0), 9);
-			tempColor += EnvCaptureTexture.SampleLevel(LinearSampler, float3(0.0, 0.0, -1.0), 9);
-			tempColor += EnvCaptureTexture.SampleLevel(LinearSampler, float3(0.0, 0.0, 1.0), 9);
+			tempColor += EnvCaptureTexture.SampleLevel(LinearSampler, float3(-1.0, 0.0, 0.0), 10);
+			tempColor += EnvCaptureTexture.SampleLevel(LinearSampler, float3(1.0, 0.0, 0.0), 10);
+			tempColor += EnvCaptureTexture.SampleLevel(LinearSampler, float3(0.0, -1.0, 0.0), 10);
+			tempColor += EnvCaptureTexture.SampleLevel(LinearSampler, float3(0.0, 1.0, 0.0), 10);
+			tempColor += EnvCaptureTexture.SampleLevel(LinearSampler, float3(0.0, 0.0, -1.0), 10);
+			tempColor += EnvCaptureTexture.SampleLevel(LinearSampler, float3(0.0, 0.0, 1.0), 10);
 		}
 
 #if !defined(REFLECTIONS)
@@ -90,9 +90,9 @@ float3 GetSamplingVector(uint3 ThreadID, in RWTexture2DArray<float4> OutputTextu
 	}
 
 #if defined(REFLECTIONS)
-	color.rgb = lerp(color.rgb, Color::IrradianceToLinear(ReflectionsTexture.SampleLevel(LinearSampler, uv, 0.0).rgb), saturate(mipLevel / 7.0));
+	color.rgb = lerp(color.rgb, Color::IrradianceToLinear(ReflectionsTexture.SampleLevel(LinearSampler, uv, 0.0).rgb), saturate(mipLevel / 8.0));
 #else
-	color.rgb = lerp(color.rgb, color.rgb * DefaultCubemap.SampleLevel(LinearSampler, uv, 0.0).xyz, saturate(mipLevel / 7.0));
+	color.rgb = lerp(color.rgb, color.rgb * DefaultCubemap.SampleLevel(LinearSampler, uv, 0.0).xyz, saturate(mipLevel / 8.0));
 #endif
 
 	color.rgb = Color::IrradianceToGamma(color.rgb);

--- a/features/Dynamic Cubemaps/Shaders/Features/DynamicCubemaps.ini
+++ b/features/Dynamic Cubemaps/Shaders/Features/DynamicCubemaps.ini
@@ -1,2 +1,2 @@
 [Info]
-Version = 2-4-1
+Version = 2-5-0

--- a/features/Exponential Height Fog/Shaders/ExponentialHeightFog/ExponentialHeightFog.hlsli
+++ b/features/Exponential Height Fog/Shaders/ExponentialHeightFog/ExponentialHeightFog.hlsli
@@ -193,7 +193,7 @@ namespace ExponentialHeightFog
 
 #if defined(DYNAMIC_CUBEMAPS)
 		if (SharedData::exponentialHeightFogSettings.useDynamicCubemaps > 0) {
-			float3 cubemapColor = DynamicCubemaps::EnvReflectionsTexture.SampleLevel(SampColorSampler, normalize(lerp(positionWS, float3(0, 0, 1), saturate((SharedData::exponentialHeightFogSettings.cubemapMipLevel + 1) / 8))), SharedData::exponentialHeightFogSettings.cubemapMipLevel).xyz;
+			float3 cubemapColor = DynamicCubemaps::EnvReflectionsTexture.SampleLevel(SampColorSampler, normalize(lerp(positionWS, float3(0, 0, 1), saturate((SharedData::exponentialHeightFogSettings.cubemapMipLevel + 1) / 9))), SharedData::exponentialHeightFogSettings.cubemapMipLevel).xyz;
 			fogInscatteringColor += cubemapColor * SharedData::exponentialHeightFogSettings.inscatteringTint.rgb * SharedData::exponentialHeightFogSettings.inscatteringTint.a;
 		}
 #endif

--- a/features/Exponential Height Fog/Shaders/Features/ExponentialHeightFog.ini
+++ b/features/Exponential Height Fog/Shaders/Features/ExponentialHeightFog.ini
@@ -1,5 +1,5 @@
 [Info]
-Version = 1-3-1
+Version = 1-3-2
 Unreleased = True
 
 [Nexus]

--- a/package/Shaders/DeferredCompositeCS.hlsl
+++ b/package/Shaders/DeferredCompositeCS.hlsl
@@ -191,7 +191,7 @@ void SampleSSGISpecular(uint2 pixCoord, sh2 lobe, inout float ao, out float3 il,
 		float3 R = reflect(-V, normalWS);
 
 		float roughness = 1.0 - glossiness;
-		float level = roughness * 7.0;
+		float level = roughness * 8.0;
 
 		sh2 specularLobe = SphericalHarmonics::FauxSpecularLobe(normalWS, V, roughness);
 

--- a/package/Shaders/Lighting.hlsl
+++ b/package/Shaders/Lighting.hlsl
@@ -1931,7 +1931,7 @@ PS_OUTPUT main(PS_INPUT input, bool frontFace : SV_IsFrontFace)
 					material.Roughness = envColorBase.a;
 				} else {
 					material.F0 = 1.0;
-					material.Roughness = 1.0 / 7.0;
+					material.Roughness = 1.0 / 8.0;
 				}
 
 #			if defined(CREATOR)

--- a/src/Features/DynamicCubemaps.cpp
+++ b/src/Features/DynamicCubemaps.cpp
@@ -10,7 +10,7 @@
 
 #define I18N_KEY_PREFIX "feature.dynamic_cubemaps."
 
-constexpr auto MIPLEVELS = 8;
+constexpr auto MIPLEVELS = 9;
 
 NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	DynamicCubemaps::Settings,
@@ -735,7 +735,7 @@ void DynamicCubemaps::SetupResources()
 				++bc6hMipLevels;
 			// Clamp: must not exceed envTexture's mip count (source reads) or the UAV array size.
 			bc6hMipLevels = std::min<std::uint32_t>(bc6hMipLevels, MIPLEVELS);
-			bc6hMipLevels = std::min<std::uint32_t>(bc6hMipLevels, 8u);
+			bc6hMipLevels = std::min<std::uint32_t>(bc6hMipLevels, 9u);
 
 			D3D11_TEXTURE2D_DESC scratchDesc = {};
 			scratchDesc.Width = scratchBase;

--- a/src/Features/DynamicCubemaps.cpp
+++ b/src/Features/DynamicCubemaps.cpp
@@ -1,5 +1,6 @@
 #include "DynamicCubemaps.h"
 
+#include <cassert>
 #include <DDSTextureLoader.h>
 #include <DirectXTex.h>
 
@@ -651,6 +652,7 @@ void DynamicCubemaps::SetupResources()
 	{
 		D3D11_TEXTURE2D_DESC texDesc;
 		cubemap.texture->GetDesc(&texDesc);
+		assert(texDesc.Width == (1u << (MIPLEVELS - 1)));
 
 		D3D11_SHADER_RESOURCE_VIEW_DESC srvDesc;
 		cubemap.SRV->GetDesc(&srvDesc);
@@ -735,7 +737,7 @@ void DynamicCubemaps::SetupResources()
 				++bc6hMipLevels;
 			// Clamp: must not exceed envTexture's mip count (source reads) or the UAV array size.
 			bc6hMipLevels = std::min<std::uint32_t>(bc6hMipLevels, MIPLEVELS);
-			bc6hMipLevels = std::min<std::uint32_t>(bc6hMipLevels, 9u);
+			bc6hMipLevels = std::min<std::uint32_t>(bc6hMipLevels, static_cast<std::uint32_t>(std::size(bc6hScratchUAVs)));
 
 			D3D11_TEXTURE2D_DESC scratchDesc = {};
 			scratchDesc.Width = scratchBase;

--- a/src/Features/DynamicCubemaps.h
+++ b/src/Features/DynamicCubemaps.h
@@ -50,8 +50,8 @@ public:
 	ConstantBuffer* spmapCB = nullptr;
 	Texture2D* envTexture = nullptr;
 	Texture2D* envReflectionsTexture = nullptr;
-	ID3D11UnorderedAccessView* uavArray[7];
-	ID3D11UnorderedAccessView* uavReflectionsArray[7];
+	ID3D11UnorderedAccessView* uavArray[8];
+	ID3D11UnorderedAccessView* uavReflectionsArray[8];
 
 	// Reflection capture
 
@@ -125,7 +125,7 @@ public:
 
 	uint32_t bc6hMipLevels = 0;
 
-	ID3D11UnorderedAccessView* bc6hScratchUAVs[8] = {};
+	ID3D11UnorderedAccessView* bc6hScratchUAVs[9] = {};
 
 	// Editor window
 

--- a/src/Features/ExponentialHeightFog.cpp
+++ b/src/Features/ExponentialHeightFog.cpp
@@ -135,7 +135,7 @@ void ExponentialHeightFog::DrawSettings()
 	}
 	ImGui::Checkbox(T(TKEY("use_dynamic_cubemaps"), "Use Dynamic Cubemaps for Inscattering"), (bool*)&settings.useDynamicCubemaps);
 	Util::WeatherUI::ColorEdit4(T(TKEY("inscattering_cubemap_tint"), "Inscattering Cubemap Tint"), this, "inscatteringTint", (float*)&settings.inscatteringTint);
-	ImGui::SliderFloat(T(TKEY("cubemap_mip_level"), "Cubemap Mip Level"), &settings.cubemapMipLevel, 1.0f, 7.0f, "%.1f");
+	ImGui::SliderFloat(T(TKEY("cubemap_mip_level"), "Cubemap Mip Level"), &settings.cubemapMipLevel, 1.0f, 8.0f, "%.1f");
 
 	ImGui::SeparatorText(T(TKEY("volumetric_fog"), "Volumetric Fog"));
 	Util::WeatherUI::Checkbox(T(TKEY("enable_volumetric_fog"), "Enable Volumetric Fog"), this, "volumetricFogEnabled", (bool*)&settings.volumetricFogEnabled);

--- a/src/Features/ExponentialHeightFog.h
+++ b/src/Features/ExponentialHeightFog.h
@@ -57,7 +57,7 @@ public:
 		float directionalInscatteringMultiplier = 1.0f;
 		float directionalInscatteringAnisotropy = 0.2f;
 		float4 inscatteringTint = { 1.0f, 1.0f, 1.0f, 1.0f };
-		float cubemapMipLevel = 7.0f;
+		float cubemapMipLevel = 8.0f;
 		float sunlightAttenuationAmount = 1.0f;
 		uint respectVanillaFogFade = 0;
 		uint disableVanillaFog = 1;

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -765,8 +765,8 @@ namespace Hooks
 	{
 		static void thunk(RE::BSGraphics::Renderer* This, uint32_t a_target, RE::BSGraphics::CubeMapRenderTargetProperties* a_properties)
 		{
-			a_properties->height = 128;
-			a_properties->width = 128;
+			a_properties->height = 256;
+			a_properties->width = 256;
 			func(This, a_target, a_properties);
 		}
 		static inline REL::Relocation<decltype(thunk)> func;
@@ -776,8 +776,8 @@ namespace Hooks
 	{
 		static void thunk(RE::BSGraphics::Renderer* This, uint32_t a_target, RE::BSGraphics::DepthStencilTargetProperties* a_properties)
 		{
-			a_properties->height = 128;
-			a_properties->width = 128;
+			a_properties->height = 256;
+			a_properties->width = 256;
 			func(This, a_target, a_properties);
 		}
 		static inline REL::Relocation<decltype(thunk)> func;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Increased reflection cubemap and depth-stencil render target resolution to 256×256 for improved visual detail.
  * Improved dynamic environment reflections with expanded cubemap mip-level support and more accurate roughness handling.
  * Updated reflection blending and fallback behavior for smoother results across surface roughness levels.
  * Increased the exponential height fog cubemap mip-level range from 7 to 8 for greater control and improved atmospheric reflections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->