### PR TITLE
fix(upscaling): prevent frame generation crash on proton

### DIFF
--- a/src/Features/Upscaling/DX12SwapChain.cpp
+++ b/src/Features/Upscaling/DX12SwapChain.cpp
@@ -234,6 +234,8 @@ HRESULT DX12SwapChain::Present(UINT SyncInterval, UINT Flags)
 	DX::ThrowIfFailed(commandQueue->Wait(d3d12Fence.get(), fenceValue));
 
 	// New frame, reset
+	if (frameFenceValues[frameIndex])
+		DX::ThrowIfFailed(d3d12Fence->SetEventOnCompletion(frameFenceValues[frameIndex], nullptr));
 	DX::ThrowIfFailed(commandAllocators[frameIndex]->Reset());
 	DX::ThrowIfFailed(commandLists[frameIndex]->Reset(commandAllocators[frameIndex].get(), nullptr));
 
@@ -271,6 +273,7 @@ HRESULT DX12SwapChain::Present(UINT SyncInterval, UINT Flags)
 	// Wait for D3D12 to finish
 	fenceValue++;
 	DX::ThrowIfFailed(commandQueue->Signal(d3d12Fence.get(), fenceValue));
+	frameFenceValues[frameIndex] = fenceValue;
 	DX::ThrowIfFailed(d3d11Context->Wait(d3d11Fence.get(), fenceValue));
 
 	// Update the frame index

--- a/src/Features/Upscaling/DX12SwapChain.cpp
+++ b/src/Features/Upscaling/DX12SwapChain.cpp
@@ -229,9 +229,9 @@ HRESULT DX12SwapChain::Present(UINT SyncInterval, UINT Flags)
 	bool isHDR = hdr && hdr->settings.enableHDR;
 
 	// Wait for D3D11 to finish (includes ApplyHDR scene encoding AND UIBrightnessCS)
+	fenceValue++;
 	DX::ThrowIfFailed(d3d11Context->Signal(d3d11Fence.get(), fenceValue));
 	DX::ThrowIfFailed(commandQueue->Wait(d3d12Fence.get(), fenceValue));
-	fenceValue++;
 
 	// New frame, reset
 	DX::ThrowIfFailed(commandAllocators[frameIndex]->Reset());
@@ -269,9 +269,9 @@ HRESULT DX12SwapChain::Present(UINT SyncInterval, UINT Flags)
 	DX::ThrowIfFailed(swapChain->Present(SyncInterval, Flags));
 
 	// Wait for D3D12 to finish
+	fenceValue++;
 	DX::ThrowIfFailed(commandQueue->Signal(d3d12Fence.get(), fenceValue));
 	DX::ThrowIfFailed(d3d11Context->Wait(d3d11Fence.get(), fenceValue));
-	fenceValue++;
 
 	// Update the frame index
 	frameIndex = swapChain->GetCurrentBackBufferIndex();

--- a/src/Features/Upscaling/DX12SwapChain.h
+++ b/src/Features/Upscaling/DX12SwapChain.h
@@ -88,6 +88,8 @@ public:
 	UINT frameIndex = 0;
 	UINT64 fenceValue = 0;
 
+	UINT64 frameFenceValues[2] = {0, 0};
+
 	LARGE_INTEGER qpf;
 
 	double refreshRate = 0;


### PR DESCRIPTION
The shared D3D11/D3D12 fence and fenceValue both start at 0, causing the first handoff to issue Signal(0). DXVK maps the shared fence to a Vulkan timeline semaphore, where signaling the current value is invalid and results in device loss.

This also fixes the first handoff on Windows, as Wait(0) is already satisfied and therefore does not synchronize with D3D11.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved frame synchronization during presentation on DirectX 11 and DirectX 12.
  * Helps prevent incorrect fence sequencing and potential rendering synchronization issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->