### PR TITLE
fix(vl): clamp volumetric lighting blur to dynamic resolution area

### DIFF
--- a/package/Shaders/ISVolumetricLightingBlurHCS.hlsl
+++ b/package/Shaders/ISVolumetricLightingBlurHCS.hlsl
@@ -33,7 +33,9 @@ groupshared float depth[TG_DIM];
 	int x = groupId.x * (TG_DIM - WINDOW * 2) + base;
 	int y = groupId.y;
 
-	int2 pix = min(int2(x, y), screenSizeMin1.xy);
+	// screenSize bounds the dynamic resolution render area; clamp to it so the halo lanes
+	// replicate the edge instead of reading stale pixels from outside it.
+	int2 pix = clamp(int2(x, y), 0, screenSizeMin1.xy);
 	float vlValue = InVLTexture[pix];
 	vl[idx] = vlValue;
 	float depthValue = DepthTexture[pix];
@@ -41,7 +43,7 @@ groupshared float depth[TG_DIM];
 
 	GroupMemoryBarrierWithGroupSync();
 
-	if (base >= 0 && base < TG_DIM - WINDOW * 2) {
+	if (base >= 0 && base < TG_DIM - WINDOW * 2 && all(int2(x, y) <= screenSizeMin1.xy)) {
 		int min12 = idx - 12;
 		int min6 = idx - 6;
 		int plus6 = idx + 6;

--- a/package/Shaders/ISVolumetricLightingBlurVCS.hlsl
+++ b/package/Shaders/ISVolumetricLightingBlurVCS.hlsl
@@ -33,7 +33,9 @@ groupshared float depth[TG_DIM];
 	int x = groupId.x;
 	int y = groupId.y * (TG_DIM - WINDOW * 2) + base;
 
-	int2 pix = min(int2(x, y), screenSizeMin1.xy);
+	// screenSize bounds the dynamic resolution render area; clamp to it so the halo lanes
+	// replicate the edge instead of reading stale pixels from outside it.
+	int2 pix = clamp(int2(x, y), 0, screenSizeMin1.xy);
 	float vlValue = InVLTexture[pix];
 	vl[idx] = vlValue;
 	float depthValue = DepthTexture[pix];
@@ -41,7 +43,7 @@ groupshared float depth[TG_DIM];
 
 	GroupMemoryBarrierWithGroupSync();
 
-	if (base >= 0 && base < TG_DIM - WINDOW * 2) {
+	if (base >= 0 && base < TG_DIM - WINDOW * 2 && all(int2(x, y) <= screenSizeMin1.xy)) {
 		int min12 = idx - 12;
 		int min6 = idx - 6;
 		int plus6 = idx + 6;

--- a/src/Features/VolumetricLighting.cpp
+++ b/src/Features/VolumetricLighting.cpp
@@ -4,6 +4,7 @@
 #include "InteriorSun.h"
 #include "ShaderCache.h"
 #include "State.h"
+#include "Utils/Game.h"
 
 #define I18N_KEY_PREFIX "feature.volumetric_lighting."
 
@@ -174,18 +175,26 @@ void VolumetricLighting::SetupResources()
 
 void VolumetricLighting::EarlyPrepass()
 {
-	int32_t width = static_cast<int32_t>((float)globals::game::graphicsState->screenWidth);
-	int32_t height = static_cast<int32_t>((float)globals::game::graphicsState->screenHeight);
+	int32_t width = static_cast<int32_t>(globals::game::graphicsState->screenWidth);
+	int32_t height = static_cast<int32_t>(globals::game::graphicsState->screenHeight);
 
-	if (width != vlData.screenX || height != vlData.screenY) {
+	if (width != fullScreenX || height != fullScreenY) {
 		blurHCS = nullptr;
 		blurVCS = nullptr;
 	}
 
-	vlData.screenX = width;
-	vlData.screenY = height;
-	vlData.screenXMin1 = width - 1;
-	vlData.screenYMin1 = height - 1;
+	fullScreenX = width;
+	fullScreenY = height;
+
+	// The blur targets are allocated at the full screen size, but under dynamic resolution only
+	// the top-left render area holds valid data. Clamping and dispatching against the full size
+	// makes the blur taps read stale pixels from outside that area along the right/bottom edges.
+	const float2 renderSize = Util::ConvertToDynamic(float2{ (float)width, (float)height });
+
+	vlData.screenX = std::max(1, static_cast<int32_t>(renderSize.x));
+	vlData.screenY = std::max(1, static_cast<int32_t>(renderSize.y));
+	vlData.screenXMin1 = vlData.screenX - 1;
+	vlData.screenYMin1 = vlData.screenY - 1;
 	vlDataCB->Update(vlData);
 
 	const auto interiorCell = RE::TES::GetSingleton()->interiorCell;
@@ -273,13 +282,17 @@ void VolumetricLighting::SetDimensionsCB() const
 	globals::d3d::context->CSSetConstantBuffers(1, 1, &cb);
 }
 
-void VolumetricLighting::SetGroupCountsHCS(uint32_t& threadGroupCountX) const
+void VolumetricLighting::SetGroupCountsHCS(uint32_t& threadGroupCountX, uint32_t& threadGroupCountY) const
 {
 	threadGroupCountX = (vlData.screenX + BlurThreadGroupSizeX - BlurWindow * 2u - 1u) / (BlurThreadGroupSizeX - BlurWindow * 2u);
+	// One group per row, so the game's full-height count would blur rows outside the dynamic resolution area.
+	threadGroupCountY = static_cast<uint32_t>(vlData.screenY);
 }
 
-void VolumetricLighting::SetGroupCountsVCS(uint32_t& threadGroupCountY) const
+void VolumetricLighting::SetGroupCountsVCS(uint32_t& threadGroupCountX, uint32_t& threadGroupCountY) const
 {
+	// One group per column, so the game's full-width count would blur columns outside the dynamic resolution area.
+	threadGroupCountX = static_cast<uint32_t>(vlData.screenX);
 	threadGroupCountY = (vlData.screenY + BlurThreadGroupSizeY - BlurWindow * 2u - 1u) / (BlurThreadGroupSizeY - BlurWindow * 2u);
 }
 

--- a/src/Features/VolumetricLighting.h
+++ b/src/Features/VolumetricLighting.h
@@ -92,15 +92,25 @@ public:
 	/** @brief Binds the screen dimensions constant buffer to compute shader slot 1. */
 	void SetDimensionsCB() const;
 	/**
-	 * @brief Calculates the thread group count for the horizontal blur dispatch.
+	 * @brief Calculates the thread group counts for the horizontal blur dispatch.
+	 *
+	 * Both axes are sized from the dynamic resolution render area so the blur never
+	 * touches the stale region outside it.
+	 *
 	 * @param threadGroupCountX Output parameter set to the required X thread group count.
+	 * @param threadGroupCountY Output parameter set to the number of rows to blur.
 	 */
-	void SetGroupCountsHCS(uint32_t& threadGroupCountX) const;
+	void SetGroupCountsHCS(uint32_t& threadGroupCountX, uint32_t& threadGroupCountY) const;
 	/**
-	 * @brief Calculates the thread group count for the vertical blur dispatch.
+	 * @brief Calculates the thread group counts for the vertical blur dispatch.
+	 *
+	 * Both axes are sized from the dynamic resolution render area so the blur never
+	 * touches the stale region outside it.
+	 *
+	 * @param threadGroupCountX Output parameter set to the number of columns to blur.
 	 * @param threadGroupCountY Output parameter set to the required Y thread group count.
 	 */
-	void SetGroupCountsVCS(uint32_t& threadGroupCountY) const;
+	void SetGroupCountsVCS(uint32_t& threadGroupCountX, uint32_t& threadGroupCountY) const;
 
 private:
 	struct VolumetricLightingDescriptor
@@ -136,6 +146,13 @@ private:
 	bool inInterior = false;
 	bool inInteriorWithSun = false;
 
+	/**
+	 * @brief Bounds of the dynamic resolution render area, in pixels.
+	 *
+	 * The blur targets are allocated at the full screen size but only the top-left
+	 * dynamic resolution region holds valid data, so these are the clamp bounds the
+	 * blur shaders sample against.
+	 */
 	struct VLData
 	{
 		int32_t screenX;
@@ -144,6 +161,11 @@ private:
 		int32_t screenYMin1;
 	};
 	VLData vlData = VLData();
+
+	// Full (non-dynamic) screen size, tracked separately so the cached blur shaders are
+	// only invalidated on an actual resolution change and not every dynamic resolution step.
+	int32_t fullScreenX = 0;
+	int32_t fullScreenY = 0;
 	ConstantBuffer* vlDataCB = nullptr;
 
 	static constexpr int32_t BlurThreadGroupSizeX = 256;

--- a/src/Hooks.cpp
+++ b/src/Hooks.cpp
@@ -930,12 +930,12 @@ namespace Hooks
 							techniqueId = 0;
 							isShader = vl.GetOrCreateBlurHCS(CurrentlyDispatchedComputeShader);
 							vl.SetDimensionsCB();
-							vl.SetGroupCountsHCS(threadGroupCountX);
+							vl.SetGroupCountsHCS(threadGroupCountX, threadGroupCountY);
 						} else if (CurrentlyDispatchedComputeShader->name == "ISVolumetricLightingBlurVCS"sv) {
 							techniqueId = 0;
 							isShader = vl.GetOrCreateBlurVCS(CurrentlyDispatchedComputeShader);
 							vl.SetDimensionsCB();
-							vl.SetGroupCountsVCS(threadGroupCountY);
+							vl.SetGroupCountsVCS(threadGroupCountX, threadGroupCountY);
 						}
 					}
 					if (isShader != nullptr) {


### PR DESCRIPTION
## What

Both volumetric lighting blur passes (`ISVolumetricLightingBlurHCS` / `ISVolumetricLightingBlurVCS`) were bounded by the **full** screen size rather than the dynamic resolution render area, so they sampled and wrote outside the valid region.

## Why

The blur targets are allocated at the full screen size, but under dynamic resolution only the top-left `dynWidth x dynHeight` region holds valid data for the current frame. `VolumetricLighting::EarlyPrepass` was writing `graphicsState->screenWidth/Height` straight into `vlData`, which is what the shaders clamp against and what the dispatch is sized from. Three distinct symptoms fell out of that, in **both** passes:

1. **Taps read stale pixels.** `min(int2(x, y), screenSizeMin1.xy)` clamped to the full texture edge, so the ±6 / ±12 bilateral taps near the right (H) and bottom (V) edges of the render area pulled in whatever the last larger-ratio frame left behind.
2. **The perpendicular dispatch axis was never narrowed.** `SetGroupCountsHCS` only overrode `threadGroupCountX` and `SetGroupCountsVCS` only `threadGroupCountY`; the other axis kept the game's full-size count (one group per row / per column). Entire rows and columns outside the render area were blurred — wasted work that also scribbled into the invalid region.
3. **No lower clamp.** The leading halo lanes have `base` down to `-12`, so `int2(x, y)` went negative and the loads returned zero. Those zero depths blow up the `abs(diff) <= 0.002f` bilateral test, so the first 12 columns (H) / rows (V) fell through to the unblurred value.

## How

**`src/Features/VolumetricLighting.cpp` / `.h`**
- `EarlyPrepass` now sizes `vlData` from `Util::ConvertToDynamic(...)`, matching how every other feature derives its render size.
- `SetGroupCountsHCS` / `SetGroupCountsVCS` each set **both** dispatch axes from the dynamic size.
- Added `fullScreenX` / `fullScreenY`, tracked separately, so the cached `blurHCS` / `blurVCS` wrappers are invalidated only on a genuine resolution change. Keying that check on `vlData` after this change would have nulled and re-created them on every dynamic resolution step, and `CreateShader` allocates a fresh `BSImagespaceShader` each call with nothing freeing the old one.

**`package/Shaders/ISVolumetricLightingBlurHCS.hlsl` / `...VCS.hlsl`**
- `min(...)` → `clamp(int2(x, y), 0, screenSizeMin1.xy)`, so halo lanes replicate the edge in both directions.
- Guarded the store with `all(int2(x, y) <= screenSizeMin1.xy)` so the trailing group cannot write past the render area.

**`src/Hooks.cpp`** — updated the two `SetGroupCounts*` callsites for the new signatures.

## Notes for reviewers

- The `Effects11::DrawVolumetricRays` path shares these two `.hlsl` files. It was already computing its constant buffer and both dispatch axes from `Util::ConvertToDynamic`, so it needed no C++ change and is compatible with the tightened shader bounds.
- Fixing the lower clamp is a small **visual** change independent of dynamic resolution: the first 12 columns/rows now blur properly instead of passing through. That is the clamp behaving as it was evidently intended to.
- `Util::ConvertToDynamic` honours `dynamicResolutionLock`, so with dynamic resolution off or locked the bounds are identical to before.
- Verified locally: `clang-format` clean, and a full `BuildDevFast` compiles and links `CommunityShaders.dll` with no errors or warnings. Not yet verified in-game against a dynamic resolution capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved volumetric lighting blur behavior with dynamic resolution.
  * Prevented halo artifacts and stale pixel sampling at render-area edges.
  * Ensured blur processing stays within valid render bounds for more consistent lighting output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->