### PR TITLE
fix(pbr): guard against mislinked texturesets

### DIFF
--- a/src/TruePBR/BSLightingShaderMaterialPBR.cpp
+++ b/src/TruePBR/BSLightingShaderMaterialPBR.cpp
@@ -2,6 +2,14 @@
 
 #include "TruePBR.h"
 
+/** @brief Drops textureSet unless it really is one; malformed meshes can link any block, and calling BSTextureSet virtuals on it is a CTD. */
+static void DiscardMislinkedTextureSet(RE::NiPointer<RE::BSTextureSet>& textureSet)
+{
+	if (textureSet != nullptr && netimmerse_cast<RE::BSShaderTextureSet*>(textureSet.get()) == nullptr) {
+		textureSet.reset();
+	}
+}
+
 BSLightingShaderMaterialPBR::~BSLightingShaderMaterialPBR()
 {
 	All.erase(this);
@@ -101,6 +109,7 @@ std::uint32_t BSLightingShaderMaterialPBR::ComputeCRC32(uint32_t srcHash)
 	hashes.projectedMaterialLogMicrofacetDensity = projectedMaterialGlintParameters.logMicrofacetDensity * 100.f;
 	hashes.projectedMaterialMicrofacetRoughness = projectedMaterialGlintParameters.microfacetRoughness * 100.f;
 	hashes.projectedMaterialDensityRandomization = projectedMaterialGlintParameters.densityRandomization * 100.f;
+	DiscardMislinkedTextureSet(textureSet);
 	if (textureSet != nullptr) {
 		hashes.rmaodHash = RE::BSCRC32<const char*>()(textureSet->GetTexturePath(RmaosTexture));
 		hashes.emissiveHash = RE::BSCRC32<const char*>()(textureSet->GetTexturePath(EmissiveTexture));
@@ -178,6 +187,7 @@ void BSLightingShaderMaterialPBR::OnLoadTextureSet(std::uint64_t arg1, RE::BSTex
 		if (inTextureSet != nullptr) {
 			textureSet = RE::NiPointer(inTextureSet);
 		}
+		DiscardMislinkedTextureSet(textureSet);
 		if (textureSet != nullptr) {
 			textureSet->SetTexture(RmaosTexture, rmaosTexture);
 			textureSet->SetTexture(EmissiveTexture, emissiveTexture);


### PR DESCRIPTION
bad Dyndolod output was crashing my game.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for texture references during loading.
  * Invalid texture references are now safely reset, preventing texture-related errors and improving rendering stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->