### PR TITLE
fix(exponential height fog): vanilla fog applied twice when disabled

### DIFF
--- a/package/Shaders/Effect.hlsl
+++ b/package/Shaders/Effect.hlsl
@@ -867,7 +867,7 @@ PS_OUTPUT main(PS_INPUT input)
 #		else
 #			if defined(EXP_HEIGHT_FOG)
 	float3 blendedColor = lerp(lightColor, vanillaFogColor, vanillaFogFactor.xxx);
-	blendedColor = lerp(blendedColor, fogColor, fogFactor.xxx);
+	blendedColor = lerp(blendedColor, fogColor, expFogFactor.xxx);
 #			else
 	float3 blendedColor = lerp(lightColor, fogColor, fogFactor.xxx);
 #			endif


### PR DESCRIPTION
This bug only occurs when exponential height fog is enabled at boot but disabled in its GUI. It was only apparent because the Horizon Fix mod adds water out there.

Screenshot of the issue that this PR fixes:

<img width="3840" height="2160" alt="ScreenShot8" src="https://github.com/user-attachments/assets/9598696a-bfbf-4ba1-8225-12463305ed21" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved exponential-height fog blending for more accurate fog color rendering in standard blend modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->