### PR TITLE
ci: skip merging hotfix branches into main

### DIFF
--- a/.github/workflows/release-semantic.yaml
+++ b/.github/workflows/release-semantic.yaml
@@ -143,10 +143,12 @@ jobs:
               # breaks a hotfix line older than main's current version. Local
               # to this checkout only — never pushed.
               if: ${{ startsWith(github.ref_name, 'hotfix/') }}
+              env:
+                  REF_NAME: ${{ github.ref_name }}
               run: |
                   set -euo pipefail
                   git fetch origin --tags --force
-                  mapfile -t KEEP < <(git tag --merged "${{ github.ref_name }}")
+                  mapfile -t KEEP < <(git tag --merged "${REF_NAME}")
                   declare -A KEEP_SET
                   for t in "${KEEP[@]}"; do KEEP_SET["$t"]=1; done
                   while read -r t; do
@@ -210,11 +212,11 @@ jobs:
               run: |
                   set -euo pipefail
                   git fetch origin --tags --force '+refs/heads/hotfix/*:refs/remotes/origin/hotfix/*'
-                  HOTFIX_REFS=$(git for-each-ref --format='%(refname)' 'refs/remotes/origin/hotfix/*')
+                  mapfile -t HOTFIX_REFS < <(git for-each-ref --format='%(refname)' 'refs/remotes/origin/hotfix/*')
                   KEYS="$(mktemp)"
                   : > "${KEYS}"
-                  if [[ -n "${HOTFIX_REFS}" ]]; then
-                    mapfile -t SHIPPED_SHAS < <(git log ${HOTFIX_REFS} --format=%B \
+                  if (( ${#HOTFIX_REFS[@]} > 0 )); then
+                    mapfile -t SHIPPED_SHAS < <(git log "${HOTFIX_REFS[@]}" --format=%B \
                       | grep -oE 'cherry picked from commit [0-9a-f]{40}' \
                       | awk '{print $NF}' | sort -u)
                     if (( ${#SHIPPED_SHAS[@]} > 0 )); then

--- a/.github/workflows/release-semantic.yaml
+++ b/.github/workflows/release-semantic.yaml
@@ -97,7 +97,9 @@ jobs:
                     echo "::error::ff_target is only valid when this workflow is dispatched on 'main' (got '${{ github.ref_name }}')."
                     exit 1
                   fi
-                  git fetch origin main dev
+                  # --tags: the collision guard below needs the hotfix lines'
+                  # tags, which are unreachable from main and dev.
+                  git fetch --tags origin main dev
                   if ! git rev-parse --verify "${FF_TARGET}^{commit}" >/dev/null 2>&1; then
                     echo "::error::ff_target SHA ${FF_TARGET} does not exist."
                     exit 1
@@ -111,6 +113,29 @@ jobs:
                   if [[ "${FF_RESOLVED}" != "${DEV_TIP}" ]]; then
                     echo "::error::ff_target ${FF_TARGET} is not the current dev tip ($(git rev-parse --short=9 origin/dev)). Promote the current dev tip (or cut a fresh RC first)."
                     exit 1
+                  fi
+                  # Hotfix tags are unreachable from main, so a patch-level
+                  # promotion can recompute a version the current line already
+                  # published and then die at `git tag`, with main already
+                  # fast-forwarded. A minor/major moves to a line no hotfix can
+                  # occupy, so it is exempt.
+                  # `|| true`: no match on a repo with no stable tag yet.
+                  MAIN_MAX="$(git tag -l 'v*' --merged origin/main | grep -Ev -- '-(rc|pr|alpha|beta)' | sort -V | tail -1 || true)"
+                  if [[ -n "${MAIN_MAX}" ]]; then
+                    MAIN_LINE="$(sed -E 's/^v([0-9]+\.[0-9]+)\..*/\1/' <<<"${MAIN_MAX}")"
+                    LINE_MAX="$(git tag -l "v${MAIN_LINE}.*" | grep -Ev -- '-(rc|pr|alpha|beta)' | sort -V | tail -1 || true)"
+                    # Capture first: `git log | grep -q` takes SIGPIPE on match,
+                    # which pipefail would surface as a false negative.
+                    SUBJECTS="$(git log "origin/main..${FF_TARGET}" --format='%s')"
+                    BODIES="$(git log "origin/main..${FF_TARGET}" --format='%b')"
+                    BUMPS_LINE=0
+                    grep -qE '^feat(\([^)]+\))?:' <<<"${SUBJECTS}" && BUMPS_LINE=1
+                    grep -qE '^[a-zA-Z]+(\([^)]+\))?!:' <<<"${SUBJECTS}" && BUMPS_LINE=1
+                    grep -qE '(^|[[:space:]])BREAKING[ -]CHANGE:' <<<"${BODIES}" && BUMPS_LINE=1
+                    if [[ "${LINE_MAX}" != "${MAIN_MAX}" && "${BUMPS_LINE}" -eq 0 ]]; then
+                      echo "::error::hotfix/${MAIN_LINE}.x has shipped ${LINE_MAX}, which is not reachable from main (${MAIN_MAX}). The promoted range carries no feat:/breaking commit, so this promotion would recompute an already-published version. Ship the remaining fixes from hotfix/${MAIN_LINE}.x instead, or promote once dev carries a minor."
+                      exit 1
+                    fi
                   fi
                   echo "main_before=$(git rev-parse origin/main^{commit})" >> "$GITHUB_OUTPUT"
                   {
@@ -218,9 +243,12 @@ jobs:
                       | awk '{print $NF}' | sort -u)
                     if (( ${#SHIPPED_SHAS[@]} > 0 )); then
                       printf '%s\n' "${SHIPPED_SHAS[@]}" > /tmp/shipped_shas.txt
+                      # Notes render the squash suffix as a link, so the key is
+                      # `[#420]`; a literal `(#420)` never appears. The closing
+                      # bracket still stops #420 matching inside #4205.
                       git log "${MAIN_BEFORE}..${DEV_BEFORE}" --format='%H %s' \
                         | awk 'NR==FNR{s[$1];next} ($1 in s)' /tmp/shipped_shas.txt - \
-                        | grep -oE '\(#[0-9]+\)$' >> "${KEYS}" || true
+                        | sed -nE 's/.*\(#([0-9]+)\)$/[#\1]/p' >> "${KEYS}" || true
                     fi
                   fi
                   sort -u -o "${KEYS}" "${KEYS}"
@@ -232,6 +260,12 @@ jobs:
                   BODY="$(mktemp)"
                   gh release view "${TAG}" --json body -q .body > "${BODY}" 2>/dev/null || true
                   grep -vF -f "${KEYS}" "${BODY}" > "${BODY}.new" || true
+                  # A section that lost every entry would render as a bare
+                  # heading; pass 1 marks headings that kept one, pass 2 prints.
+                  awk 'NR==FNR { if (/^### /) h = $0; else if (/^\* /) keep[h] = 1; next }
+                       /^### / { skip = !keep[$0] }
+                       !skip' "${BODY}.new" "${BODY}.new" > "${BODY}.trimmed"
+                  mv "${BODY}.trimmed" "${BODY}.new"
                   if ! diff -q "${BODY}" "${BODY}.new" >/dev/null; then
                     gh release edit "${TAG}" --notes-file "${BODY}.new"
                     echo "deduped release notes for ${TAG}"

--- a/.github/workflows/release-semantic.yaml
+++ b/.github/workflows/release-semantic.yaml
@@ -152,25 +152,6 @@ jobs:
                     --apply-bumps \
                     --output /tmp/feature-version-audit.txt
 
-            - name: Prune sibling-line tags (hotfix branch only)
-              # Scopes semantic-release's version-ordering view to just this
-              # branch's own lineage: without this, its "release" branches
-              # (no `range`) share one global ascending version order, which
-              # breaks a hotfix line older than main's current version. Local
-              # to this checkout only — never pushed.
-              if: ${{ startsWith(github.ref_name, 'hotfix/') }}
-              env:
-                  REF_NAME: ${{ github.ref_name }}
-              run: |
-                  set -euo pipefail
-                  git fetch origin --tags --force
-                  mapfile -t KEEP < <(git tag --merged "${REF_NAME}")
-                  declare -A KEEP_SET
-                  for t in "${KEEP[@]}"; do KEEP_SET["$t"]=1; done
-                  while read -r t; do
-                    [[ -n "${t}" && -z "${KEEP_SET[$t]:-}" ]] && git tag -d "$t" >/dev/null
-                  done < <(git tag -l 'v*')
-
             - name: Semantic Release
               id: semantic
               uses: cycjimmy/semantic-release-action@v6

--- a/.github/workflows/release-semantic.yaml
+++ b/.github/workflows/release-semantic.yaml
@@ -1,14 +1,12 @@
 name: "Release: Semantic Version"
 
-# Dispatch on: dev (RC) | main (stable, current line) | hotfix/X.Y.x
-# (older line, only valid when main has shipped a newer minor/major).
+# Dispatch on: dev (RC) | main (stable) | hotfix/X.Y.x (any release line,
+# current or older — released directly and uniformly, no promotion).
 #
-# Promotion (ff_target on main): FF main to ff_target, run semantic-
-# release, then reconcile the source branch. Dev-source merges main into
-# dev (ancestry-only) and FF-reconciles dev. Hotfix-staging source resets
-# the maintenance branch (hotfix/X.Y.x) to the released main tip so the
-# NEXT current-line patch still fast-forwards main; dev is left untouched
-# and folds the hotfix in at the next minor/major promotion.
+# Promotion (ff_target on main): FF main to the exact current dev tip, run
+# semantic-release, then FF-reconcile dev to absorb the resulting release
+# commit. main only ever advances this way — hotfixes never touch main, so
+# main can't diverge from dev between promotions.
 
 on:
     workflow_dispatch:
@@ -89,65 +87,24 @@ jobs:
                     echo "::error::ff_target is only valid when this workflow is dispatched on 'main' (got '${{ github.ref_name }}')."
                     exit 1
                   fi
-                  # Fetch dev + every hotfix branch so the ancestor checks can
-                  # find ff_target regardless of which staging branch it's on.
-                  git fetch origin main dev '+refs/heads/hotfix/*:refs/remotes/origin/hotfix/*'
+                  git fetch origin main dev
                   if ! git rev-parse --verify "${FF_TARGET}^{commit}" >/dev/null 2>&1; then
                     echo "::error::ff_target SHA ${FF_TARGET} does not exist."
                     exit 1
                   fi
-                  # main being an ancestor of ff_target is enforced per-source
-                  # below. dev-source promotions may legitimately have a
-                  # diverged main (interim hotfixes); the reconcile pre-step
-                  # merges main into dev to fix that before the FF.
-                  #
-                  # Identify the source branch for the promotion.
-                  #   dev source     → merge main into dev first (if diverged),
-                  #                    then FF-reconcile dev afterward. No rewrite.
-                  #   hotfix-staging → dev is NOT reconciled here; the next
-                  #                    minor/major promotion folds the hotfix in
-                  #                    via its dev-source merge pre-step.
-                  SOURCE=""
+                  # main only ever advances by fast-forwarding to dev's tip, so
+                  # ff_target must be the CURRENT dev tip exactly. A stale
+                  # (ancestor-but-not-tip) dev SHA would drop newer dev commits
+                  # when dev is FF-reconciled back to main after the release.
                   FF_RESOLVED="$(git rev-parse "${FF_TARGET}^{commit}")"
                   DEV_TIP="$(git rev-parse origin/dev^{commit})"
-                  if [[ "${FF_RESOLVED}" == "${DEV_TIP}" ]]; then
-                    # dev-source promotion: ff_target must be the CURRENT dev tip
-                    # exactly. A stale (ancestor-but-not-tip) dev SHA would make
-                    # the reconcile merge's first parent an old commit, and the
-                    # force-with-lease push would then rewrite newer dev work.
-                    SOURCE="dev"
-                  elif git merge-base --is-ancestor "${FF_RESOLVED}" origin/dev; then
-                    echo "::error::ff_target ${FF_TARGET} is an ancestor of dev but not its tip ($(git rev-parse --short=9 origin/dev)). Promote the current dev tip (or cut a fresh RC) — promoting a stale dev point would rewrite newer dev commits."
-                    exit 1
-                  else
-                    while read -r REF; do
-                      [[ -z "${REF}" ]] && continue
-                      if git merge-base --is-ancestor "${FF_RESOLVED}" "${REF}"; then
-                        SOURCE="${REF#origin/}"
-                        break
-                      fi
-                    done < <(git for-each-ref --format='%(refname:short)' 'refs/remotes/origin/hotfix/*')
-                  fi
-                  if [[ -z "${SOURCE}" ]]; then
-                    echo "::error::ff_target ${FF_TARGET} is not an ancestor of dev or any origin/hotfix/* branch — refusing to promote an unreviewed SHA."
+                  if [[ "${FF_RESOLVED}" != "${DEV_TIP}" ]]; then
+                    echo "::error::ff_target ${FF_TARGET} is not the current dev tip ($(git rev-parse --short=9 origin/dev)). Promote the current dev tip (or cut a fresh RC first)."
                     exit 1
                   fi
-                  # hotfix-staging sources must be a clean fast-forward of main.
-                  # The post-release reconcile step resets the maintenance branch
-                  # to main after every current-line patch, so the next staging
-                  # branch is built on main's tip and this check stays satisfiable.
-                  # dev sources may have a diverged main; the dev-reconcile
-                  # pre-step merges it in first.
-                  if [[ "${SOURCE}" != "dev" ]]; then
-                    if ! git merge-base --is-ancestor origin/main "${FF_TARGET}"; then
-                      echo "::error::hotfix-staging ff_target ${FF_TARGET} is not a fast-forward of main."
-                      exit 1
-                    fi
-                  fi
-                  echo "source=${SOURCE}" >> "$GITHUB_OUTPUT"
+                  echo "main_before=$(git rev-parse origin/main^{commit})" >> "$GITHUB_OUTPUT"
                   {
                     echo "## Promotion plan"
-                    echo "- Source branch: \`${SOURCE}\`"
                     echo "- Target SHA: \`$(git rev-parse --short=9 "${FF_TARGET}")\`"
                     PRERELEASE_TAG=$(git tag --points-at "${FF_TARGET}" | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+-(rc|pr)[.0-9]+$' | head -n1 || true)
                     echo "- Prerelease tag at target: \`${PRERELEASE_TAG:-<none>}\`"
@@ -157,95 +114,11 @@ jobs:
                     git log --oneline "origin/main..${FF_TARGET}" | sed 's/^/    /'
                   } >> "$GITHUB_STEP_SUMMARY"
 
-            - name: Reconcile dev (merge main into dev, dev source only)
-              id: reconcile
-              if: ${{ inputs.ff_target != '' && steps.validate.outputs.source == 'dev' }}
-              env:
-                  TOKEN: ${{ steps.app-token.outputs.token }}
-                  FF_TARGET: ${{ inputs.ff_target }}
-              run: |
-                  set -euo pipefail
-                  git fetch origin main dev
-                  MAIN_BEFORE="$(git rev-parse origin/main)"
-                  DEV_SHA="$(git rev-parse "${FF_TARGET}")"
-                  echo "main_before=${MAIN_BEFORE}" >> "$GITHUB_OUTPUT"
-                  echo "dev_before=${DEV_SHA}" >> "$GITHUB_OUTPUT"
-
-                  # dev is the sole source of truth. Version-bump files are the
-                  # only paths allowed to diverge between main and dev (resolved
-                  # to dev); anything else is a process violation and hard-fails.
-                  ALLOWLIST_REGEX='^(CMakeLists\.txt|features/.+/Shaders/Features/[^/]+\.ini)$'
-
-                  if git merge-base --is-ancestor "${MAIN_BEFORE}" "${DEV_SHA}"; then
-                    # main already folded into dev — nothing to merge.
-                    echo "effective_target=${DEV_SHA}" >> "$GITHUB_OUTPUT"
-                    echo "::notice::main already an ancestor of dev; no merge needed."
-                    exit 0
-                  fi
-
-                  # Merge main into dev to establish ANCESTRY ONLY, on a detached
-                  # HEAD so no local branch is mutated. The result tree must equal
-                  # dev's tree (the merge adds history, not content).
-                  git checkout --quiet --detach "${DEV_SHA}"
-                  if git merge --no-ff --no-edit \
-                       -m "chore: merge main into dev (reconcile hotfixes) [skip ci]" "${MAIN_BEFORE}"; then
-                    mapfile -t CHANGED < <(git diff --name-only "${DEV_SHA}" HEAD)
-                  else
-                    mapfile -t CHANGED < <(git diff --name-only --diff-filter=U)
-                    MERGE_CONFLICTED=1
-                  fi
-
-                  # Any diverging path outside the allowlist is a tripwire: main
-                  # must not carry non-dev-sourced content. Fail before any push.
-                  VIOLATIONS=()
-                  for p in "${CHANGED[@]}"; do
-                    [[ -z "$p" ]] && continue
-                    [[ "$p" =~ ${ALLOWLIST_REGEX} ]] || VIOLATIONS+=("$p")
-                  done
-                  if (( ${#VIOLATIONS[@]} > 0 )); then
-                    echo "::error::main carries non-dev-sourced changes outside the version-file allowlist:"
-                    printf '  %s\n' "${VIOLATIONS[@]}"
-                    git merge --abort 2>/dev/null || true
-                    exit 1
-                  fi
-
-                  # Resolve every diverging (allowlisted) path to dev's content.
-                  for p in "${CHANGED[@]}"; do
-                    [[ -z "$p" ]] && continue
-                    git checkout "${DEV_SHA}" -- "$p"
-                    git add -- "$p"
-                  done
-                  if [[ "${MERGE_CONFLICTED:-0}" -eq 1 ]]; then
-                    git -c core.editor=true commit --no-edit >/dev/null
-                  else
-                    git diff --cached --quiet || git commit --amend --no-edit >/dev/null
-                  fi
-
-                  # Belt-and-suspenders: merge tree MUST equal dev's tree.
-                  if ! git diff --quiet "${DEV_SHA}" HEAD; then
-                    echo "::error::post-resolution tree differs from dev; refusing to proceed"
-                    git diff --name-only "${DEV_SHA}" HEAD
-                    exit 1
-                  fi
-
-                  TARGET="$(git rev-parse HEAD)"
-                  echo "effective_target=${TARGET}" >> "$GITHUB_OUTPUT"
-
-                  # Fast-forward push of dev to the merge commit (its first parent
-                  # is the old dev tip) — no force, so dev's protection (force-push
-                  # disabled) is respected; the App's PR-bypass authorizes it.
-                  REMOTE="https://x-access-token:${TOKEN}@github.com/${{ github.repository }}.git"
-                  CURRENT_DEV="$(git rev-parse origin/dev)"
-                  git push --force-with-lease="dev:${CURRENT_DEV}" "${REMOTE}" "${TARGET}:refs/heads/dev"
-                  echo "::notice::Merged main into dev (${TARGET}); dev fast-forwarded."
-
             - name: Fast-forward main to ff_target
               if: ${{ inputs.ff_target != '' }}
               env:
                   TOKEN: ${{ steps.app-token.outputs.token }}
-                  # Use the reconcile merge commit when dev was reconciled,
-                  # otherwise the originally dispatched ff_target.
-                  FF_TARGET: ${{ steps.reconcile.outputs.effective_target || inputs.ff_target }}
+                  FF_TARGET: ${{ inputs.ff_target }}
               run: |
                   set -euo pipefail
                   REMOTE="https://x-access-token:${TOKEN}@github.com/${{ github.repository }}.git"
@@ -262,6 +135,23 @@ jobs:
                   python tools/feature_version_audit.py \
                     --apply-bumps \
                     --output /tmp/feature-version-audit.txt
+
+            - name: Prune sibling-line tags (hotfix branch only)
+              # Scopes semantic-release's version-ordering view to just this
+              # branch's own lineage: without this, its "release" branches
+              # (no `range`) share one global ascending version order, which
+              # breaks a hotfix line older than main's current version. Local
+              # to this checkout only — never pushed.
+              if: ${{ startsWith(github.ref_name, 'hotfix/') }}
+              run: |
+                  set -euo pipefail
+                  git fetch origin --tags --force
+                  mapfile -t KEEP < <(git tag --merged "${{ github.ref_name }}")
+                  declare -A KEEP_SET
+                  for t in "${KEEP[@]}"; do KEEP_SET["$t"]=1; done
+                  while read -r t; do
+                    [[ -n "${t}" && -z "${KEEP_SET[$t]:-}" ]] && git tag -d "$t" >/dev/null
+                  done < <(git tag -l 'v*')
 
             - name: Semantic Release
               id: semantic
@@ -301,34 +191,40 @@ jobs:
                     --ref "${TAG}"
 
             - name: Dedup release notes (drop interim hotfix entries)
-              # Best-effort: prune fixes already shipped via interim hotfixes
-              # from this minor/major's draft notes. semantic-release created the
-              # draft (with notes) in the step above; release-build.yaml only
-              # updates it minutes later after its build, so this quick edit lands
-              # first. continue-on-error so notes cosmetics never block a release.
-              if: ${{ inputs.ff_target != '' && steps.validate.outputs.source == 'dev' && steps.semantic.outputs.new_release_published == 'true' }}
+              # Best-effort: a fix already shipped as a patch (cherry-picked
+              # with -x onto some hotfix/X.Y.x branch and released) is still
+              # part of dev's own history, so it would otherwise be listed
+              # again in this minor/major's notes. Match commits being
+              # promoted from dev against hotfix branches' cherry-pick
+              # trailers by exact SHA, then dedupe by that commit's own PR
+              # number. continue-on-error so notes cosmetics never block a
+              # release.
+              if: ${{ inputs.ff_target != '' && steps.semantic.outputs.new_release_published == 'true' }}
               continue-on-error: true
               env:
                   GH_TOKEN: ${{ steps.app-token.outputs.token }}
                   GH_REPO: ${{ github.repository }}
-                  MAIN_BEFORE: ${{ steps.reconcile.outputs.main_before }}
-                  DEV_BEFORE: ${{ steps.reconcile.outputs.dev_before }}
+                  MAIN_BEFORE: ${{ steps.validate.outputs.main_before }}
+                  DEV_BEFORE: ${{ inputs.ff_target }}
                   TAG: ${{ steps.semantic.outputs.new_release_git_tag }}
               run: |
                   set -euo pipefail
-                  git fetch origin --tags --force
-                  # Interim hotfix commits live between the previous minor (the
-                  # merge-base of the pre-promotion main and dev) and the
-                  # pre-promotion main tip. Collect their PR numbers and the
-                  # `cherry picked from commit <sha>` trailers as dedup keys.
-                  BASE="$(git merge-base "${MAIN_BEFORE}" "${DEV_BEFORE}")"
+                  git fetch origin --tags --force '+refs/heads/hotfix/*:refs/remotes/origin/hotfix/*'
+                  HOTFIX_REFS=$(git for-each-ref --format='%(refname)' 'refs/remotes/origin/hotfix/*')
                   KEYS="$(mktemp)"
-                  {
-                    git log "${BASE}..${MAIN_BEFORE}" --format='%s' | grep -oE '#[0-9]+' || true
-                    git log "${BASE}..${MAIN_BEFORE}" --format='%b' \
-                      | grep -oiE 'cherry picked from commit [0-9a-f]{7,40}' \
-                      | awk '{print substr($NF,1,9)}' || true
-                  } | sort -u > "${KEYS}"
+                  : > "${KEYS}"
+                  if [[ -n "${HOTFIX_REFS}" ]]; then
+                    mapfile -t SHIPPED_SHAS < <(git log ${HOTFIX_REFS} --format=%B \
+                      | grep -oE 'cherry picked from commit [0-9a-f]{40}' \
+                      | awk '{print $NF}' | sort -u)
+                    if (( ${#SHIPPED_SHAS[@]} > 0 )); then
+                      printf '%s\n' "${SHIPPED_SHAS[@]}" > /tmp/shipped_shas.txt
+                      git log "${MAIN_BEFORE}..${DEV_BEFORE}" --format='%H %s' \
+                        | awk 'NR==FNR{s[$1];next} ($1 in s)' /tmp/shipped_shas.txt - \
+                        | grep -oE '#[0-9]+' >> "${KEYS}" || true
+                    fi
+                  fi
+                  sort -u -o "${KEYS}" "${KEYS}"
                   if [[ ! -s "${KEYS}" ]]; then
                     echo "no interim hotfix keys; nothing to dedup"; exit 0
                   fi
@@ -344,8 +240,8 @@ jobs:
                     echo "no shipped keys found in ${TAG} notes"
                   fi
 
-            - name: Reconcile dev with release commit (promotion mode, dev source only)
-              if: ${{ inputs.ff_target != '' && steps.semantic.outputs.new_release_published == 'true' && steps.validate.outputs.source == 'dev' }}
+            - name: Reconcile dev with release commit (promotion mode)
+              if: ${{ inputs.ff_target != '' && steps.semantic.outputs.new_release_published == 'true' }}
               env:
                   TOKEN: ${{ steps.app-token.outputs.token }}
               run: |
@@ -374,44 +270,3 @@ jobs:
                   CURRENT_DEV=$(git rev-parse origin/dev)
                   git push --force-with-lease="dev:${CURRENT_DEV}" "${REMOTE}" "${NEW_MAIN}:refs/heads/dev"
                   echo "::notice::Reconciled dev to main ($NEW_MAIN)."
-
-            - name: Reconcile maintenance branch with release commit (hotfix-staging source)
-              # Current-line patches FF main to the staging tip, then semantic-
-              # release appends chore(release): on main. The maintenance branch
-              # still points at its PR merge commit (which main can't take —
-              # linear-history protection) and lacks that release commit, so it
-              # diverges from main and the NEXT patch's staging branch would no
-              # longer fast-forward main. Reset the maintenance branch to the
-              # released main tip so it stays in lockstep while it is the current
-              # line (the mirror of the dev reconcile above). When main later
-              # moves to a new minor, this branch stops being reconciled and
-              # becomes the divergent older-line maintenance branch — correct.
-              #
-              # hotfix/* is not branch-protected, so this force-push only needs
-              # the App's normal write access (no bypass entry required, unlike
-              # the FF pushes to main and dev).
-              if: ${{ inputs.ff_target != '' && steps.semantic.outputs.new_release_published == 'true' && steps.validate.outputs.source != 'dev' }}
-              env:
-                  TOKEN: ${{ steps.app-token.outputs.token }}
-                  SOURCE: ${{ steps.validate.outputs.source }}
-                  FF_TARGET: ${{ inputs.ff_target }}
-              run: |
-                  set -euo pipefail
-                  git fetch origin main "${SOURCE}"
-                  NEW_MAIN=$(git rev-parse origin/main)
-                  CURRENT_HOTFIX=$(git rev-parse "origin/${SOURCE}")
-                  # Stale ff_target guard: validate only checks ff_target is an
-                  # ANCESTOR of the branch, so an old SHA can pass while newer
-                  # commits sit on the tip. NEW_MAIN is ff_target plus the release
-                  # commit, so resetting SOURCE to it would silently drop any
-                  # content the tip has beyond ff_target. The expected PR merge
-                  # commit carries no content, so an empty diff means the reset is
-                  # safe; a non-empty diff means the promotion is stale.
-                  if ! git diff --quiet "${FF_TARGET}" "${CURRENT_HOTFIX}"; then
-                    echo "::error::maintenance branch ${SOURCE} ($(git rev-parse --short=9 "${CURRENT_HOTFIX}")) carries content beyond the promoted ff_target ($(git rev-parse --short=9 "${FF_TARGET}")); refusing to reset it to main and drop those commits. Re-promote the current branch tip."
-                    git diff --name-only "${FF_TARGET}" "${CURRENT_HOTFIX}"
-                    exit 1
-                  fi
-                  REMOTE="https://x-access-token:${TOKEN}@github.com/${{ github.repository }}.git"
-                  git push --force-with-lease="${SOURCE}:${CURRENT_HOTFIX}" "${REMOTE}" "${NEW_MAIN}:refs/heads/${SOURCE}"
-                  echo "::notice::Reconciled ${SOURCE} to main (${NEW_MAIN})."

--- a/.github/workflows/release-semantic.yaml
+++ b/.github/workflows/release-semantic.yaml
@@ -76,6 +76,16 @@ jobs:
                   git config user.name "github-actions[bot]"
                   git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
+            - name: Require ff_target when dispatched on main
+              # main only ever releases via promotion. Skipping this guard
+              # would let every `if: inputs.ff_target != ''` gate below
+              # (including the dev reconcile) silently no-op, publishing a
+              # release on main without reconciling dev.
+              if: ${{ github.ref_name == 'main' && inputs.ff_target == '' }}
+              run: |
+                  echo "::error::main only releases via promotion — set ff_target to the current dev tip SHA. Dispatching on main with no ff_target is not supported."
+                  exit 1
+
             - name: Validate ff_target (promotion mode)
               id: validate
               if: ${{ inputs.ff_target != '' }}
@@ -122,9 +132,15 @@ jobs:
               run: |
                   set -euo pipefail
                   REMOTE="https://x-access-token:${TOKEN}@github.com/${{ github.repository }}.git"
-                  # FF-only push: --force-with-lease guards against concurrent
-                  # changes; if main moved we abort rather than overwrite.
                   CURRENT_MAIN=$(git rev-parse origin/main)
+                  # --force-with-lease only guards against a concurrent change
+                  # to main's remote tip; it does not require FF_TARGET to
+                  # actually descend from CURRENT_MAIN. Verify that ourselves
+                  # before force-pushing.
+                  if ! git merge-base --is-ancestor "${CURRENT_MAIN}" "${FF_TARGET}"; then
+                    echo "::error::${FF_TARGET} is not a fast-forward of main (${CURRENT_MAIN}) — refusing to force-push a non-fast-forward."
+                    exit 1
+                  fi
                   git push --force-with-lease="main:${CURRENT_MAIN}" "${REMOTE}" "${FF_TARGET}:refs/heads/main"
                   # Re-point our local working tree at the new main tip so
                   # semantic-release runs against the promoted history.
@@ -223,7 +239,7 @@ jobs:
                       printf '%s\n' "${SHIPPED_SHAS[@]}" > /tmp/shipped_shas.txt
                       git log "${MAIN_BEFORE}..${DEV_BEFORE}" --format='%H %s' \
                         | awk 'NR==FNR{s[$1];next} ($1 in s)' /tmp/shipped_shas.txt - \
-                        | grep -oE '#[0-9]+' >> "${KEYS}" || true
+                        | grep -oE '\(#[0-9]+\)$' >> "${KEYS}" || true
                     fi
                   fi
                   sort -u -o "${KEYS}" "${KEYS}"

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -1,3 +1,36 @@
+// The branches array is scoped to the branch actually being released rather
+// than listing every line at once. Two hard constraints force this:
+//
+//   1. semantic-release caps `release`-type branches at 3 and globs branch
+//      patterns against every branch on origin, so a `hotfix/*` pattern with
+//      several live lines throws ERELEASEBRANCHES.
+//   2. Giving the pattern a `range` (making it a maintenance branch) instead
+//      forces every hotfix line to be strictly older than main's version, so a
+//      current-line hotfix resolves to an empty range and dies with
+//      EINVALIDNEXTVERSION.
+//
+// Scoping sidesteps both: one release branch per run, no ordering relative to
+// sibling lines. GITHUB_REF_NAME is set for every GitHub Actions step; the
+// fallback keeps local `semantic-release --dry-run` runs working.
+const refName = process.env.GITHUB_REF_NAME ?? '';
+const hotfixLine = /^hotfix\/(\d+\.(?:\d+|x)\.x)$/.exec(refName)?.[1];
+
+// A scoped hotfix branch accepts patch/minor/major, so an unclamped `feat:`
+// on hotfix/1.2.x would resolve to 1.3.0 and collide with a version already
+// shipped from main. release-hotfix.yaml only cherry-picks fix:/perf:, but
+// clamp here as well so a hand-pushed commit can't jump the line.
+const commitAnalyzer = hotfixLine
+  ? [
+      '@semantic-release/commit-analyzer',
+      {
+        releaseRules: [
+          { breaking: true, release: 'patch' },
+          { type: 'feat', release: 'patch' },
+        ],
+      },
+    ]
+  : '@semantic-release/commit-analyzer';
+
 module.exports = {
   // 'main' is the stable release channel. It only ever advances by fast-
   // forwarding to dev's tip during a minor/major promotion (release-
@@ -6,22 +39,12 @@ module.exports = {
   //
   // 'dev' is the integration channel and produces vX.Y.Z-rc.N prereleases.
   //
-  // 'hotfix/X.Y.x' is a release branch for ANY line, current or older,
-  // treated uniformly. It has no `range`: release-semantic.yaml prunes every
-  // tag not reachable from the dispatched hotfix branch before invoking
-  // semantic-release, which scopes its version-ordering view to that
-  // branch's own lineage instead of the shared array order `range` would
-  // otherwise require.
-  branches: [
-    'main',
-    { name: 'dev', prerelease: 'rc' },
-    {
-      name: 'hotfix/+([0-9])?(.{+([0-9]),x}).x',
-      channel: '${name.split("/")[1]}',
-    },
-  ],
+  // 'hotfix/X.Y.x' releases patches for ANY line, current or older, uniformly.
+  branches: hotfixLine
+    ? [{ name: refName, channel: hotfixLine }]
+    : ['main', { name: 'dev', prerelease: 'rc' }],
   plugins: [
-    '@semantic-release/commit-analyzer',
+    commitAnalyzer,
     '@semantic-release/release-notes-generator',
     [
       '@google/semantic-release-replace-plugin',

--- a/.releaserc.js
+++ b/.releaserc.js
@@ -1,20 +1,22 @@
 module.exports = {
-  // 'main' is the stable release channel. Patches to the current line land
-  // here directly (cherry-picked from dev) and produce vX.Y.Z. Minors/majors
-  // land here via the dev → main promotion flow in release-semantic.yaml.
+  // 'main' is the stable release channel. It only ever advances by fast-
+  // forwarding to dev's tip during a minor/major promotion (release-
+  // semantic.yaml) — hotfixes never touch it directly, so it can't diverge
+  // from dev between promotions.
   //
   // 'dev' is the integration channel and produces vX.Y.Z-rc.N prereleases.
   //
-  // 'hotfix/X.Y.x' is the maintenance channel for OLDER release lines.
-  // semantic-release validates it as a maintenance branch, which means it is
-  // only valid once 'main' has shipped a release on a newer minor/major than
-  // X.Y. Patches to the current line do NOT use this — use a fix PR to main.
+  // 'hotfix/X.Y.x' is a release branch for ANY line, current or older,
+  // treated uniformly. It has no `range`: release-semantic.yaml prunes every
+  // tag not reachable from the dispatched hotfix branch before invoking
+  // semantic-release, which scopes its version-ordering view to that
+  // branch's own lineage instead of the shared array order `range` would
+  // otherwise require.
   branches: [
     'main',
     { name: 'dev', prerelease: 'rc' },
     {
       name: 'hotfix/+([0-9])?(.{+([0-9]),x}).x',
-      range: '${name.split("/")[1]}',
       channel: '${name.split("/")[1]}',
     },
   ],


### PR DESCRIPTION
After this PR hotfix branches won't be merged back into main for releases, instead they are left dangling.
Prevents the need for complex reconciliation steps that are prone to breaking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release Process**
  * Releases are promoted from development to the main release line after validation.
  * Development remains synchronized with the latest released version.
  * Hotfix releases are limited to the appropriate maintenance line and produce patch-level updates.
  * Release notes are deduplicated to prevent repeated entries.
  * Branch promotion and hotfix handling are now more consistent and predictable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->