### PR TITLE
fix(hdr): prevent startup frame trails

### DIFF
--- a/src/Features/Upscaling/DX12SwapChain.cpp
+++ b/src/Features/Upscaling/DX12SwapChain.cpp
@@ -134,6 +134,10 @@ void DX12SwapChain::RecreateWrappedResources(const DXGI_SWAP_CHAIN_DESC1& desc)
 	delete uiBufferWrapped;
 	swapChainBufferWrapped = newSwapChainBuffer.release();
 	uiBufferWrapped = newUiBuffer.release();
+
+	const float clearColor[4]{};
+	d3d11Context->ClearRenderTargetView(swapChainBufferWrapped->rtv, clearColor);
+	d3d11Context->ClearRenderTargetView(uiBufferWrapped->rtv, clearColor);
 }
 
 DXGISwapChainProxy* DX12SwapChain::GetSwapChainProxy()
@@ -273,6 +277,7 @@ HRESULT DX12SwapChain::Present(UINT SyncInterval, UINT Flags)
 	frameIndex = swapChain->GetCurrentBackBufferIndex();
 
 	float clearColor[4]{ 0, 0, 0, 0 };
+	d3d11Context->ClearRenderTargetView(swapChainBufferWrapped->rtv, clearColor);
 	d3d11Context->ClearRenderTargetView(uiBufferWrapped->rtv, clearColor);
 
 	// If VSync is disabled, use frame limiter to prevent tearing and optimise pacing

--- a/src/Menu/BackgroundBlur.cpp
+++ b/src/Menu/BackgroundBlur.cpp
@@ -131,11 +131,6 @@ namespace BackgroundBlur
 			return {};
 		}
 
-		bool IsUpscalingBlurSourceActive(const Upscaling& upscaling)
-		{
-			return upscaling.d3d12SwapChainActive || (upscaling.loaded && upscaling.IsUpscalingActive());
-		}
-
 		bool IsMainOrLoadingMenuOpen()
 		{
 			auto* state = globals::state;
@@ -147,10 +142,9 @@ namespace BackgroundBlur
 			return !shaderCache || (shaderCache->menuLoaded && !shaderCache->IsCompiling());
 		}
 
-		bool ShouldSkipStartupMenuBlur(const Upscaling& upscaling)
+		bool ShouldSkipStartupMenuBlur()
 		{
-			return !IsUpscalingBlurSourceActive(upscaling) &&
-			       IsMainOrLoadingMenuOpen() &&
+			return IsMainOrLoadingMenuOpen() &&
 			       !IsStartupMenuBlurSourceReady(globals::shaderCache);
 		}
 
@@ -584,7 +578,7 @@ namespace BackgroundBlur
 		                 hdr->hdrTexture && hdr->hdrTexture->resource && hdr->hdrTexture->srv && hdr->hdrTexture->rtv;
 
 		// Startup main/loading back buffer can be black until DataLoaded and initial shader work finish.
-		if (ShouldSkipStartupMenuBlur(upscaling))
+		if (ShouldSkipStartupMenuBlur())
 			return;
 
 		winrt::com_ptr<ID3D11Texture2D> currentTexture;


### PR DESCRIPTION
## Summary
- Port of [Open Shaders #428](https://github.com/alandtse/open-shaders/pull/428): clear the persistent D3D12 proxy backbuffer after Present and on recreate so prior UI frames do not feed back when HDR Display is loaded.
- Also relaxes startup menu blur skip so it no longer requires upscaling/D3D12 to be inactive.

## Test plan
- [ ] Launch with HDR Display enabled + D3D12 swap chain path; confirm no leftover UI trails on main/loading menus
- [ ] Resize window / change resolution and confirm buffers still clear cleanly
- [ ] Verify menu background blur still behaves correctly during startup and after shaders finish loading