### PR TITLE
fix(skylighting): remove dead clamp from probe cell addressing

### DIFF
--- a/features/Skylighting/Shaders/Skylighting/UpdateProbesCS.hlsl
+++ b/features/Skylighting/Shaders/Skylighting/UpdateProbesCS.hlsl
@@ -61,7 +61,7 @@ static const float3 noise3D[32] = {
 	const float fadeInThreshold = 15;
 	const static sh2 unitSH = Skylighting::UNIT_SH;
 	const SharedData::SkylightingSettings settings = SharedData::skylightingSettings;
-	uint3 cellID = uint3(max(int3(dtid) - settings.ArrayOrigin.xyz, 0) % Skylighting::ARRAY_DIM);
+	uint3 cellID = ((uint3)dtid - settings.ArrayOrigin.xyz) % Skylighting::ARRAY_DIM;
 	uint3 validMin = (uint3)max(0, settings.ValidMargin.xyz);
 	uint3 validMax = Skylighting::ARRAY_DIM - 1 + (uint3)min(0, settings.ValidMargin.xyz);
 	bool isValid = all(cellID >= validMin) && all(cellID <= validMax);  // check if the cell is newly added


### PR DESCRIPTION
`ArrayOrigin` is `uint4`, so the subtraction is unsigned and `max(..., 0)` never fires. Behaviour is unchanged, but the clamp reads as signed intent and misleads anyone porting the shader. If the field were ever made signed, it would silently collapse cells below the origin instead of wrapping.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Rendering**
  - Updated skylighting probe coordinate handling for negative offsets.
  - Probe calculations now wrap around the available coordinate range instead of clamping negative values to zero, producing more consistent lighting behavior across probe boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->