### PR TITLE
chore: update repo URLs and README updates

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -39,7 +39,7 @@ SKSE64 plugin providing modular DirectX 11 graphics enhancements for Skyrim SE/A
 ### Essential Repository Setup
 
 ```bash
-git clone https://github.com/doodlum/skyrim-community-shaders.git --recursive
+git clone https://github.com/community-shaders/skyrim-community-shaders.git --recursive
 cd skyrim-community-shaders
 git submodule update --init --recursive  # If not cloned with --recursive
 ```

--- a/.github/workflows/maint-cleanup-releases.yaml
+++ b/.github/workflows/maint-cleanup-releases.yaml
@@ -153,7 +153,7 @@ jobs:
                           tag_name=$(echo "$line" | cut -d' ' -f1)
                           reason=$(echo "$line" | cut -d'(' -f2- | sed 's/)$//')
                           echo "  • $tag_name - $reason"
-                          echo "    🔗 https://github.com/doodlum/skyrim-community-shaders/releases/tag/$tag_name"
+                          echo "    🔗 https://github.com/community-shaders/skyrim-community-shaders/releases/tag/$tag_name"
                         fi
                       done
                       echo ""

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Latest Release](https://img.shields.io/github/v/release/community-shaders/skyrim-community-shaders)](https://github.com/community-shaders/skyrim-community-shaders/releases)
 [![License](https://img.shields.io/github/license/community-shaders/skyrim-community-shaders)](./LICENSE)
 [![Last Commit](https://img.shields.io/github/last-commit/community-shaders/skyrim-community-shaders)](https://github.com/community-shaders/skyrim-community-shaders/commits)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/community-shaders/skyrim-community-shaders/release-build.yaml?event=release)](https://github.com/community-shaders/skyrim-community-shaders/actions)
 [![Discord](https://img.shields.io/discord/1080142797870485606?label=discord&logo=discord&color=5865F2)](https://discord.com/invite/nkrQybAsyy)
 [![Open Issues](https://img.shields.io/github/issues/community-shaders/skyrim-community-shaders)](https://github.com/community-shaders/skyrim-community-shaders/issues)
 [![Contributors](https://img.shields.io/github/contributors/community-shaders/skyrim-community-shaders)](https://github.com/community-shaders/skyrim-community-shaders/graphs/contributors)

--- a/README.md
+++ b/README.md
@@ -1,14 +1,12 @@
-[![Latest Release](https://img.shields.io/github/v/release/doodlum/skyrim-community-shaders)](https://github.com/doodlum/skyrim-community-shaders/releases)
-[![License](https://img.shields.io/github/license/doodlum/skyrim-community-shaders)](./LICENSE)
-[![Last Commit](https://img.shields.io/github/last-commit/doodlum/skyrim-community-shaders)](https://github.com/doodlum/skyrim-community-shaders/commits)
-[![Build Status](https://img.shields.io/github/actions/workflow/status/doodlum/skyrim-community-shaders/release-build.yaml?branch=dev)](https://github.com/doodlum/skyrim-community-shaders/actions)
+[![Latest Release](https://img.shields.io/github/v/release/community-shaders/skyrim-community-shaders)](https://github.com/community-shaders/skyrim-community-shaders/releases)
+[![License](https://img.shields.io/github/license/community-shaders/skyrim-community-shaders)](./LICENSE)
+[![Last Commit](https://img.shields.io/github/last-commit/community-shaders/skyrim-community-shaders)](https://github.com/community-shaders/skyrim-community-shaders/commits)
 [![Discord](https://img.shields.io/discord/1080142797870485606?label=discord&logo=discord&color=5865F2)](https://discord.com/invite/nkrQybAsyy)
-[![Open Issues](https://img.shields.io/github/issues/doodlum/skyrim-community-shaders)](https://github.com/doodlum/skyrim-community-shaders/issues)
-[![Contributors](https://img.shields.io/github/contributors/doodlum/skyrim-community-shaders)](https://github.com/doodlum/skyrim-community-shaders/graphs/contributors)
-[![Stars](https://img.shields.io/github/stars/doodlum/skyrim-community-shaders?style=social)](https://github.com/doodlum/skyrim-community-shaders/stargazers)
+[![Open Issues](https://img.shields.io/github/issues/community-shaders/skyrim-community-shaders)](https://github.com/community-shaders/skyrim-community-shaders/issues)
+[![Contributors](https://img.shields.io/github/contributors/community-shaders/skyrim-community-shaders)](https://github.com/community-shaders/skyrim-community-shaders/graphs/contributors)
+[![Stars](https://img.shields.io/github/stars/community-shaders/skyrim-community-shaders?style=social)](https://github.com/community-shaders/skyrim-community-shaders/stargazers)
 
-[![Pre-commit CI](https://results.pre-commit.ci/badge/github/doodlum/skyrim-community-shaders/dev.svg)](https://results.pre-commit.ci/latest/github/doodlum/skyrim-community-shaders/dev)
-![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/doodlum/skyrim-community-shaders?utm_source=oss&utm_medium=github&utm_campaign=doodlum%2Fskyrim-community-shaders&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews)
+![CodeRabbit Pull Request Reviews](https://img.shields.io/coderabbit/prs/github/community-shaders/skyrim-community-shaders?utm_source=oss&utm_medium=github&utm_campaign=community-shaders%2Fskyrim-community-shaders&labelColor=171717&color=FF570A&link=https%3A%2F%2Fcoderabbit.ai&label=CodeRabbit+Reviews)
 
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/doodlum/skyrim-community-shaders)
 
@@ -50,6 +48,7 @@ Install them manually only if you want them in everywhere.
 
 -   [Address Library for SKSE](https://www.nexusmods.com/skyrimspecialedition/mods/32444)
     -   Needed for SSE/AE
+-   [SSE Engine Fixes](https://www.nexusmods.com/skyrimspecialedition/mods/17230)
 
 ## Build Instructions
 
@@ -58,7 +57,7 @@ Install them manually only if you want them in everywhere.
 To clone the repository with all submodules, run the following command in your terminal:
 
 ```bash
-git clone https://github.com/doodlum/skyrim-community-shaders.git --recursive
+git clone https://github.com/community-shaders/skyrim-community-shaders.git --recursive
 cd skyrim-community-shaders
 ```
 

--- a/src/Menu/HomePageRenderer.cpp
+++ b/src/Menu/HomePageRenderer.cpp
@@ -163,7 +163,7 @@ void HomePageRenderer::RenderQuickLinksSection()
 
 	ImGui::NextColumn();
 	if (ImGui::Button(T("menu.home.github", "GitHub"), ImVec2(-1, 0))) {
-		ShellExecuteA(NULL, "open", "https://github.com/doodlum/skyrim-community-shaders", NULL, NULL, SW_SHOWNORMAL);
+		ShellExecuteA(NULL, "open", "https://github.com/community-shaders/skyrim-community-shaders", NULL, NULL, SW_SHOWNORMAL);
 	}
 
 	ImGui::NextColumn();
@@ -173,7 +173,7 @@ void HomePageRenderer::RenderQuickLinksSection()
 
 	ImGui::NextColumn();
 	if (ImGui::Button(T("menu.home.dev_wiki", "Developer Wiki"), ImVec2(-1, 0))) {
-		ShellExecuteA(NULL, "open", "https://github.com/doodlum/skyrim-community-shaders/wiki", NULL, NULL, SW_SHOWNORMAL);
+		ShellExecuteA(NULL, "open", "https://github.com/community-shaders/skyrim-community-shaders/wiki", NULL, NULL, SW_SHOWNORMAL);
 	}
 
 	ImGui::Columns(1);

--- a/tools/feature_version_audit.py
+++ b/tools/feature_version_audit.py
@@ -843,7 +843,7 @@ def analyze_features(FEATURES_DIR, feature_meta_map, base_ref, only_changed=Fals
         commit_link = ""
         if bump_commit:
             author_str = f" ({bump_author})" if bump_author else ""
-            commit_link = f"[link](https://github.com/doodlum/skyrim-community-shaders/commit/{bump_commit}){author_str}"
+            commit_link = f"[link](https://github.com/community-shaders/skyrim-community-shaders/commit/{bump_commit}){author_str}"
 
         def bold(val):
             return f"**{val}**" if is_attention and val != '' and val != '-' else val
@@ -934,7 +934,7 @@ def format_new_features_table(new_features, feature_meta_map, get_commit_author,
             nexus_link = f"[Nexus]({meta['mod_link']})" if meta and meta['mod_link'] else ("**Missing metadata**" if not meta else "")
             author = get_commit_author(commit) if commit else None
             author_str = f" ({author})" if author else ""
-            commit_link = f"[link](https://github.com/doodlum/skyrim-community-shaders/commit/{commit}){author_str}" if commit else ""
+            commit_link = f"[link](https://github.com/community-shaders/skyrim-community-shaders/commit/{commit}){author_str}" if commit else ""
             lines.append(f"| {boldmeta(name)} | {boldmeta(ver)} | {nexus_link} | {commit_link} |")
     return lines
 


### PR DESCRIPTION
All GH links in repo are stale due to the org migration. Since doodlum has their own fork now, everything points to the wrong place.

- Update repo paths in accordance with the GH organization
  - Only remaining reference is the DeepWiki link which is only indexed for doodlum's fork, not upstream
- README updates
  - Removed pre-commit badge, seems like it was disabled so it's permanently stale
  - Fixed build status badge, it was permanently "failing" before, now it tracks the right workflow
  - Added Engine Fixes user requirement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated repository, clone, badge, release, and commit links to the current project location.
  * Added SSE Engine Fixes to the listed user requirements.
  * Updated build status badge behavior and removed the Pre-commit CI badge.

* **User Interface**
  * Updated the home page GitHub and Developer Wiki quick links to the current project location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->