### PR TITLE
ci: drop unavailable issues scope from hotfix app token

### DIFF
--- a/.github/workflows/release-hotfix.yaml
+++ b/.github/workflows/release-hotfix.yaml
@@ -64,11 +64,11 @@ jobs:
               with:
                   app-id: ${{ secrets.APP_ID }}
                   private-key: ${{ secrets.APP_PRIVATE_KEY }}
-                  # Least privilege: this job pushes branches, opens/closes PRs, and
-                  # creates the "hotfix" label.
+                  # Least privilege: this job pushes branches and opens/closes PRs.
+                  # Requesting a scope the App installation lacks (e.g. issues)
+                  # fails token minting with 422.
                   permission-contents: write
                   permission-pull-requests: write
-                  permission-issues: write
 
             # TEMPORARY DEBUG: verify the generated App token can actually reach
             # the repo before checkout. Remove once the auth issue is resolved.
@@ -345,20 +345,18 @@ jobs:
                     echo "See: [Hotfix Release Process](https://github.com/${{ github.repository }}/wiki/Developers#hotfix-release-process)"
                   } > /tmp/pr-body.md
 
-                  # Best-effort: ensure the hotfix label exists so --label
-                  # doesn't fail the workflow on repos that haven't created it.
-                  gh label create hotfix \
-                    --repo '${{ github.repository }}' \
-                    --color ededed \
-                    --description "Hotfix candidate" 2>/dev/null || true
-
-                  gh pr create \
+                  PR_URL=$(gh pr create \
                     --repo '${{ github.repository }}' \
                     --base "${HOTFIX}" \
                     --head "${STAGING}" \
                     --title "hotfix(${{ steps.plan.outputs.maj_min }}): ${PICKED} fix(es) on top of ${BASE}" \
-                    --body-file /tmp/pr-body.md \
-                    --label hotfix
+                    --body-file /tmp/pr-body.md)
+                  echo "Opened ${PR_URL}"
+
+                  # Cosmetic label — no workflow keys off it, so never fail the
+                  # run if the label is missing or the token can't apply it.
+                  gh pr edit "${PR_URL}" --add-label hotfix \
+                    || echo "::warning::Could not apply the 'hotfix' label to ${PR_URL}."
 
             - name: Note when no commits were picked
               if: ${{ steps.cherry.outputs.picked_count == '0' }}


### PR DESCRIPTION
The release bot App installation has no issues permission, and
create-github-app-token can only narrow granted scopes, never add
them, so requesting permission-issues failed token minting with 422.
Only `gh label create` needed it; the hotfix label already exists,
and applying it to a PR works under pull-requests: write.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved hotfix pull request creation by reducing required permissions.
  - Hotfix pull requests are now created even if label application fails.
  - Added a warning when the hotfix label cannot be applied after creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->