### PR TITLE
fix(menu): menu input lag and scroll granularity

### DIFF
--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -479,6 +479,10 @@ struct BSInputDeviceManager_PollInputDevices
 		auto menu = globals::menu;
 
 		if (a_events) {
+			if (auto* inputManager = RE::BSInputDeviceManager::GetSingleton()) {
+				if (const auto* mouse = inputManager->GetMouse())
+					menu->RecordDirectInputWheelDelta(mouse->GetRuntimeData().dInputNextState.z);
+			}
 			menu->ProcessInputEvents(a_events);
 
 			if (*a_events) {

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -1040,7 +1040,6 @@ void Menu::ProcessInputEventQueue()
 {
 	std::unique_lock<std::shared_mutex> mutex(_inputEventMutex);
 	ImGuiIO& io = ImGui::GetIO();
-	float skyrimWheelY = 0.0f;
 	for (auto& event : _keyEventQueue) {
 		if (event.eventType == RE::INPUT_EVENT_TYPE::kChar) {
 			io.AddInputCharacter(event.keyCode);
@@ -1053,11 +1052,6 @@ void Menu::ProcessInputEventQueue()
 			if (event.keyCode > 7) {  // middle scroll
 				if (ew && ew->previewMode == EditorWindow::PreviewMode::FreeCamera) {
 					ew->AdjustFlySpeed(event.keyCode == 8 ? 1.0f : -1.0f);
-				} else if (!flying) {
-					// Skyrim models the wheel as a pseudo-button. Count only its initial transition;
-					// forwarding held repeats makes a trackpad gesture scroll once per game poll.
-					if (event.IsDown())
-						skyrimWheelY += event.keyCode == 8 ? 1.0f : -1.0f;
 				}
 			} else if (!flying) {
 				if (event.keyCode > 5)
@@ -1276,8 +1270,7 @@ void Menu::ProcessInputEventQueue()
 	}
 
 	const auto directInputWheelRaw = _directInputWheelDelta.exchange(0, std::memory_order_relaxed);
-	const float wheelY = directInputWheelRaw != 0 ?
-		static_cast<float>(directInputWheelRaw) / static_cast<float>(WHEEL_DELTA) : skyrimWheelY;
+	const float wheelY = static_cast<float>(directInputWheelRaw) / static_cast<float>(WHEEL_DELTA);
 	if (wheelY != 0.0f)
 		io.AddMouseWheelEvent(0.0f, wheelY);
 

--- a/src/Menu.cpp
+++ b/src/Menu.cpp
@@ -680,6 +680,11 @@ void Menu::Init()
 
 	auto& imgui_io = ImGui::GetIO();
 	imgui_io.ConfigFlags = ImGuiConfigFlags_NavEnableKeyboard | ImGuiConfigFlags_NavEnableGamepad | ImGuiConfigFlags_DockingEnable;
+	// Skyrim delivers input as a frame-sized batch. ImGui's default trickle mode may consume only
+	// part of such a batch to spread rapid transitions over subsequent frames. High-rate wheel input
+	// can therefore grow InputEventsQueue without bound and replay stale cursor/input state seconds
+	// later. Consume the complete batch in the next NewFrame instead.
+	imgui_io.ConfigInputTrickleEventQueue = false;
 	imgui_io.ConfigDockingWithShift = settings.RequireShiftToDock;
 	imgui_io.BackendFlags = ImGuiBackendFlags_HasMouseCursors | ImGuiBackendFlags_RendererHasVtxOffset | ImGuiBackendFlags_HasGamepad;
 
@@ -1035,6 +1040,7 @@ void Menu::ProcessInputEventQueue()
 {
 	std::unique_lock<std::shared_mutex> mutex(_inputEventMutex);
 	ImGuiIO& io = ImGui::GetIO();
+	float skyrimWheelY = 0.0f;
 	for (auto& event : _keyEventQueue) {
 		if (event.eventType == RE::INPUT_EVENT_TYPE::kChar) {
 			io.AddInputCharacter(event.keyCode);
@@ -1048,7 +1054,10 @@ void Menu::ProcessInputEventQueue()
 				if (ew && ew->previewMode == EditorWindow::PreviewMode::FreeCamera) {
 					ew->AdjustFlySpeed(event.keyCode == 8 ? 1.0f : -1.0f);
 				} else if (!flying) {
-					io.AddMouseWheelEvent(0, event.value * (event.keyCode == 8 ? 1 : -1));
+					// Skyrim models the wheel as a pseudo-button. Count only its initial transition;
+					// forwarding held repeats makes a trackpad gesture scroll once per game poll.
+					if (event.IsDown())
+						skyrimWheelY += event.keyCode == 8 ? 1.0f : -1.0f;
 				}
 			} else if (!flying) {
 				if (event.keyCode > 5)
@@ -1266,7 +1275,19 @@ void Menu::ProcessInputEventQueue()
 		}
 	}
 
+	const auto directInputWheelRaw = _directInputWheelDelta.exchange(0, std::memory_order_relaxed);
+	const float wheelY = directInputWheelRaw != 0 ?
+		static_cast<float>(directInputWheelRaw) / static_cast<float>(WHEEL_DELTA) : skyrimWheelY;
+	if (wheelY != 0.0f)
+		io.AddMouseWheelEvent(0.0f, wheelY);
+
 	_keyEventQueue.clear();
+}
+
+void Menu::RecordDirectInputWheelDelta(std::int32_t delta)
+{
+	if (delta != 0)
+		_directInputWheelDelta.fetch_add(delta, std::memory_order_relaxed);
 }
 
 bool Menu::IsCapturingHotkeyInput() const

--- a/src/Menu.h
+++ b/src/Menu.h
@@ -153,6 +153,8 @@ public:
 
 	/** @brief Translates raw Skyrim input events into the internal key event queue */
 	void ProcessInputEvents(RE::InputEvent* const* a_events);
+	/** Records the raw DirectInput mouse-wheel delta before Skyrim reduces it to pseudo-buttons. */
+	void RecordDirectInputWheelDelta(std::int32_t delta);
 	/** @brief Returns true if the menu should consume all input (menu open or capturing hotkey) */
 	bool ShouldSwallowInput();
 	/** @brief Returns true if the free camera preview is in flying mode */
@@ -559,6 +561,7 @@ private:
 	// Input event handling
 	std::vector<KeyEvent> _keyEventQueue;
 	mutable std::shared_mutex _inputEventMutex;
+	std::atomic<int64_t> _directInputWheelDelta = 0;
 
 	// Keys whose key-down already fired a combo hotkey. Their matching key-up is
 	// suppressed so a shared single-key binding (e.g. End) doesn't also fire once


### PR DESCRIPTION
This PR fixes two usability issues with the CS menu:
1. Inputs from high-polling-rate devices would pile up behind ImGUI's rate-limited input handling. Turned off trickle mode to fix this.
2. Skyrim quantizes scroll inputs heavily, leading to nearly unusable scrolling in ImGUI menus. Changed ImGUI's scroll input from Skyrim-scroll to raw DirectInput scroll to recover fractional values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mouse-wheel input handling for more reliable scrolling.
  * Prevented wheel events from being lost or processed inconsistently during rapid input.
  * Ensured accumulated wheel movement is applied once per input cycle for smoother behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->