### PR TITLE
fix(pbr): broken pbr decal

### DIFF
--- a/src/TruePBR/BSLightingShaderMaterialPBR.cpp
+++ b/src/TruePBR/BSLightingShaderMaterialPBR.cpp
@@ -2,10 +2,16 @@
 
 #include "TruePBR.h"
 
-/** @brief Drops textureSet unless it really is one; malformed meshes can link any block, and calling BSTextureSet virtuals on it is a CTD. */
+/** @brief Drops textureSet unless its NiRTTI derives from BSTextureSet; malformed meshes can link any block, and calling BSTextureSet virtuals on it is a CTD. */
 static void DiscardMislinkedTextureSet(RE::NiPointer<RE::BSTextureSet>& textureSet)
 {
-	if (textureSet != nullptr && netimmerse_cast<RE::BSShaderTextureSet*>(textureSet.get()) == nullptr) {
+	if (textureSet == nullptr) {
+		return;
+	}
+
+	static const auto* textureSetRTTI = REL::Relocation<const RE::NiRTTI*>{ RE::BSTextureSet::Ni_RTTI }.get();
+	const RE::NiRTTI* rtti = textureSet->GetRTTI();
+	if (rtti == nullptr || !rtti->IsKindOf(textureSetRTTI)) {
 		textureSet.reset();
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of texture sets used by physically based rendering.
  * Invalid texture set references are now safely detected and reset, reducing the risk of rendering issues or crashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->