### PR TITLE
fix(sss): albedo turning dark with LL

### DIFF
--- a/features/Subsurface Scattering/Shaders/Features/SubsurfaceScattering.ini
+++ b/features/Subsurface Scattering/Shaders/Features/SubsurfaceScattering.ini
@@ -1,2 +1,2 @@
 [Info]
-Version = 3-2-0
+Version = 3-2-1

--- a/features/Subsurface Scattering/Shaders/SubsurfaceScattering/Burley.hlsli
+++ b/features/Subsurface Scattering/Shaders/SubsurfaceScattering/Burley.hlsli
@@ -48,24 +48,25 @@ float3 GetScalingFactor(float3 albedo)
 	return 3.5f + 100.f * pow(abs(value), 4);
 }
 
-float4 BurleyNormalizedSS(uint2 DTid, float2 texCoord, float sssAmount, bool humanProfile)
+float4 BurleyNormalizedSS(uint2 DTid, float2 texCoord, float sssAmount, bool humanProfile, float4 originalSceneColor)
 {
 	float centerDepth = SharedData::GetScreenDepth(DepthTexture[DTid].x);
 
 	float4 centerColor = ColorTexture[DTid];
 	if (sssAmount == 0 || centerDepth <= 0) {
-		return centerColor;
+		return originalSceneColor;
 	}
 
-	float4 surfaceAlbedo = AlbedoTexture[DTid];
-	float3 originalColor = centerColor.xyz;
+	float4 surfaceAlbedoSample = AlbedoTexture[DTid];
+	float3 surfaceAlbedo = SSSDecodeAlbedo(surfaceAlbedoSample.xyz);
+	float3 originalIrradiance = centerColor.xyz;
 
 	float4 diffuseMeanFreePath = humanProfile ? MeanFreePathHuman : MeanFreePathBase;
 	diffuseMeanFreePath.xyz = float3(max(diffuseMeanFreePath.x, 1e-5f), max(diffuseMeanFreePath.y, 1e-5f), max(diffuseMeanFreePath.z, 1e-5f));
 	diffuseMeanFreePath *= sssAmount;
 
 	float dmfpForSampling = diffuseMeanFreePath.w;
-	float s = GetScalingFactor(surfaceAlbedo.www).x;
+	float s = GetScalingFactor(surfaceAlbedoSample.www).x;
 	float d = dmfpForSampling / s;
 	float3 s3d = GetScalingFactor(surfaceAlbedo.xyz);
 	float3 d3d = diffuseMeanFreePath.xyz * dmfpForSampling / s3d;
@@ -129,13 +130,11 @@ float4 BurleyNormalizedSS(uint2 DTid, float2 texCoord, float sssAmount, bool hum
 	}
 
 	colorSum *= any(weightSum == 0.0f) ? 0.0f : (1.0f / weightSum);
-	colorSum = lerp(colorSum, originalColor, saturate(centerWeight));
+	colorSum = lerp(colorSum, originalIrradiance, saturate(centerWeight));
 
-	float3 albedo = AlbedoTexture[DTid.xy].xyz;
-	float3 color = SSSApplyAlbedo(Color::IrradianceToGamma(colorSum), albedo, SSS_SCATTER_MODE_POST);
-	float3 centerColorRestored = SSSApplyAlbedo(Color::IrradianceToGamma(originalColor), albedo, SSS_SCATTER_MODE_POST);
-	color = lerp(centerColorRestored, color, saturate(sssAmount > 0.0));
+	float3 color = SSSApplyAlbedo(colorSum, Color::IrradianceToLinear(originalSceneColor.rgb), surfaceAlbedo, SSS_SCATTER_MODE_POST);
+	color = Color::IrradianceToGamma(color);
 
-	float4 outColor = float4(color, ColorTexture[DTid.xy].w);
+	float4 outColor = float4(color, originalSceneColor.w);
 	return outColor;
 }

--- a/features/Subsurface Scattering/Shaders/SubsurfaceScattering/DiffuseExtractionCS.hlsl
+++ b/features/Subsurface Scattering/Shaders/SubsurfaceScattering/DiffuseExtractionCS.hlsl
@@ -12,7 +12,8 @@ Texture2D<float4> AlbedoTexture : register(t3);
 		return;
 
 	float4 color = ColorTexture[DTid.xy];
-	color.rgb = SSSRemoveAlbedo(color.rgb, AlbedoTexture[DTid.xy].rgb, ScatterMode);
-	color.rgb = Color::IrradianceToLinear(color.rgb);
+	float3 linearColor = Color::IrradianceToLinear(color.rgb);
+	float3 albedo = SSSDecodeAlbedo(AlbedoTexture[DTid.xy].rgb);
+	color.rgb = SSSRemoveAlbedo(linearColor, albedo, ScatterMode);
 	OutputRW[DTid.xy] = color;
 }

--- a/features/Subsurface Scattering/Shaders/SubsurfaceScattering/SSSCommon.hlsli
+++ b/features/Subsurface Scattering/Shaders/SubsurfaceScattering/SSSCommon.hlsli
@@ -22,22 +22,51 @@ cbuffer PerFrameSSS : register(b1)
 	float4 MeanFreePathHuman;
 };
 
-float3 SSSRemoveAlbedo(float3 color, float3 albedo, uint mode)
+float3 SSSDecodeAlbedo(float3 encodedAlbedo)
 {
-	if (mode == SSS_SCATTER_MODE_PRE)
-		return color;
-	albedo /= Color::PBRLightingScale;
-	float3 divisor = (mode == SSS_SCATTER_MODE_PRE_POST) ? sqrt(albedo) : albedo;
-	return lerp(color, color / max(divisor, EPSILON_SSS_ALBEDO), albedo > EPSILON_SSS_ALBEDO);
+	float3 albedo = encodedAlbedo / Color::PBRLightingScale;
+	return max(Color::IrradianceToLinear(albedo), 0.0f);
 }
 
-float3 SSSApplyAlbedo(float3 irradiance, float3 albedo, uint mode)
+float3 SSSGetAlbedoFactor(float3 albedo, uint mode)
+{
+	if (mode == SSS_SCATTER_MODE_PRE)
+		return 1.0f;
+	return (mode == SSS_SCATTER_MODE_PRE_POST) ? sqrt(max(albedo, 0.0f)) : max(albedo, 0.0f);
+}
+
+float3 SSSGetAlbedoParticipation(float3 albedo)
+{
+	// Keep the existing low-albedo protection, but transition all channels
+	// continuously instead of changing semantics at one quantized UNORM code.
+	// The threshold is converted to the same linear domain as albedo so non-linear
+	// lighting retains its previous effective cutoff.
+	float threshold = Color::IrradianceToLinear(EPSILON_SSS_ALBEDO);
+	return smoothstep(threshold, threshold * 4.0f, albedo);
+}
+
+float3 SSSRemoveAlbedo(float3 linearColor, float3 albedo, uint mode)
+{
+	if (mode == SSS_SCATTER_MODE_PRE)
+		return linearColor;
+
+	float3 factor = SSSGetAlbedoFactor(albedo, mode);
+	float3 participation = SSSGetAlbedoParticipation(albedo);
+	return linearColor * participation / max(factor, EPSILON_DIVISION);
+}
+
+float3 SSSApplyAlbedo(float3 irradiance, float3 originalLinearColor, float3 albedo, uint mode)
 {
 	if (mode == SSS_SCATTER_MODE_PRE)
 		return irradiance;
-	albedo /= Color::PBRLightingScale;
-	float3 multiplier = (mode == SSS_SCATTER_MODE_PRE_POST) ? sqrt(albedo) : albedo;
-	return lerp(irradiance, irradiance * multiplier, albedo > EPSILON_SSS_ALBEDO);
+
+	float3 factor = SSSGetAlbedoFactor(albedo, mode);
+	float3 participation = SSSGetAlbedoParticipation(albedo);
+
+	// Participation gates both emission into and reception from the blur. Squaring
+	// it here makes the operation an exact identity without blur, while zero-albedo
+	// channels retain the original color and cannot acquire unpremultiplied energy.
+	return irradiance * factor * participation + originalLinearColor * (1.0f - participation * participation);
 }
 
 #endif

--- a/features/Subsurface Scattering/Shaders/SubsurfaceScattering/SeparableSSSCS.hlsl
+++ b/features/Subsurface Scattering/Shaders/SubsurfaceScattering/SeparableSSSCS.hlsl
@@ -33,7 +33,7 @@ SamplerState PointSampler : register(s0);
 	if (sssAmount > 0.0) {
 		bool humanProfile = MaskTexture[DTid.xy].y > 0.0;
 
-		float4 color = BurleyNormalizedSS(DTid.xy, texCoord, sssAmount, humanProfile);
+		float4 color = BurleyNormalizedSS(DTid.xy, texCoord, sssAmount, humanProfile, SSSRW[DTid.xy]);
 		SSSRW[DTid.xy] = max(0, color);
 	}
 
@@ -52,10 +52,12 @@ SamplerState PointSampler : register(s0);
 	if (sssAmount > 0.0) {
 		bool humanProfile = MaskTexture[DTid.xy].y > 0.0;
 
+		float4 originalColor = SSSRW[DTid.xy];
 		float4 color = SSSSBlurCS(texCoord, float2(0.0, 1.0), sssAmount, humanProfile);
+		float3 albedo = SSSDecodeAlbedo(AlbedoTexture[DTid.xy].rgb);
+		color.rgb = SSSApplyAlbedo(color.rgb, Color::IrradianceToLinear(originalColor.rgb), albedo, ScatterMode);
 		color.rgb = Color::IrradianceToGamma(color.rgb);
-		color.rgb = SSSApplyAlbedo(color.rgb, AlbedoTexture[DTid.xy].rgb, ScatterMode);
-		SSSRW[DTid.xy] = float4(color.rgb, 1.0);
+		SSSRW[DTid.xy] = float4(color.rgb, originalColor.a);
 	}
 
 #endif


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved subsurface scattering color accuracy by processing albedo and irradiance in linear color space.
  - Preserved the original scene color and transparency when scattering is disabled, invalid, or minimally applied.
  - Smoothed albedo participation for more natural transitions and reduced color artifacts.
  - Updated the subsurface scattering feature configuration version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->