### PR TITLE
feat(effects11): patch Truth ENB & Elder ENB settings

### DIFF
--- a/features/Effects11/Shaders/Effects11/SettingsPatches.json
+++ b/features/Effects11/Shaders/Effects11/SettingsPatches.json
@@ -114,7 +114,10 @@
 			{ "variable": "|- AA - Enable CREAA", "value": "false" },
 			{ "variable": "---------- FXAA: Use FXAA ----------", "value": "false" },
 			{ "variable": "ANTIALIASING.SMAA.Enable SMAA", "value": "false" },
-			{ "variable": "ANTIALIASING.CREAA.Enable CREAA", "value": "false" }
+			{ "variable": "ANTIALIASING.CREAA.Enable CREAA", "value": "false" },
+
+			{ "variable": "[Truth 70] Postpass | Vignette Strength", "value": "0.0" },
+			{ "variable": "[Truth 70] Postpass | Grain Shape", "value": "0.0" }
 		]
 	},
 	{
@@ -136,7 +139,9 @@
 
 			{ "variable": "Grain", "value": "false" },
 			{ "variable": "Lens Distortion", "value": "false" },
-			{ "variable": "Vignette", "value": "false" }
+			{ "variable": "Vignette", "value": "false" },
+
+			{ "variable": "GRADE | Clarity Enable", "value": "false" }
 		]
 	}
 ]


### PR DESCRIPTION
Adds three variable names to `SettingsPatches.json` for two ENB presets Effects 11 does not currently recognise. Data only, no code paths touched.

### What these are

**Truth ENB** draws a vignette and film grain in its postpass stage, both on by default:

- `[Truth 70] Postpass | Vignette Strength`
- `[Truth 70] Postpass | Grain Shape`

They are declared in the preset's postpass parameter slot, which is why they belong under the `enbeffectpostpass.fx` object rather than `enbeffect.fx`.

I zeroed them instead of disabling the stage on purpose. The same stage applies triangular dither at the end, nothing else in the chain supplies it, and switching the stage off entirely bands a graded sky. Zeroing the two values leaves the dither running.

**Elder ENB** exposes `GRADE | Clarity Enable`, a nine-tap wide-radius unsharp mask with midtone bias. It reaches the output through `enbeffect.fx`, so it sits under that object. It ships disabled, so this entry is preventative rather than a fix for current behaviour. It seemed worth the one line since a user who enables it under Effects 11 gets local-contrast sharpening on top of whatever the framework is already doing, with nothing to warn them.

### Why it matters

The existing entries cover sharpening, blur, AA, vignette, and letterboxing by exact variable-name string. These three names are not in that set, so the stages behind them survive the automatic patch and stack on Community Shaders upscaling and TAA. That is the failure the patch table exists to prevent; these presets just happen to use their own naming.

### Verification

The file parses, and each entry lands under the shader file that actually declares it, checked programmatically rather than by eye. Entry count goes from 115 to 118. No performance numbers because this changes no code path; it sets three preset values that are already read by the existing settings patcher.

I am the author of both presets, so I can answer questions about what any of these values do.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Added optional settings for controlling post-processing vignette strength, grain shape, and clarity.
  * Existing CREAA disable setting remains available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->