### PR TITLE
fix(hooks): vtable fallback when Detours fails

### DIFF
--- a/include/PCH.h
+++ b/include/PCH.h
@@ -27,7 +27,7 @@ void* operator new[](size_t size, size_t alignment, size_t alignmentOffset, cons
 
 using namespace std::literals;
 
-// Forward declaration
+// Defined in src/Utils/VTableHookFallback.cpp
 namespace Util
 {
 	std::uintptr_t VTableHookFallback(void* a_object, std::size_t a_idx, void* a_thunk, LONG a_detourError);

--- a/include/PCH.h
+++ b/include/PCH.h
@@ -27,6 +27,12 @@ void* operator new[](size_t size, size_t alignment, size_t alignmentOffset, cons
 
 using namespace std::literals;
 
+// Forward declaration
+namespace Util
+{
+	std::uintptr_t VTableHookFallback(void* a_object, std::size_t a_idx, void* a_thunk, LONG a_detourError);
+}
+
 namespace stl
 {
 	using namespace SKSE::stl;
@@ -107,10 +113,17 @@ namespace stl
 	{
 		auto vtable = *reinterpret_cast<uintptr_t**>(target);
 		T::func = vtable[idx];
-		DetourTransactionBegin();
-		DetourUpdateThread(GetCurrentThread());
-		DetourAttach(reinterpret_cast<PVOID*>(&T::func), reinterpret_cast<PVOID>(T::thunk));
-		DetourTransactionCommit();
+		LONG result = DetourTransactionBegin();
+		if (result == NO_ERROR) {
+			DetourUpdateThread(GetCurrentThread());
+			result = DetourAttach(reinterpret_cast<PVOID*>(&T::func), reinterpret_cast<PVOID>(T::thunk));
+			if (result == NO_ERROR)
+				result = DetourTransactionCommit();
+			else
+				DetourTransactionAbort();
+		}
+		if (result != NO_ERROR)
+			T::func = Util::VTableHookFallback(target, idx, reinterpret_cast<PVOID>(T::thunk), result);
 	}
 }
 

--- a/src/Utils/VTableHookFallback.cpp
+++ b/src/Utils/VTableHookFallback.cpp
@@ -1,0 +1,94 @@
+#include "VTableHookFallback.h"
+
+#include <algorithm>
+#include <cstring>
+#include <memory>
+#include <mutex>
+#include <unordered_map>
+
+namespace
+{
+	inline constexpr std::size_t max_cloned_vtable_slots = 256;
+
+	// Objects repointed at a plugin-owned vtable clone. Later hooks on the same object
+	// must patch the same clone, and clones must stay dispatchable after this DLL's
+	// static destructors have run, so the map is intentionally leaked.
+	std::mutex clonedVTableMutex;
+	auto& clonedVTables = *new std::unordered_map<void*, std::unique_ptr<std::uintptr_t[]>>();
+
+	// Copies vtable slots page by page, stopping at the first page that faults; the
+	// vtable may live in memory VirtualQuery cannot measure. Returns the slots copied.
+	std::size_t CopyReadableSlots(std::uintptr_t* a_dst, const std::uintptr_t* a_src, std::size_t a_count) noexcept
+	{
+		std::size_t copied = 0;
+		__try {
+			while (copied < a_count) {
+				const auto cursor = reinterpret_cast<std::uintptr_t>(a_src + copied);
+				const auto pageEnd = (cursor & ~static_cast<std::uintptr_t>(0xFFF)) + 0x1000;
+				const auto chunk = std::min(a_count - copied, (pageEnd - cursor) / sizeof(std::uintptr_t));
+				std::memcpy(a_dst + copied, a_src + copied, chunk * sizeof(std::uintptr_t));
+				copied += chunk;
+			}
+		} __except (EXCEPTION_EXECUTE_HANDLER) {
+		}
+		return copied;
+	}
+}
+
+namespace Util
+{
+	std::uintptr_t VTableHookFallback(void* a_object, std::size_t a_idx, void* a_thunk, LONG a_detourError)
+	{
+		std::scoped_lock lock(clonedVTableMutex);
+
+		// Read under the lock: a concurrent hook may have just repointed this object at a
+		// clone, and the clone check below must see the current vtable pointer.
+		auto vtable = *static_cast<std::uintptr_t**>(a_object);
+		const auto original = vtable[a_idx];
+
+		if (a_idx >= max_cloned_vtable_slots) {
+			logger::warn("[Hooks] virtual slot {} exceeds the supported clone size {}; left unhooked (Detours error {})", a_idx, max_cloned_vtable_slots, a_detourError);
+			return original;
+		}
+
+		// An earlier hook may already have repointed this object at a clone; cloning again
+		// would discard it. The slot value read above came from the clone, so returning it
+		// preserves chaining.
+		if (auto it = clonedVTables.find(a_object); it != clonedVTables.end() && it->second.get() == vtable) {
+			it->second[a_idx] = reinterpret_cast<std::uintptr_t>(a_thunk);
+			logger::warn("[Hooks] Detours could not patch virtual slot {} (error {}); patched the object's existing vtable clone", a_idx, a_detourError);
+			return original;
+		}
+
+		MEMORY_BASIC_INFORMATION mbi{};
+		const bool queried = VirtualQuery(vtable, &mbi, sizeof(mbi)) == sizeof(mbi);
+
+		// Swap the slot in place, keeping execute rights if the page has them.
+		constexpr DWORD executeProtects = PAGE_EXECUTE | PAGE_EXECUTE_READ | PAGE_EXECUTE_READWRITE | PAGE_EXECUTE_WRITECOPY;
+		const DWORD writableProtect = (queried && (mbi.Protect & executeProtects) != 0) ? PAGE_EXECUTE_READWRITE : PAGE_READWRITE;
+		DWORD previousProtect = 0;
+		if (VirtualProtect(&vtable[a_idx], sizeof(std::uintptr_t), writableProtect, &previousProtect)) {
+			vtable[a_idx] = reinterpret_cast<std::uintptr_t>(a_thunk);
+			DWORD restoredProtect = 0;
+			if (!VirtualProtect(&vtable[a_idx], sizeof(std::uintptr_t), previousProtect, &restoredProtect))
+				logger::warn("[Hooks] could not restore protection {:#x} on virtual slot {} (error {})", previousProtect, a_idx, GetLastError());
+			logger::warn("[Hooks] Detours could not patch virtual slot {} (error {}); swapped the vtable slot in place", a_idx, a_detourError);
+			return original;
+		}
+		const DWORD protectResult = GetLastError();
+
+		// Clone the vtable, patch the copy, repoint the object; needs no protection change.
+		// Copy the full capacity so every readable source slot keeps resolving through
+		// the clone.
+		auto clone = std::make_unique<std::uintptr_t[]>(max_cloned_vtable_slots);
+		if (CopyReadableSlots(clone.get(), vtable, max_cloned_vtable_slots) <= a_idx) {
+			logger::warn("[Hooks] virtual slot {} could not be hooked: Detours failed (error {}), the vtable page refused VirtualProtect (error {}), and the vtable was unreadable at that slot", a_idx, a_detourError, protectResult);
+			return original;
+		}
+		clone[a_idx] = reinterpret_cast<std::uintptr_t>(a_thunk);
+		*static_cast<std::uintptr_t**>(a_object) = clone.get();
+		clonedVTables[a_object] = std::move(clone);
+		logger::warn("[Hooks] Detours could not patch virtual slot {} (error {}) and the vtable page refused VirtualProtect (error {}); repointed the object at a patched vtable clone", a_idx, a_detourError, protectResult);
+		return original;
+	}
+}

--- a/src/Utils/VTableHookFallback.cpp
+++ b/src/Utils/VTableHookFallback.cpp
@@ -8,16 +8,17 @@
 
 namespace
 {
-	inline constexpr std::size_t max_cloned_vtable_slots = 256;
+	inline constexpr std::size_t maxClonedVTableSlots = 256;
 
-	// Objects repointed at a plugin-owned vtable clone. Later hooks on the same object
-	// must patch the same clone, and clones must stay dispatchable after this DLL's
-	// static destructors have run, so the map is intentionally leaked.
+	// Objects that now point at a vtable clone owned by this DLL. A later hook on the same
+	// object must patch the same clone. The map is leaked on purpose: the game still calls
+	// through the clones after this DLL's static destructors have run.
 	std::mutex clonedVTableMutex;
 	auto& clonedVTables = *new std::unordered_map<void*, std::unique_ptr<std::uintptr_t[]>>();
 
-	// Copies vtable slots page by page, stopping at the first page that faults; the
-	// vtable may live in memory VirtualQuery cannot measure. Returns the slots copied.
+	// Copies vtable slots one page at a time and stops at the first page that faults,
+	// because VirtualQuery cannot always report how far the vtable stays readable.
+	// Returns the number of slots copied.
 	std::size_t CopyReadableSlots(std::uintptr_t* a_dst, const std::uintptr_t* a_src, std::size_t a_count) noexcept
 	{
 		std::size_t copied = 0;
@@ -41,19 +42,19 @@ namespace Util
 	{
 		std::scoped_lock lock(clonedVTableMutex);
 
-		// Read under the lock: a concurrent hook may have just repointed this object at a
-		// clone, and the clone check below must see the current vtable pointer.
+		// Read the vtable pointer under the lock: another thread may have just pointed this
+		// object at a clone, and the clone check below must see that.
 		auto vtable = *static_cast<std::uintptr_t**>(a_object);
 		const auto original = vtable[a_idx];
 
-		if (a_idx >= max_cloned_vtable_slots) {
-			logger::warn("[Hooks] virtual slot {} exceeds the supported clone size {}; left unhooked (Detours error {})", a_idx, max_cloned_vtable_slots, a_detourError);
+		if (a_idx >= maxClonedVTableSlots) {
+			logger::warn("[Hooks] virtual slot {} exceeds the supported clone size {}; left unhooked (Detours error {})", a_idx, maxClonedVTableSlots, a_detourError);
 			return original;
 		}
 
-		// An earlier hook may already have repointed this object at a clone; cloning again
-		// would discard it. The slot value read above came from the clone, so returning it
-		// preserves chaining.
+		// If an earlier hook already pointed this object at a clone, patch that clone; a new
+		// clone would drop the earlier hook. `original` was read from the clone, so the hooks
+		// still chain.
 		if (auto it = clonedVTables.find(a_object); it != clonedVTables.end() && it->second.get() == vtable) {
 			it->second[a_idx] = reinterpret_cast<std::uintptr_t>(a_thunk);
 			logger::warn("[Hooks] Detours could not patch virtual slot {} (error {}); patched the object's existing vtable clone", a_idx, a_detourError);
@@ -61,11 +62,11 @@ namespace Util
 		}
 
 		MEMORY_BASIC_INFORMATION mbi{};
-		const bool queried = VirtualQuery(vtable, &mbi, sizeof(mbi)) == sizeof(mbi);
+		const bool querySucceeded = VirtualQuery(vtable, &mbi, sizeof(mbi)) == sizeof(mbi);
 
 		// Swap the slot in place, keeping execute rights if the page has them.
 		constexpr DWORD executeProtects = PAGE_EXECUTE | PAGE_EXECUTE_READ | PAGE_EXECUTE_READWRITE | PAGE_EXECUTE_WRITECOPY;
-		const DWORD writableProtect = (queried && (mbi.Protect & executeProtects) != 0) ? PAGE_EXECUTE_READWRITE : PAGE_READWRITE;
+		const DWORD writableProtect = (querySucceeded && (mbi.Protect & executeProtects) != 0) ? PAGE_EXECUTE_READWRITE : PAGE_READWRITE;
 		DWORD previousProtect = 0;
 		if (VirtualProtect(&vtable[a_idx], sizeof(std::uintptr_t), writableProtect, &previousProtect)) {
 			vtable[a_idx] = reinterpret_cast<std::uintptr_t>(a_thunk);
@@ -75,20 +76,20 @@ namespace Util
 			logger::warn("[Hooks] Detours could not patch virtual slot {} (error {}); swapped the vtable slot in place", a_idx, a_detourError);
 			return original;
 		}
-		const DWORD protectResult = GetLastError();
+		const DWORD protectError = GetLastError();
 
-		// Clone the vtable, patch the copy, repoint the object; needs no protection change.
-		// Copy the full capacity so every readable source slot keeps resolving through
-		// the clone.
-		auto clone = std::make_unique<std::uintptr_t[]>(max_cloned_vtable_slots);
-		if (CopyReadableSlots(clone.get(), vtable, max_cloned_vtable_slots) <= a_idx) {
-			logger::warn("[Hooks] virtual slot {} could not be hooked: Detours failed (error {}), the vtable page refused VirtualProtect (error {}), and the vtable was unreadable at that slot", a_idx, a_detourError, protectResult);
+		// Last option: clone the vtable, patch the clone, and point the object at it. This
+		// needs no protection change. Copy every readable slot, not only a_idx, so the other
+		// virtual functions keep working through the clone.
+		auto clone = std::make_unique<std::uintptr_t[]>(maxClonedVTableSlots);
+		if (CopyReadableSlots(clone.get(), vtable, maxClonedVTableSlots) <= a_idx) {
+			logger::warn("[Hooks] virtual slot {} could not be hooked: Detours failed (error {}), the vtable page refused VirtualProtect (error {}), and the vtable was unreadable at that slot", a_idx, a_detourError, protectError);
 			return original;
 		}
 		clone[a_idx] = reinterpret_cast<std::uintptr_t>(a_thunk);
 		*static_cast<std::uintptr_t**>(a_object) = clone.get();
 		clonedVTables[a_object] = std::move(clone);
-		logger::warn("[Hooks] Detours could not patch virtual slot {} (error {}) and the vtable page refused VirtualProtect (error {}); repointed the object at a patched vtable clone", a_idx, a_detourError, protectResult);
+		logger::warn("[Hooks] Detours could not patch virtual slot {} (error {}) and the vtable page refused VirtualProtect (error {}); repointed the object at a patched vtable clone", a_idx, a_detourError, protectError);
 		return original;
 	}
 }

--- a/src/Utils/VTableHookFallback.cpp
+++ b/src/Utils/VTableHookFallback.cpp
@@ -42,15 +42,17 @@ namespace Util
 	{
 		std::scoped_lock lock(clonedVTableMutex);
 
+		// Check the bound before reading the slot: the object may already point at a clone,
+		// which has exactly maxClonedVTableSlots entries.
+		if (a_idx >= maxClonedVTableSlots) {
+			logger::warn("[Hooks] virtual slot {} exceeds the supported clone size {}; left unhooked (Detours error {})", a_idx, maxClonedVTableSlots, a_detourError);
+			return 0;
+		}
+
 		// Read the vtable pointer under the lock: another thread may have just pointed this
 		// object at a clone, and the clone check below must see that.
 		auto vtable = *static_cast<std::uintptr_t**>(a_object);
 		const auto original = vtable[a_idx];
-
-		if (a_idx >= maxClonedVTableSlots) {
-			logger::warn("[Hooks] virtual slot {} exceeds the supported clone size {}; left unhooked (Detours error {})", a_idx, maxClonedVTableSlots, a_detourError);
-			return original;
-		}
 
 		// If an earlier hook already pointed this object at a clone, patch that clone; a new
 		// clone would drop the earlier hook. `original` was read from the clone, so the hooks
@@ -87,8 +89,11 @@ namespace Util
 			return original;
 		}
 		clone[a_idx] = reinterpret_cast<std::uintptr_t>(a_thunk);
-		*static_cast<std::uintptr_t**>(a_object) = clone.get();
-		clonedVTables[a_object] = std::move(clone);
+		// Store the clone before pointing the object at it, so a throwing insert cannot
+		// leave the object with a dangling vtable pointer.
+		auto& storedClone = clonedVTables[a_object];
+		storedClone = std::move(clone);
+		*static_cast<std::uintptr_t**>(a_object) = storedClone.get();
 		logger::warn("[Hooks] Detours could not patch virtual slot {} (error {}) and the vtable page refused VirtualProtect (error {}); repointed the object at a patched vtable clone", a_idx, a_detourError, protectError);
 		return original;
 	}

--- a/src/Utils/VTableHookFallback.h
+++ b/src/Utils/VTableHookFallback.h
@@ -3,16 +3,16 @@
 namespace Util
 {
 	/**
-	 * @brief Hooks virtual slot a_idx of COM object a_object with a_thunk after Detours
-	 * failed to patch the slot's implementation: swaps the vtable slot in place, or, when
-	 * the vtable page itself rejects VirtualProtect, repoints the object at a patched
-	 * clone of its vtable.
+	 * @brief Hook virtual slot a_idx of a_object with a_thunk when Detours could not patch
+	 * the function in that slot.
 	 *
-	 * Needed under Wine/CrossOver, where the D3D11 translation layer lives in host-mapped
-	 * memory whose pages reject every protection change, so only the clone can carry the
-	 * hook.
+	 * First writes a_thunk into the vtable slot in place. When the vtable page rejects
+	 * VirtualProtect, points the object at a patched clone of its vtable instead.
 	 *
-	 * @return The original function pointer the hook must call through.
+	 * Under Wine/CrossOver the D3D11 translation layer lives in host-mapped memory that
+	 * rejects every protection change, so only the clone can carry the hook.
+	 *
+	 * @return The original function pointer that the hook must call.
 	 */
 	std::uintptr_t VTableHookFallback(void* a_object, std::size_t a_idx, void* a_thunk, LONG a_detourError);
 }

--- a/src/Utils/VTableHookFallback.h
+++ b/src/Utils/VTableHookFallback.h
@@ -1,0 +1,18 @@
+#pragma once
+
+namespace Util
+{
+	/**
+	 * @brief Hooks virtual slot a_idx of COM object a_object with a_thunk after Detours
+	 * failed to patch the slot's implementation: swaps the vtable slot in place, or, when
+	 * the vtable page itself rejects VirtualProtect, repoints the object at a patched
+	 * clone of its vtable.
+	 *
+	 * Needed under Wine/CrossOver, where the D3D11 translation layer lives in host-mapped
+	 * memory whose pages reject every protection change, so only the clone can carry the
+	 * hook.
+	 *
+	 * @return The original function pointer the hook must call through.
+	 */
+	std::uintptr_t VTableHookFallback(void* a_object, std::size_t a_idx, void* a_thunk, LONG a_detourError);
+}

--- a/src/Utils/VTableHookFallback.h
+++ b/src/Utils/VTableHookFallback.h
@@ -12,7 +12,8 @@ namespace Util
 	 * Under Wine/CrossOver the D3D11 translation layer lives in host-mapped memory that
 	 * rejects every protection change, so only the clone can carry the hook.
 	 *
-	 * @return The original function pointer that the hook must call.
+	 * @return The original function pointer that the hook must call, or 0 when the slot
+	 * was left unhooked.
 	 */
 	std::uintptr_t VTableHookFallback(void* a_object, std::size_t a_idx, void* a_thunk, LONG a_detourError);
 }


### PR DESCRIPTION
Note: This PR is heavily Claude-assisted. I did my absolute best to do this carefully and review every step of the way. All verification was done manually by me and I've done multiple code-review passes. Feedback is appreciated.

## Summary

Fixes #1974 (interior point lights not illuminating on CrossOver/macOS, closed as not reproducible). The same root cause also breaks Screen-Space Shadows (banding), grass point lighting, height fog, the CPU light distance sort, and upscaler frame data on that platform, because they all consume the same dead per-frame snapshot.

`stl::detour_vfunc` discarded the Detours return codes. Under Wine (CrossOver), `DetourAttach` on `ID3D11DeviceContext::Map`/`Unmap` fails with error 87, so the hooks silently never installed. `frameBufferCached` then stays zeroed, LightLimitFix uploads light positions without the camera-relative adjust, and interiors render unlit.

## Root cause

On CrossOver, the D3D11 implementation (D3DMetal or DXMT) is a translation layer living in host-mapped memory that Wine does not track: `VirtualQuery` reports the vtable region as `MEM_FREE`, and every protection-changing call on those pages fails with error 87, code and vtable pages alike. Detours needs `VirtualProtect` on the target code, so it can never patch these functions; the same applies to CommonLibSSE's `REL::safe_write`/`write_vfunc`. Reproduced on both D3DMetal and DXMT. Notably, the `IDXGISwapChain::Present` hook works in the same session (dxgi is a genuine Wine PE module), which is why the CS menu renders normally and the failure went unnoticed.

## The fix

`stl::detour_vfunc` (PCH.h) still tries Detours first, now with its result actually checked; on Windows Detours succeeds and behavior is unchanged. On failure it calls `Util::VTableHookFallback` (`src/Utils/VTableHookFallback.cpp`), which escalates:

1. **In-place vtable slot swap**: rewrite the pointer inside the vtable. Covers environments where code cannot be patched but the vtable is ordinary memory.
2. **Vtable clone**: copy the vtable into plugin memory, patch the copy, repoint the object's vtable pointer. Needs no `VirtualProtect` at all; the COM ABI guarantees dispatch through the slot. A per-object registry makes every slot hooked on the same object share one clone, and the copy is fault-contained page by page.

Logging is silent on success; each fallen-back slot emits one `[Hooks]` warn naming the slot, the error, and the mechanism used.

## Verification

Apple Silicon MacBook Pro, macOS 26.5, CrossOver 26.2, D3DMetal, Skyrim SE 1.6.1170. Log after the fix:

```
[W] [Hooks] Detours could not patch virtual slot 35 (error 87) and the vtable page refused VirtualProtect (error 87); repointed the object at a patched vtable clone
[W] [Hooks] Detours could not patch virtual slot 23 (error 87) and the vtable page refused VirtualProtect (error 87); repointed the object at a patched vtable clone
[W] [Hooks] Detours could not patch virtual slot 14 (error 87); patched the object's existing vtable clone
[W] [Hooks] Detours could not patch virtual slot 15 (error 87); patched the object's existing vtable clone
```

(Slot 35 = `OMSetBlendState`, 23 = `CreateSamplerState`, 14/15 = `Map`/`Unmap` reusing the context clone; `Present` needs no fallback.)

Test matrix, all passing: interior point lights, Screen-Space Shadows without banding, first vs third person, Candlelight, exterior night torches, grass near flames. The `OMSetBlendState` and `CreateSamplerState` hooks were also silently broken on this platform and now install; no visual regressions observed.

## Screenshots

Cave interior bug:
<img width="1920" height="1200" alt="CleanShot 2026-08-11 at 11 38 15" src="https://github.com/user-attachments/assets/fe60b39f-dd8f-4418-95a4-ebf7c3940db8" />

Cave interior fixed:
<img width="1920" height="1200" alt="CleanShot 2026-08-11 at 11 38 23" src="https://github.com/user-attachments/assets/1a4e4771-6a14-4357-9993-0ea66560df84" />

Screen space shadows bug:
<img width="1920" height="1200" alt="CleanShot 2026-08-11 at 11 40 35" src="https://github.com/user-attachments/assets/1db0882c-f3f7-40e0-affd-7849c666f59c" />

Screen space shadows fixed:
<img width="1920" height="1200" alt="CleanShot 2026-08-11 at 11 40 46" src="https://github.com/user-attachments/assets/c952e357-ccb2-43d3-aebc-420d517f2a97" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a fallback mechanism for virtual-function hooks when standard hooking fails.
  * Supports protected virtual tables and patched table copies when necessary.
  * Preserves original function pointers and supports repeated hooks on the same object, including Wine and CrossOver environments.

* **Bug Fixes**
  * Improved hook failure handling by safely aborting unsuccessful operations and preserving error details.
  * Reports unsupported hooks, unreadable tables, and memory-protection restoration failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
