### PR TITLE
fix(rendering): support external render scaling

### DIFF
--- a/src/Features/Effects11.cpp
+++ b/src/Features/Effects11.cpp
@@ -696,8 +696,7 @@ void Effects11::DrawVolumetricRays()
 
 	D3D11_TEXTURE2D_DESC mainTexDesc{};
 	main.texture->GetDesc(&mainTexDesc);
-	float2 resolution = { static_cast<float>(mainTexDesc.Width), static_cast<float>(mainTexDesc.Height) };
-	resolution = Util::ConvertToDynamic(resolution);
+	float2 resolution = Util::GetActiveRenderSize();
 	uint32_t dynWidth = static_cast<uint32_t>(resolution.x);
 	uint32_t dynHeight = static_cast<uint32_t>(resolution.y);
 

--- a/src/Features/Effects11/TextureManager.cpp
+++ b/src/Features/Effects11/TextureManager.cpp
@@ -5,6 +5,7 @@
 #include "EffectManager.h"
 #include "Globals.h"
 #include "State.h"
+#include "Utils/Game.h"
 
 TextureManager& TextureManager::GetSingleton()
 {
@@ -38,8 +39,9 @@ void TextureManager::SwapTextures(const std::string& name1, const std::string& n
 
 void TextureManager::CreateCommonTextures()
 {
-	UINT screenWidth = globals::game::graphicsState->screenWidth;
-	UINT screenHeight = globals::game::graphicsState->screenHeight;
+	const auto bufferSize = Util::GetRenderBufferSize();
+	UINT screenWidth = static_cast<UINT>(bufferSize.x);
+	UINT screenHeight = static_cast<UINT>(bufferSize.y);
 
 	commonTextureCache.insert({ "TextureHDRTemp", CreateTexture(screenWidth, screenHeight, DXGI_FORMAT_R16G16B16A16_FLOAT, "TextureManager::TextureHDRTemp") });
 	commonTextureCache.insert({ "TextureHDRTemp2", CreateTexture(screenWidth, screenHeight, DXGI_FORMAT_R16G16B16A16_FLOAT, "TextureManager::TextureHDRTemp2") });

--- a/src/Features/ExponentialHeightFog.cpp
+++ b/src/Features/ExponentialHeightFog.cpp
@@ -236,8 +236,7 @@ void ExponentialHeightFog::EnsureVolumetricResources()
 {
 	uint32_t pixelSize = std::clamp(settings.volumetricGridPixelSize, 4u, 64u);
 	const uint32_t gridZ = std::clamp(settings.volumetricGridSizeZ, 16u, 160u);
-	float2 screenSz{ (float)globals::game::graphicsState->screenWidth, (float)globals::game::graphicsState->screenHeight };
-	auto renderSize = Util::ConvertToDynamic(screenSz);
+	const auto renderSize = Util::GetActiveRenderSize();
 
 	auto getGridSize = [&renderSize, gridZ](uint32_t a_pixelSize) {
 		return DirectX::XMUINT4{

--- a/src/Features/LightLimitFix.cpp
+++ b/src/Features/LightLimitFix.cpp
@@ -20,7 +20,8 @@ NLOHMANN_DEFINE_TYPE_NON_INTRUSIVE_WITH_DEFAULT(
 	EnableLightsVisualisation,
 	LightsVisualisationMode)
 
-static constexpr uint CLUSTER_MAX_LIGHTS = 128;
+// Keep the allocation in sync with MAX_CLUSTER_LIGHTS in Common.hlsli.
+static constexpr uint CLUSTER_MAX_LIGHTS = 256;
 
 void LightLimitFix::DrawSettings()
 {
@@ -88,7 +89,11 @@ LightLimitFix::PerFrame LightLimitFix::GetCommonBufferData()
 
 void LightLimitFix::SetupResources()
 {
-	float2 screenSize{ (float)globals::game::graphicsState->screenWidth, (float)globals::game::graphicsState->screenHeight };
+	const auto dimensions = Util::GetRenderDimensions();
+	float2 screenSize{
+		std::max(dimensions.OutputSize.x, dimensions.BufferSize.x),
+		std::max(dimensions.OutputSize.y, dimensions.BufferSize.y)
+	};
 	clusterSize[0] = ((uint)screenSize.x + 63) / 64;
 	clusterSize[1] = ((uint)screenSize.y + 63) / 64;
 	clusterSize[2] = 32;
@@ -518,7 +523,22 @@ void LightLimitFix::UpdateStructure()
 	lightsNear = *globals::game::cameraNear;
 	lightsFar = *globals::game::cameraFar;
 
-	auto renderSize = Util::ConvertToDynamic(float2{ (float)globals::game::graphicsState->screenWidth, (float)globals::game::graphicsState->screenHeight });
+	const auto dimensions = Util::GetRenderDimensions();
+	const auto renderSize = dimensions.ActiveSize;
+	static bool loggedDimensions = false;
+	if (!loggedDimensions) {
+		const auto& runtimeData = globals::game::graphicsState->GetRuntimeData();
+		logger::info(
+			"[RenderDimensions] LightLimitFix output={}x{}, buffer={}x{}, active={}x{}, lock={}",
+			static_cast<uint32_t>(dimensions.OutputSize.x),
+			static_cast<uint32_t>(dimensions.OutputSize.y),
+			static_cast<uint32_t>(dimensions.BufferSize.x),
+			static_cast<uint32_t>(dimensions.BufferSize.y),
+			static_cast<uint32_t>(dimensions.ActiveSize.x),
+			static_cast<uint32_t>(dimensions.ActiveSize.y),
+			runtimeData.dynamicResolutionLock);
+		loggedDimensions = true;
+	}
 	clusterSize[0] = ((uint)renderSize.x + 63) / 64;
 	clusterSize[1] = ((uint)renderSize.y + 63) / 64;
 	clusterSize[2] = 32;

--- a/src/Features/ScreenSpaceGI.cpp
+++ b/src/Features/ScreenSpaceGI.cpp
@@ -766,7 +766,7 @@ void ScreenSpaceGI::DrawSSGI()
 	auto rts = renderer->GetRuntimeData().renderTargets;
 	auto deferred = globals::deferred;
 
-	float2 size = Util::ConvertToDynamic(float2{ (float)globals::game::graphicsState->screenWidth, (float)globals::game::graphicsState->screenHeight });
+	float2 size = Util::ConvertToDynamic(globals::state->screenSize);
 	auto resolution = std::array{ (uint)size.x, (uint)size.y };
 	auto resChoices = std::array{
 		resolution, std::array{ resolution[0] >> 1, resolution[1] >> 1 }, std::array{ resolution[0] >> 2, resolution[1] >> 2 }

--- a/src/Features/ScreenSpaceGI.cpp
+++ b/src/Features/ScreenSpaceGI.cpp
@@ -667,8 +667,8 @@ bool ScreenSpaceGI::ShadersOK()
 void ScreenSpaceGI::UpdateSB()
 {
 	float2 res = { (float)texRadiance->desc.Width, (float)texRadiance->desc.Height };
-	float2 dynres = Util::ConvertToDynamic(res);
-	dynres = { floor(dynres.x), floor(dynres.y) };
+	float2 dynres = Util::GetActiveRenderSize();
+	dynres = { std::min(floor(dynres.x), res.x), std::min(floor(dynres.y), res.y) };
 
 	static float4x4 prevInvView = {};
 
@@ -766,7 +766,7 @@ void ScreenSpaceGI::DrawSSGI()
 	auto rts = renderer->GetRuntimeData().renderTargets;
 	auto deferred = globals::deferred;
 
-	float2 size = Util::ConvertToDynamic(globals::state->screenSize);
+	float2 size = Util::GetActiveRenderSize();
 	auto resolution = std::array{ (uint)size.x, (uint)size.y };
 	auto resChoices = std::array{
 		resolution, std::array{ resolution[0] >> 1, resolution[1] >> 1 }, std::array{ resolution[0] >> 2, resolution[1] >> 2 }

--- a/src/Features/ScreenSpaceShadows.cpp
+++ b/src/Features/ScreenSpaceShadows.cpp
@@ -66,7 +66,7 @@ void ScreenSpaceShadows::ClearShaderCache()
 
 uint ScreenSpaceShadows::GetScaledSampleCount()
 {
-	float2 renderSize = Util::ConvertToDynamic(globals::state->screenSize);
+	float2 renderSize = Util::GetActiveRenderSize();
 
 	// Scale sample count based on both dimensions relative to 1920x1080 reference
 	float2 referenceRes = { 1920.0f, 1080.0f };
@@ -127,7 +127,8 @@ void ScreenSpaceShadows::DrawShadows()
 
 	auto lightProjectionF = CalculateLightProjection();
 
-	float2 renderSize = Util::ConvertToDynamic(globals::state->screenSize);
+	const auto dimensions = Util::GetRenderDimensions();
+	float2 renderSize = dimensions.ActiveSize;
 	int viewportSize[2] = { (int)renderSize.x, (int)renderSize.y };
 
 	int minRenderBounds[2] = { 0, 0 };
@@ -150,9 +151,9 @@ void ScreenSpaceShadows::DrawShadows()
 	auto buffer = raymarchCB->CB();
 	context->CSSetConstantBuffers(1, 1, &buffer);
 
-	auto viewport = globals::game::graphicsState;
-
-	float2 dynamicRes = { viewport->GetRuntimeData().dynamicResolutionWidthRatio, viewport->GetRuntimeData().dynamicResolutionHeightRatio };
+	// bend_sss addresses a full physical texture with active-render pixels. This
+	// scale is 1 when an external upscaler has already resized the texture.
+	float2 dynamicRes = dimensions.ActiveToBufferScale;
 
 	// Shared dispatch logic
 	auto Dispatch = [&](ID3D11ComputeShader* shader, const float* lightProj,

--- a/src/Features/ScreenSpaceShadows.cpp
+++ b/src/Features/ScreenSpaceShadows.cpp
@@ -66,7 +66,7 @@ void ScreenSpaceShadows::ClearShaderCache()
 
 uint ScreenSpaceShadows::GetScaledSampleCount()
 {
-	float2 renderSize = Util::ConvertToDynamic(float2{ (float)globals::game::graphicsState->screenWidth, (float)globals::game::graphicsState->screenHeight });
+	float2 renderSize = Util::ConvertToDynamic(globals::state->screenSize);
 
 	// Scale sample count based on both dimensions relative to 1920x1080 reference
 	float2 referenceRes = { 1920.0f, 1080.0f };
@@ -127,7 +127,7 @@ void ScreenSpaceShadows::DrawShadows()
 
 	auto lightProjectionF = CalculateLightProjection();
 
-	float2 renderSize = Util::ConvertToDynamic(float2{ (float)globals::game::graphicsState->screenWidth, (float)globals::game::graphicsState->screenHeight });
+	float2 renderSize = Util::ConvertToDynamic(globals::state->screenSize);
 	int viewportSize[2] = { (int)renderSize.x, (int)renderSize.y };
 
 	int minRenderBounds[2] = { 0, 0 };

--- a/src/Features/VolumetricLighting.cpp
+++ b/src/Features/VolumetricLighting.cpp
@@ -174,8 +174,9 @@ void VolumetricLighting::SetupResources()
 
 void VolumetricLighting::EarlyPrepass()
 {
-	int32_t width = static_cast<int32_t>((float)globals::game::graphicsState->screenWidth);
-	int32_t height = static_cast<int32_t>((float)globals::game::graphicsState->screenHeight);
+	const auto renderSize = Util::GetActiveRenderSize();
+	int32_t width = static_cast<int32_t>(renderSize.x);
+	int32_t height = static_cast<int32_t>(renderSize.y);
 
 	if (width != vlData.screenX || height != vlData.screenY) {
 		blurHCS = nullptr;

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -843,8 +843,6 @@ void State::SetupResources()
 
 	frameTimingActive = false;
 
-	auto renderer = globals::game::renderer;
-
 	permutationCB = new ConstantBuffer(ConstantBufferDesc<PermutationCB>());
 	sharedDataCB = new ConstantBuffer(ConstantBufferDesc<SharedDataCB>());
 
@@ -852,10 +850,20 @@ void State::SetupResources()
 	(void)data;
 	featureDataCB = new ConstantBuffer(ConstantBufferDesc((uint32_t)size));
 
-	// Grab main texture to get resolution
-	D3D11_TEXTURE2D_DESC texDesc{};
-	renderer->GetRuntimeData().renderTargets[RE::RENDER_TARGETS::kMAIN].texture->GetDesc(&texDesc);
-	screenSize = { (float)texDesc.Width, (float)texDesc.Height };
+	const auto renderDimensions = Util::GetRenderDimensions();
+	screenSize = renderDimensions.BufferSize;
+	const auto& runtimeData = globals::game::graphicsState->GetRuntimeData();
+	logger::info(
+		"[RenderDimensions] setup output={}x{}, buffer={}x{}, active={}x{}, active/buffer={:.4f}x{:.4f}, lock={}",
+		static_cast<uint32_t>(renderDimensions.OutputSize.x),
+		static_cast<uint32_t>(renderDimensions.OutputSize.y),
+		static_cast<uint32_t>(renderDimensions.BufferSize.x),
+		static_cast<uint32_t>(renderDimensions.BufferSize.y),
+		static_cast<uint32_t>(renderDimensions.ActiveSize.x),
+		static_cast<uint32_t>(renderDimensions.ActiveSize.y),
+		renderDimensions.ActiveToBufferScale.x,
+		renderDimensions.ActiveToBufferScale.y,
+		runtimeData.dynamicResolutionLock);
 
 	globals::d3d::context->QueryInterface(__uuidof(pPerf), reinterpret_cast<void**>(&pPerf));
 
@@ -1036,6 +1044,8 @@ void State::UpdateSharedData([[maybe_unused]] bool a_inWorld, [[maybe_unused]] b
 		data.DirLightDirection.Normalize();
 
 		data.CameraData = Util::GetCameraData();
+		const auto renderDimensions = Util::GetRenderDimensions();
+		screenSize = renderDimensions.BufferSize;
 		data.BufferDim = { screenSize.x, screenSize.y, 1.0f / screenSize.x, 1.0f / screenSize.y };
 		data.Timer = timer;
 

--- a/src/State.cpp
+++ b/src/State.cpp
@@ -855,6 +855,7 @@ void State::SetupResources()
 	// Grab main texture to get resolution
 	D3D11_TEXTURE2D_DESC texDesc{};
 	renderer->GetRuntimeData().renderTargets[RE::RENDER_TARGETS::kMAIN].texture->GetDesc(&texDesc);
+	screenSize = { (float)texDesc.Width, (float)texDesc.Height };
 
 	globals::d3d::context->QueryInterface(__uuidof(pPerf), reinterpret_cast<void**>(&pPerf));
 
@@ -1035,7 +1036,7 @@ void State::UpdateSharedData([[maybe_unused]] bool a_inWorld, [[maybe_unused]] b
 		data.DirLightDirection.Normalize();
 
 		data.CameraData = Util::GetCameraData();
-		data.BufferDim = { (float)globals::game::graphicsState->screenWidth, (float)globals::game::graphicsState->screenHeight, 1.0f / (float)globals::game::graphicsState->screenWidth, 1.0f / (float)globals::game::graphicsState->screenHeight };
+		data.BufferDim = { screenSize.x, screenSize.y, 1.0f / screenSize.x, 1.0f / screenSize.y };
 		data.Timer = timer;
 
 		auto temporal = Util::GetTemporal();
@@ -1069,7 +1070,7 @@ void State::UpdateSharedData([[maybe_unused]] bool a_inWorld, [[maybe_unused]] b
 		if (upscaling.loaded) {
 			auto upscaleMethod = upscaling.GetUpscaleMethod();
 			if (temporal && upscaleMethod != Upscaling::UpscaleMethod::kTAA) {
-				float2 screenSz{ (float)globals::game::graphicsState->screenWidth, (float)globals::game::graphicsState->screenHeight };
+				float2 screenSz = screenSize;
 				auto renderSize = Util::ConvertToDynamic(screenSz, true);
 				data.MipBias = std::log2f(renderSize.x / screenSz.x);
 				if (upscaleMethod == Upscaling::UpscaleMethod::kDLSS)

--- a/src/State.h
+++ b/src/State.h
@@ -264,6 +264,7 @@ public:
 
 	bool inWorld = false;
 	bool activeReflections = false;
+	float2 screenSize = {};
 
 	// Cached menu open states, updated once per frame in Reset().
 	// Avoids repeated IsMenuOpen calls (each constructs a BSFixedString).

--- a/src/Utils/Game.cpp
+++ b/src/Utils/Game.cpp
@@ -192,6 +192,69 @@ namespace Util
 		return vFOVRad;
 	}
 
+	float2 GetOutputSize()
+	{
+		if (!globals::game::graphicsState)
+			return {};
+
+		return {
+			static_cast<float>(globals::game::graphicsState->screenWidth),
+			static_cast<float>(globals::game::graphicsState->screenHeight)
+		};
+	}
+
+	float2 GetRenderBufferSize()
+	{
+		float2 size = GetOutputSize();
+		if (!globals::game::renderer)
+			return size;
+
+		auto& main = globals::game::renderer->GetRuntimeData().renderTargets[RE::RENDER_TARGETS::kMAIN];
+		if (!main.texture)
+			return size;
+
+		D3D11_TEXTURE2D_DESC desc{};
+		main.texture->GetDesc(&desc);
+		if (desc.Width && desc.Height)
+			size = { static_cast<float>(desc.Width), static_cast<float>(desc.Height) };
+
+		return size;
+	}
+
+	RenderDimensions GetRenderDimensions()
+	{
+		RenderDimensions dimensions{};
+		dimensions.OutputSize = GetOutputSize();
+		dimensions.BufferSize = GetRenderBufferSize();
+
+		if (dimensions.OutputSize.x <= 0.0f || dimensions.OutputSize.y <= 0.0f)
+			dimensions.OutputSize = dimensions.BufferSize;
+		if (dimensions.BufferSize.x <= 0.0f || dimensions.BufferSize.y <= 0.0f)
+			dimensions.BufferSize = dimensions.OutputSize;
+
+		dimensions.BufferIsOutputSized =
+			static_cast<uint32_t>(dimensions.BufferSize.x) == static_cast<uint32_t>(dimensions.OutputSize.x) &&
+			static_cast<uint32_t>(dimensions.BufferSize.y) == static_cast<uint32_t>(dimensions.OutputSize.y);
+
+		// When an external upscaler replaces kMAIN with a render-resolution texture,
+		// its dimensions already include the scale. Applying the engine ratio again
+		// is the source of the displaced screen-space effects seen with PureDark.
+		dimensions.ActiveSize = dimensions.BufferIsOutputSized ? ConvertToDynamic(dimensions.BufferSize) : dimensions.BufferSize;
+		dimensions.ActiveSize.x = std::clamp(std::floor(dimensions.ActiveSize.x), 1.0f, dimensions.BufferSize.x);
+		dimensions.ActiveSize.y = std::clamp(std::floor(dimensions.ActiveSize.y), 1.0f, dimensions.BufferSize.y);
+		dimensions.ActiveToBufferScale = {
+			dimensions.ActiveSize.x / dimensions.BufferSize.x,
+			dimensions.ActiveSize.y / dimensions.BufferSize.y
+		};
+
+		return dimensions;
+	}
+
+	float2 GetActiveRenderSize()
+	{
+		return GetRenderDimensions().ActiveSize;
+	}
+
 	float2 ConvertToDynamic(float2 a_size, bool a_ignoreLock)
 	{
 		auto viewport = globals::game::graphicsState;
@@ -207,9 +270,8 @@ namespace Util
 
 	DispatchCount GetScreenDispatchCount(bool a_dynamic)
 	{
-		// screenSize is the actual render-buffer size, already at render scale.
-		float2 resolution = globals::state->screenSize;
-		(void)a_dynamic;
+		const auto dimensions = GetRenderDimensions();
+		const float2 resolution = a_dynamic ? dimensions.ActiveSize : dimensions.OutputSize;
 
 		uint dispatchX = (uint)std::ceil(resolution.x / 8.0f);
 		uint dispatchY = (uint)std::ceil(resolution.y / 8.0f);

--- a/src/Utils/Game.cpp
+++ b/src/Utils/Game.cpp
@@ -187,7 +187,7 @@ namespace Util
 		static float& cameraFOVDeg = (*(float*)(REL::RelocationID(513786, 388785).address()));  // FOV degrees
 		float hFOVRad = cameraFOVDeg * (3.14159265359f / 180.0f);
 		float unitHalfWidth = tan(hFOVRad / 2);                                                                // This is same as camera frustum RL
-		float unitHalfHeight = unitHalfWidth / ((float)globals::game::graphicsState->screenWidth / (float)globals::game::graphicsState->screenHeight);  // frustum TB
+		float unitHalfHeight = unitHalfWidth / (globals::state->screenSize.x / globals::state->screenSize.y);  // frustum TB
 		float vFOVRad = 2.0f * atan(unitHalfHeight);
 		return vFOVRad;
 	}
@@ -207,11 +207,9 @@ namespace Util
 
 	DispatchCount GetScreenDispatchCount(bool a_dynamic)
 	{
-		float2 resolution{ (float)globals::game::graphicsState->screenWidth, (float)globals::game::graphicsState->screenHeight };
-
-		// Feature passes use the scaled render area even when the vanilla dynamic-resolution lock is set.
-		if (a_dynamic)
-			resolution = ConvertToDynamic(resolution, true);
+		// screenSize is the actual render-buffer size, already at render scale.
+		float2 resolution = globals::state->screenSize;
+		(void)a_dynamic;
 
 		uint dispatchX = (uint)std::ceil(resolution.x / 8.0f);
 		uint dispatchY = (uint)std::ceil(resolution.y / 8.0f);

--- a/src/Utils/Game.h
+++ b/src/Utils/Game.h
@@ -37,6 +37,29 @@ namespace Util
 
 	RE::NiPoint3 GetEyePosition();
 
+	/**
+	 * @brief Resolution spaces used by screen-space rendering.
+	 *
+	 * OutputSize is the game/window output size. BufferSize is the physical
+	 * kMAIN texture size. ActiveSize is the portion of that texture rendered
+	 * this frame. External upscalers may resize kMAIN themselves while also
+	 * exposing dynamic-resolution ratios, so those ratios must not be applied
+	 * to an already-resized buffer.
+	 */
+	struct RenderDimensions
+	{
+		float2 OutputSize{};
+		float2 BufferSize{};
+		float2 ActiveSize{};
+		float2 ActiveToBufferScale{ 1.0f, 1.0f };
+		bool BufferIsOutputSized = true;
+	};
+
+	[[nodiscard]] float2 GetOutputSize();
+	[[nodiscard]] float2 GetRenderBufferSize();
+	[[nodiscard]] RenderDimensions GetRenderDimensions();
+	[[nodiscard]] float2 GetActiveRenderSize();
+
 	float2 ConvertToDynamic(float2 a_size, bool a_ignoreLock = false);
 
 	// Game unit conversions


### PR DESCRIPTION
## Summary
- Distinguish final output size, physical render-buffer size, and the active rendered region.
- Treat an externally resized `kMAIN` target as already scaled instead of applying the engine dynamic-resolution ratio a second time.
- Use the appropriate resolution space in shared shader data, dispatch sizing, Light Limit Fix, Screen Space Shadows, Screen Space GI, Volumetric Lighting, Exponential Height Fog, and Effects11 resources.
- Keep Light Limit Fix's CPU allocation capacity synchronized with the shader's per-cluster light limit.
- Add concise render-dimension diagnostics for setup and Light Limit Fix initialization.

## Rationale
External render-scaling integrations can expose a final output size that differs from the physical resources Community Shaders operates on. Some integrations also update Skyrim's dynamic-resolution state, so deriving every screen-space pass from the output dimensions—or scaling a resource that is already physically reduced—misaligns sampling, projection, cluster construction, and dispatch coverage.

The centralized resolution helper makes those spaces explicit and preserves native-resolution behavior while supporting external upscalers and other render-resolution overrides.

## Testing
- `cmake --build --preset Dev`
- Release DLL and AIO packaging completed successfully.
- Verified in game with an external renderer using a 1920x910 physical color/depth/motion-vector buffer and a 3840x1820 output.
- Confirmed correct placement for screen-space shadows and related material effects.
- Confirmed Light Limit Fix receives 1920x910 as its active/physical size, eliminating distance-dependent light popping.
- External integration log contained no warnings or errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when applying dynamic resolution across screen-space lighting, shadows, volumetric effects, fog, and field-of-view calculations.
  * Improved render-size handling so visual effects and dispatches better align with the active image and output dimensions.
  * Increased supported clustered-light capacity, improving lighting behavior in scenes with many lights.
  * Added clearer render-dimension diagnostics to assist with identifying resolution-related issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->