### PR TITLE
fix(effects11): loading raindrop texture twice

### DIFF
--- a/src/Features/Effects11.cpp
+++ b/src/Features/Effects11.cpp
@@ -184,8 +184,8 @@ void Effects11::LoadRaindropTexture()
 
 void Effects11::SetupResources()
 {
+	// Initialize() -> Apply() already loads the raindrop texture; do not load it again here.
 	EffectManager::GetSingleton().Initialize();
-	LoadRaindropTexture();
 }
 
 void Effects11::ClearShaderCache()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented redundant raindrop texture loading during effect resource setup.
  * Maintained existing raindrop effects while improving initialization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->